### PR TITLE
Update maplibre-gl-js by using maplibre-gl-dart

### DIFF
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -16,7 +16,7 @@
 
   <!-- Maplibre -->
   <!-- TODO: URL taken from the Maptiler tutorial; use official and stable release once available-->
-  <script src="https://cdn.maptiler.com/maplibre-gl-js/v1.13.0-rc.4/mapbox-gl.js"></script>
+  <script src="https://cdn.maptiler.com/maplibre-gl-js/v2.2.0-pre.2/maplibre-gl.js"></script>
 
   <title>example</title>
   <link rel="manifest" href="/manifest.json">

--- a/maplibre_gl_web/lib/mapbox_gl_web.dart
+++ b/maplibre_gl_web/lib/mapbox_gl_web.dart
@@ -15,8 +15,8 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
-import 'package:mapbox_gl_dart/mapbox_gl_dart.dart' hide Point, Source;
-import 'package:mapbox_gl_dart/mapbox_gl_dart.dart' as mapbox show Point;
+import 'package:maplibre_gl_dart/mapbox_gl_dart.dart' hide Point, Source;
+import 'package:maplibre_gl_dart/mapbox_gl_dart.dart' as mapbox show Point;
 import 'package:image/image.dart' hide Point;
 import 'package:maplibre_gl_web/src/layer_tools.dart';
 

--- a/maplibre_gl_web/lib/src/mapbox_map_controller.dart
+++ b/maplibre_gl_web/lib/src/mapbox_map_controller.dart
@@ -2,7 +2,7 @@ part of maplibre_gl_web;
 
 //TODO Url taken from the Maptiler tutorial; use official and stable release once available
 final _maplibreGlCssUrl =
-    'https://cdn.maptiler.com/maplibre-gl-js/v1.13.0-rc.4/mapbox-gl.css';
+    'https://cdn.maptiler.com/maplibre-gl-js/v2.2.0-pre.2/maplibre-gl.css';
 
 class MaplibreMapController extends MapLibreGlPlatform
     implements MapboxMapOptionsSink {

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -21,7 +21,11 @@ dependencies:
       url: https://github.com/m0nac0/flutter-maplibre-gl.git
       path: maplibre_gl_platform_interface
       ref: main
-  mapbox_gl_dart: ^0.2.0-nullsafety
+  #mapbox_gl_dart: ^0.2.0-nullsafety
+  mapbox_gl_dart:
+    git:
+      url: https://github.com/m0nac0/maplibre-gl-dart.git
+      ref: main
   image: ^3.0.2
 
 dependency_overrides:

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -21,16 +21,17 @@ dependencies:
       url: https://github.com/m0nac0/flutter-maplibre-gl.git
       path: maplibre_gl_platform_interface
       ref: main
-  #mapbox_gl_dart: ^0.2.0-nullsafety
-  mapbox_gl_dart:
+  maplibre_gl_dart:
     git:
       url: https://github.com/m0nac0/maplibre-gl-dart.git
-      ref: main
+      ref: 0.2.2
   image: ^3.0.2
 
 dependency_overrides:
   maplibre_gl_platform_interface:
     path: ../maplibre_gl_platform_interface
+  #maplibre_gl_dart:
+  #  path: ../../maplibre-gl-dart
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,15 +53,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
-  mapbox_gl_dart:
+  maplibre_gl_dart:
     dependency: transitive
     description:
       path: "."
-      ref: main
-      resolved-ref: ee7f888577bcac03a03f16596616229141ffec98
+      ref: "0.2.2"
+      resolved-ref: "24a48ecec0d07e02a0c51ced68a05f543d871583"
       url: "https://github.com/m0nac0/maplibre-gl-dart.git"
     source: git
-    version: "0.2.1"
+    version: "0.2.2"
   maplibre_gl_platform_interface:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -56,24 +56,26 @@ packages:
   mapbox_gl_dart:
     dependency: transitive
     description:
-      name: mapbox_gl_dart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0-nullsafety.0"
+      path: "."
+      ref: main
+      resolved-ref: ee7f888577bcac03a03f16596616229141ffec98
+      url: "https://github.com/m0nac0/maplibre-gl-dart.git"
+    source: git
+    version: "0.2.1"
   maplibre_gl_platform_interface:
     dependency: "direct main"
     description:
       path: maplibre_gl_platform_interface
       relative: true
     source: path
-    version: "0.15.0"
+    version: "0.15.1"
   maplibre_gl_web:
     dependency: "direct main"
     description:
       path: maplibre_gl_web
       relative: true
     source: path
-    version: "0.15.0"
+    version: "0.15.1"
   material_color_utilities:
     dependency: transitive
     description:


### PR DESCRIPTION
Relied on renaming the JS interop namespace in https://github.com/m0nac0/maplibre-gl-dart/commit/ee7f888577bcac03a03f16596616229141ffec98