### PR TITLE
Add opportunity to use map in widget tests

### DIFF
--- a/lib/mapbox_gl.dart
+++ b/lib/mapbox_gl.dart
@@ -46,7 +46,10 @@ export 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
         RasterDemSourceProperties,
         GeojsonSourceProperties,
         VideoSourceProperties,
-        ImageSourceProperties;
+        ImageSourceProperties,
+        MapLibreGlPlatform,
+        MethodChannelMaplibreGl,
+        OnPlatformViewCreatedCallback;
 
 part 'src/controller.dart';
 

--- a/maplibre_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/mapbox_gl_platform_interface.dart
@@ -6,6 +6,8 @@ part of maplibre_gl_platform_interface;
 typedef OnPlatformViewCreatedCallback = void Function(int);
 
 abstract class MapLibreGlPlatform {
+  static MethodChannelMaplibreGl? _instance;
+
   /// The default instance of [MapboxGlPlatform] to use.
   ///
   /// Defaults to [MethodChannelMaplibreGl].
@@ -13,7 +15,11 @@ abstract class MapLibreGlPlatform {
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [MapLibreGlPlatform] when they register themselves.
   static MapLibreGlPlatform Function() createInstance =
-      () => MethodChannelMaplibreGl();
+      () => _instance ?? MethodChannelMaplibreGl();
+
+  static set instance(MethodChannelMaplibreGl instance) {
+    _instance = instance;
+  }
 
   final onInfoWindowTappedPlatform = ArgumentCallbacks<String>();
 


### PR DESCRIPTION
Hey! I needed to use the map in widget tests. But as it uses platform views those are not working properly during widget tests. So I made some classes visible and added a method to provide fake `MethodChannelMaplibreGl` to `MapLibreGlPlatform`.

Usage
```dart
class FakeMethodChannelMaplibreGl implements MethodChannelMaplibreGl {
...
}

 MapLibreGlPlatform.instance = FakeMethodChannelMaplibreGl();
```