### PR TITLE
Trimming styleString to simplify the JSON detection

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -258,6 +258,7 @@ final class MapboxMapController
   public void setStyleString(String styleString) {
     // clear old layer id from the location Component
     clearLocationComponentLayer();
+    styleString = styleString.trim();
 
     // Check if json, url, absolute path or asset path:
     if (styleString == null || styleString.isEmpty()) {


### PR DESCRIPTION
I trim the styleString to allow spaces at the start of json strings