### PR TITLE
Fix: Installation of example on Android 12

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <!-- TODO: removed android:exported="false" from https://github.com/flutter-mapbox-gl/maps/pull/904 (caused launch issues)-->
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"


### PR DESCRIPTION
With out this, on Android 12 the following error might appear when testing:

com.mapbox.mapboxglexample.MainActivity: Targeting S+ (version 31 and above) requires that an
explicit value for android:exported be
defined when intent filters are present]