### PR TITLE
Simplify iOS usage instructions and example podfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## upcoming version
-
+* Developers do not need to adapt their Podfile for iOS apps anymore as it was previously described in the Readme.  [https://github.com/maplibre/flutter-maplibre-gl/pull/278](https://github.com/maplibre/flutter-maplibre-gl/pull/278)
 ### Breaking Change:
 * `useDelayedDisposal` was removed since its now fixed in https://github.com/maplibre/flutter-maplibre-gl/pull/259
 * `useHybridCompositionOverride` was removed since it was added in the following fix: https://github.com/maplibre/flutter-maplibre-gl/pull/203 and we reverted the fix and used another approach to fix the actual issue.

--- a/README.md
+++ b/README.md
@@ -43,16 +43,6 @@ Documentation is available on the docs branch in the doc/api folder and automati
 
 Please visit [https://github.com/maplibre/maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js) and [https://github.com/maplibre/maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native) for more information about the Maplibre libraries.
 
-### iOS
-To use this plugin with iOS, you need to add the source repository and 2 additional pods to your Podfile, as shown in the example app: https://github.com/maplibre/flutter-maplibre-gl/blob/main/example/ios/Podfile
-
-```ruby
-source 'https://cdn.cocoapods.org/'
-source 'https://github.com/m0nac0/flutter-maplibre-podspecs.git'
-
-pod 'MapLibre'
-pod 'MapLibreAnnotationExtension'
-```
 
 ### Web
 Include the following JavaScript and CSS files in the `<head>` of the `web/index.html` file.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Documentation is available on the docs branch in the doc/api folder and automati
 
 Please visit [https://github.com/maplibre/maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js) and [https://github.com/maplibre/maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native) for more information about the Maplibre libraries.
 
-## iOS
+### iOS
 To use this plugin with iOS, you do not need to adapt your app's Podfile anymore! If you previously adapted the Podfile because of the instructions here, this should not be necessary anymore with the latest changes and you should be able to remove these lines from your Podfile: 
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Documentation is available on the docs branch in the doc/api folder and automati
 
 Please visit [https://github.com/maplibre/maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js) and [https://github.com/maplibre/maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native) for more information about the Maplibre libraries.
 
+## iOS
+To use this plugin with iOS, you do not need to adapt your app's Podfile anymore! If you previously adapted the Podfile because of the instructions here, this should not be necessary anymore with the latest changes and you should be able to remove these lines from your Podfile: 
+
+```ruby
+source 'https://cdn.cocoapods.org/'
+source 'https://github.com/m0nac0/flutter-maplibre-podspecs.git'
+
+pod 'MapLibre'
+pod 'MapLibreAnnotationExtension'
+```
+
+You can also check our example app's Podfile: https://github.com/maplibre/flutter-maplibre-gl/blob/main/example/ios/Podfile
 
 ### Web
 Include the following JavaScript and CSS files in the `<head>` of the `web/index.html` file.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,3 @@
-source 'https://cdn.cocoapods.org/'
-
 # Uncomment this line to define a global platform for your project
 platform :ios, '11.0'
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,11 +1,7 @@
 source 'https://cdn.cocoapods.org/'
-source 'https://github.com/m0nac0/flutter-maplibre-podspecs.git'
 
 # Uncomment this line to define a global platform for your project
 platform :ios, '11.0'
-
-pod 'MapLibre'
-pod 'MapLibreAnnotationExtension'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
As noted in #276, developers shouldn't need to adapt their Podfiles anymore, since Maplibre is now a published pod and the dependency on MaplibreAnnotationExtension is removed in #277.