### PR TITLE
Cherry-pick: fixed crashes with ios offline manager (upstream#724)

### DIFF
--- a/ios/Classes/OfflineManagerUtils.swift
+++ b/ios/Classes/OfflineManagerUtils.swift
@@ -70,6 +70,10 @@ class OfflineManagerUtils {
             }
         })
         if let packToRemoveUnwrapped = packToRemove {
+            // deletion is only safe if the download is suspended
+            packToRemoveUnwrapped.suspend()
+            OfflineManagerUtils.releaseDownloader(id: id)
+
             offlineStorage.removePack(packToRemoveUnwrapped) { error in
                 if let error = error {
                     result(FlutterError(

--- a/ios/Classes/OfflinePackDownloadManager.swift
+++ b/ios/Classes/OfflinePackDownloadManager.swift
@@ -134,7 +134,6 @@ class OfflinePackDownloader {
         ))
         if let region = OfflineRegion.fromOfflinePack(pack) {
             OfflineManagerUtils.deleteRegion(result: result, id: region.id)
-            OfflineManagerUtils.releaseDownloader(id:region.id)
         }
     }
     
@@ -158,7 +157,6 @@ class OfflinePackDownloader {
         ))
         if let region = OfflineRegion.fromOfflinePack(pack) {
             OfflineManagerUtils.deleteRegion(result: result, id: region.id)
-            OfflineManagerUtils.releaseDownloader(id: region.id)
         }
     }
     
@@ -193,7 +191,7 @@ class OfflinePackDownloader {
             return false
         }
         // We can tell whether 2 packs are the same by comparing metadata we assigned earlier
-        return pack.context == currentlyManagedPack.context
+        return pack.state != .invalid && pack.context == currentlyManagedPack.context
     }
     
     private func calculateDownloadingProgress(


### PR DESCRIPTION
* fixed crashes with ios offline manager

* removed redundant call to releaseDownloader