### PR TITLE
👷Fix the codespace by upgrading the docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,3 @@
 {
-    "image": "cirrusci/flutter"
+    "image": "ghcr.io/cirruslabs/flutter"
 }


### PR DESCRIPTION
Currently, starting the example in the Codespace does not work:
```
# cd example/
# flutter run -d web-server --web-hostname=0.0.0.0
Downloading Web SDK...                                           2,735ms
Downloading CanvasKit...                                         1,107ms
Running "flutter pub get" in example...
Resolving dependencies... 
The current Dart SDK version is 2.19.4.

Because maplibre_gl_example requires SDK version >=3.0.0 <4.0.0, version solving failed.
```

To have a dart 3.x image, we need to move away from `cirrusci/flutter`, as it's deprecated. The recommended replacement is `ghcr.io/cirruslabs/flutter`


Cf message on `cirrusci/flutter` docker image: https://hub.docker.com/r/cirrusci/flutter

> DEPRECATED
> New releases available at https://github.com/cirruslabs/docker-images-flutter/pkgs/container/flutter