### PR TITLE
iOS example: pin pod versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ To use this plugin with iOS, you need to add the source repository and 2 additio
 source 'https://cdn.cocoapods.org/'
 source 'https://github.com/m0nac0/flutter-maplibre-podspecs.git'
 
-pod 'MapLibre'
-pod 'MapLibreAnnotationExtension'
+pod 'MapLibre', '5.12.2'
+pod 'MapLibreAnnotationExtension', '0.0.1-beta.2'
 ```
 
 ### Web

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -4,8 +4,8 @@ source 'https://github.com/m0nac0/flutter-maplibre-podspecs.git'
 # Uncomment this line to define a global platform for your project
 platform :ios, '11.0'
 
-pod 'MapLibre'
-pod 'MapLibreAnnotationExtension'
+pod 'MapLibre', '5.12.2'
+pod 'MapLibreAnnotationExtension', '0.0.1-beta.2'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
I want to add new pod versions of the MapLibre pod (https://github.com/m0nac0/flutter-maplibre-podspecs/pull/2).

I think it's a good idea to pin the MapLibre native version here and then explicitly update it after we have tested the new MapLibre native version.