### PR TITLE
Use offical maplibre-gl.js and add README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ pod 'MapLibre'
 pod 'MapLibreAnnotationExtension'
 ```
 
+### Web
+Include the following JavaScript and CSS files in the `<head>` of the `web/index.html` file.
+
+```html
+<script src='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js'></script>
+<link href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' rel='stylesheet' />
+```
+
 ## Supported API
 
 | Feature | Android | iOS | Web |

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -15,8 +15,8 @@
   <link rel="shortcut icon" type="image/png" href="/favicon.png"/>
 
   <!-- Maplibre -->
-  <!-- TODO: URL taken from the Maptiler tutorial; use official and stable release once available-->
-  <script src="https://cdn.maptiler.com/maplibre-gl-js/v2.2.0-pre.2/maplibre-gl.js"></script>
+  <script src='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js'></script>
+  <link href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' rel='stylesheet' />
 
   <title>example</title>
   <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
Changes the web example app to use the [offical](https://github.com/maplibre/maplibre-gl-js) maplibre-gl.js files.

Adds a short section to the readme describing the requirements in order to make the package work for web.