### PR TITLE
Moved EventChannel creation in the downloadOfflineRegion method

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -98,6 +98,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         String channelName = methodCall.argument("channelName");
         // Prepare args
         downloadOfflineRegionChannelHandler = new OfflineChannelHandlerImpl(messenger, channelName);
+        result.success(null);
         break;
       case "downloadOfflineRegion":
         // Get args from caller

--- a/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/GlobalMethodHandler.java
@@ -28,6 +28,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
   @NonNull private final BinaryMessenger messenger;
   @Nullable private PluginRegistry.Registrar registrar;
   @Nullable private FlutterPlugin.FlutterAssets flutterAssets;
+  @Nullable private OfflineChannelHandlerImpl downloadOfflineRegionChannelHandler;
 
   GlobalMethodHandler(@NonNull PluginRegistry.Registrar registrar) {
     this.registrar = registrar;
@@ -93,19 +94,28 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         Map<String, String> headers = (Map<String, String>) methodCall.argument("headers");
         MapboxHttpRequestUtil.setHttpHeaders(headers, result);
         break;
+      case "downloadOfflineRegion#setup":
+        String channelName = methodCall.argument("channelName");
+        // Prepare args
+        downloadOfflineRegionChannelHandler = new OfflineChannelHandlerImpl(messenger, channelName);
+        break;
       case "downloadOfflineRegion":
         // Get args from caller
         Map<String, Object> definitionMap = (Map<String, Object>) methodCall.argument("definition");
         Map<String, Object> metadataMap = (Map<String, Object>) methodCall.argument("metadata");
-        String channelName = methodCall.argument("channelName");
 
-        // Prepare args
-        OfflineChannelHandlerImpl channelHandler =
-            new OfflineChannelHandlerImpl(messenger, channelName);
+        if (downloadOfflineRegionChannelHandler == null) {
+          result.error(
+                  "downloadOfflineRegion#setup NOT CALLED",
+                  "The setup has not been called, please call downloadOfflineRegion#setup before",
+                  null);
+          break;
+        }
 
         // Start downloading
         OfflineManagerUtils.downloadRegion(
-            result, context, definitionMap, metadataMap, channelHandler);
+            result, context, definitionMap, metadataMap, downloadOfflineRegionChannelHandler);
+        downloadOfflineRegionChannelHandler = null;
         break;
       case "getListOfRegions":
         OfflineManagerUtils.regionsList(result, context);

--- a/android/src/main/java/com/mapbox/mapboxgl/OfflineManagerUtils.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/OfflineManagerUtils.java
@@ -76,9 +76,6 @@ abstract class OfflineManagerUtils {
                 result.success(new Gson().toJson(regionData));
 
                 _offlineRegion = offlineRegion;
-                // Start downloading region
-                _offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE);
-                channelHandler.onStart();
                 // Observe downloading state
                 OfflineRegion.OfflineRegionObserver observer =
                     new OfflineRegion.OfflineRegionObserver() {
@@ -140,7 +137,12 @@ abstract class OfflineManagerUtils {
                         deleteRegion(null, context, _offlineRegion.getID());
                       }
                     };
+
                 _offlineRegion.setObserver(observer);
+
+                // Start downloading region
+                _offlineRegion.setDownloadState(OfflineRegion.STATE_ACTIVE);
+                channelHandler.onStart();
               }
 
               /**

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -107,7 +107,7 @@ Future<OfflineRegion> downloadOfflineRegion(
         PlatformException(
           code: 'UnknowException',
           message:
-          'This error is unhandled by plugin. Please contact us if needed.',
+              'This error is unhandled by plugin. Please contact us if needed.',
           details: error,
         ),
       );

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -92,13 +92,6 @@ Future<OfflineRegion> downloadOfflineRegion(
   String channelName =
       'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
-  final result = await _globalChannel
-      .invokeMethod('downloadOfflineRegion', <String, dynamic>{
-    'channelName': channelName,
-    'definition': definition.toMap(),
-    'metadata': metadata,
-  });
-
   if (onEvent != null) {
     EventChannel(channelName).receiveBroadcastStream().handleError((error) {
       if (error is PlatformException) {
@@ -109,7 +102,7 @@ Future<OfflineRegion> downloadOfflineRegion(
         PlatformException(
           code: 'UnknowException',
           message:
-              'This error is unhandled by plugin. Please contact us if needed.',
+          'This error is unhandled by plugin. Please contact us if needed.',
           details: error,
         ),
       );
@@ -143,6 +136,13 @@ Future<OfflineRegion> downloadOfflineRegion(
       onEvent(status ?? (throw 'Invalid event status ${jsonData['status']}'));
     });
   }
+
+  final result = await _globalChannel
+      .invokeMethod('downloadOfflineRegion', <String, dynamic>{
+    'channelName': channelName,
+    'definition': definition.toMap(),
+    'metadata': metadata,
+  });
 
   return OfflineRegion.fromMap(json.decode(result));
 }

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -92,6 +92,11 @@ Future<OfflineRegion> downloadOfflineRegion(
   String channelName =
       'downloadOfflineRegion_${DateTime.now().microsecondsSinceEpoch}';
 
+  await _globalChannel
+      .invokeMethod('downloadOfflineRegion#setup', <String, dynamic>{
+    'channelName': channelName,
+  });
+
   if (onEvent != null) {
     EventChannel(channelName).receiveBroadcastStream().handleError((error) {
       if (error is PlatformException) {
@@ -139,7 +144,6 @@ Future<OfflineRegion> downloadOfflineRegion(
 
   final result = await _globalChannel
       .invokeMethod('downloadOfflineRegion', <String, dynamic>{
-    'channelName': channelName,
     'definition': definition.toMap(),
     'metadata': metadata,
   });


### PR DESCRIPTION
Here i splitted the downloadOfflineRegion method on the native side both on IOS and android. This is to avoid edge case when the download is so fast that the event channel doesnt link to the native side. When this happen, the callback `onEvent` is never called. This is an inconsitency that can create infinite loadings.