### PR TITLE
Fix getVisibleRegion method

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -680,11 +680,12 @@ final class MapboxMapController
           reply.put(
               "sw",
               Arrays.asList(
-                  visibleRegion.nearLeft.getLatitude(), visibleRegion.nearLeft.getLongitude()));
+                  visibleRegion.latLngBounds.getLatSouth(), visibleRegion.latLngBounds.getLonWest()));
           reply.put(
               "ne",
               Arrays.asList(
-                  visibleRegion.farRight.getLatitude(), visibleRegion.farRight.getLongitude()));
+                    visibleRegion.latLngBounds.getLatNorth(), visibleRegion.latLngBounds.getLonEast()));
+
           result.success(reply);
           break;
         }


### PR DESCRIPTION
This change resolves #178 by using latLngBounds of visibleRegion intread of nearLeft/farRight.