### PR TITLE
Fix queryRenderedFeaturesInRect for iOS

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -145,7 +145,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
                 let bottom = arguments["bottom"] as? Double,
                 let left = arguments["left"] as? Double,
                 let right = arguments["right"] as? Double {
-                features = mapView.visibleFeatures(in: CGRect(x: left, y: top, width: right, height: bottom), styleLayerIdentifiers: layerIds, predicate: filterExpression)
+                features = mapView.visibleFeatures(in: CGRect(x: left, y: top, width: right - left, height: bottom - top), styleLayerIdentifiers: layerIds, predicate: filterExpression)
             }
             var featuresJson = [String]()
             for feature in features {


### PR DESCRIPTION
We noticed a bug in the method `queryRenderredFeaturesInRect` which only occurs on iOS. After detecting where the problem is, we want to contribute and fix this bug upstream.