### PR TITLE
Added getSourceIds to the controller

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1376,6 +1376,25 @@ final class MapboxMapController
           result.success(reply);
           break;
         }
+      case "style#getSourceIds":
+      {
+        if (style == null) {
+          result.error(
+                  "STYLE IS NULL",
+                  "The style is null. Has onStyleLoaded() already been invoked?",
+                  null);
+        }
+        Map<String, Object> reply = new HashMap<>();
+
+        List<String> sourceIds = new ArrayList<>();
+        for (Source source : style.getSources()) {
+          sourceIds.add(source.getId());
+        }
+
+        reply.put("sources", sourceIds);
+        result.success(reply);
+        break;
+      }
       default:
         result.notImplemented();
     }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -258,6 +258,7 @@ final class MapboxMapController
   public void setStyleString(String styleString) {
     // clear old layer id from the location Component
     clearLocationComponentLayer();
+    styleString = styleString.trim();
 
     // Check if json, url, absolute path or asset path:
     if (styleString == null || styleString.isEmpty()) {

--- a/example/lib/get_map_informations.dart
+++ b/example/lib/get_map_informations.dart
@@ -26,7 +26,6 @@ class _GetMapInfoBodyState extends State<GetMapInfoBody> {
   void onMapCreated(MaplibreMapController controller) {
     setState(() {
       this.controller = controller;
-      print('controller set');
     });
   }
 

--- a/example/lib/get_map_informations.dart
+++ b/example/lib/get_map_informations.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/mapbox_gl.dart';
+
+import 'page.dart';
+
+class GetMapInfoPage extends ExamplePage {
+  GetMapInfoPage() : super(const Icon(Icons.info), 'Get map state');
+
+  @override
+  Widget build(BuildContext context) {
+    return GetMapInfoBody();
+  }
+}
+
+class GetMapInfoBody extends StatefulWidget {
+  const GetMapInfoBody();
+
+  @override
+  State<GetMapInfoBody> createState() => _GetMapInfoBodyState();
+}
+
+class _GetMapInfoBodyState extends State<GetMapInfoBody> {
+  MaplibreMapController? controller;
+  String data = '';
+
+  void onMapCreated(MaplibreMapController controller) {
+    setState(() {
+      this.controller = controller;
+      print('controller set');
+    });
+  }
+
+  void displaySources() async {
+    if (controller == null) {
+      return;
+    }
+    List<String> sources = await controller!.getSourceIds();
+    setState(() {
+      data = 'Sources: ${sources.map((e) => '"$e"').join(', ')}';
+    });
+  }
+
+  void displayLayers() async {
+    if (controller == null) {
+      return;
+    }
+    List<String> layers = (await controller!.getLayerIds()).cast<String>();
+    setState(() {
+      data = 'Layers: ${layers.map((e) => '"$e"').join(', ')}';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Center(
+          child: SizedBox(
+            width: 300.0,
+            height: 200.0,
+            child: MaplibreMap(
+              initialCameraPosition: const CameraPosition(
+                target: LatLng(-33.852, 151.211),
+                zoom: 11.0,
+              ),
+              onMapCreated: onMapCreated,
+              compassEnabled: false,
+              annotationOrder: [],
+              myLocationEnabled: false,
+              styleString: '''{
+                "version": 8,
+                "sources": {
+                  "OSM": {
+                    "type": "raster",
+                    "tiles": [
+                      "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                      "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                      "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    ],
+                    "tileSize": 256,
+                    "attribution": "© OpenStreetMap contributors",
+                    "maxzoom": 18
+                  }
+                },
+                "layers": [
+                  {
+                    "id": "OSM-layer",
+                    "source": "OSM",
+                    "type": "raster"
+                  }
+                ]
+              }''',
+            ),
+          ),
+        ),
+        Center(
+          child: const Text('© OpenStreetMap contributors'),
+        ),
+        Expanded(
+            child: SingleChildScrollView(
+          child: Column(
+            children: [
+              SizedBox(height: 30),
+              Center(child: Text(data)),
+              SizedBox(height: 30),
+              ElevatedButton(
+                onPressed: controller == null ? null : displayLayers,
+                child: const Text('Get map layers'),
+              ),
+              ElevatedButton(
+                onPressed: controller == null ? null : displaySources,
+                child: const Text('Get map sources'),
+              )
+            ],
+          ),
+        )),
+      ],
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:location/location.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:maplibre_gl_example/get_map_informations.dart';
 import 'package:maplibre_gl_example/given_bounds.dart';
 
 import 'animate_camera.dart';
@@ -52,6 +53,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   ClickAnnotationPage(),
   Sources(),
   GivenBoundsPage(),
+  GetMapInfoPage(),
 ];
 
 class MapsDemo extends StatefulWidget {

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -766,7 +766,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             reply["layers"] = layerIds as NSObject
             result(reply)
 
-        case "style#getSrouceIds":
+        case "style#getSourceIds":
             var sourceIds = [String]()
 
             guard let style = mapView.style else { return }

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -765,6 +765,17 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
             var reply = [String: NSObject]()
             reply["layers"] = layerIds as NSObject
             result(reply)
+
+        case "style#getSrouceIds":
+            var sourceIds = [String]()
+
+            guard let style = mapView.style else { return }
+
+            style.sources.forEach { source in sourceIds.append(source.identifier) }
+
+            var reply = [String: NSObject]()
+            reply["sources"] = sourceIds as NSObject
+            result(reply)
             
         case "style#getFilter":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1271,7 +1271,9 @@ class MaplibreMapController extends ChangeNotifier {
   }
 
   Future<List<String>> getSourceIds() async {
-    return (await _mapboxGlPlatform.getSourceIds()).whereType<String>().toList();
+    return (await _mapboxGlPlatform.getSourceIds())
+        .whereType<String>()
+        .toList();
   }
 
   @override

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1270,8 +1270,8 @@ class MaplibreMapController extends ChangeNotifier {
     return _mapboxGlPlatform.getLayerIds();
   }
 
-  Future<List> getSourceIds() {
-    return _mapboxGlPlatform.getSourceIds();
+  Future<List<String>> getSourceIds() async {
+    return (await _mapboxGlPlatform.getSourceIds()).whereType<String>().toList();
   }
 
   @override

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1270,6 +1270,9 @@ class MaplibreMapController extends ChangeNotifier {
     return _mapboxGlPlatform.getLayerIds();
   }
 
+  /// Retrieve every source ids of the map as a [String] list, including the ones added internally
+  ///
+  /// This method is not currently implemented on the web
   Future<List<String>> getSourceIds() async {
     return (await _mapboxGlPlatform.getSourceIds())
         .whereType<String>()

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1270,6 +1270,10 @@ class MaplibreMapController extends ChangeNotifier {
     return _mapboxGlPlatform.getLayerIds();
   }
 
+  Future<List> getSourceIds() {
+    return _mapboxGlPlatform.getSourceIds();
+  }
+
   @override
   void dispose() {
     super.dispose();

--- a/maplibre_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -91,6 +91,8 @@ abstract class MapLibreGlPlatform {
 
   Future<List> getLayerIds();
 
+  Future<List> getSourceIds();
+
   Future<void> setFilter(String layerId, dynamic filter);
 
   Future<dynamic> getFilter(String layerId);

--- a/maplibre_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -758,7 +758,7 @@ class MethodChannelMaplibreGl extends MapLibreGlPlatform {
   Future<List> getSourceIds() async {
     try {
       final Map<dynamic, dynamic> reply =
-      await _channel.invokeMethod('style#getSourceIds');
+          await _channel.invokeMethod('style#getSourceIds');
       return reply['sources'].map((it) => it.toString()).toList();
     } on PlatformException catch (e) {
       return new Future.error(e);

--- a/maplibre_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_mapbox_gl.dart
@@ -753,4 +753,15 @@ class MethodChannelMaplibreGl extends MapLibreGlPlatform {
       return new Future.error(e);
     }
   }
+
+  @override
+  Future<List> getSourceIds() async {
+    try {
+      final Map<dynamic, dynamic> reply =
+      await _channel.invokeMethod('style#getSourceIds');
+      return reply['sources'].map((it) => it.toString()).toList();
+    } on PlatformException catch (e) {
+      return new Future.error(e);
+    }
+  }
 }

--- a/maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -1045,4 +1045,9 @@ class MaplibreMapController extends MapLibreGlPlatform
   Future<List> getLayerIds() async {
     throw UnimplementedError();
   }
+
+  @override
+  Future<List> getSourceIds() async {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
Added getSourceIds to the controller with the android (tested) and ios (no ability to test here sorry). Not implemented on the web as getLayerIds in not implemented too

I made the controller method returning a list of strings (`Future<List<String>>`) to have an explicit `String` list unlike `getLayerIds` who have a `Future<List<dynamic>>`