### PR TITLE
✨attributionButtonPosition for web

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A possible explanation could be: "Shows your location on the map".
 ## Running in GitHub Codespaces
 When you open this project in GitHub Codespaces, you can run the example app on web with the command 
 ```
-$ cd examples
+$ cd example
 $ flutter run -d web-server --web-hostname=0.0.0.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,11 @@ A possible explanation could be: "Shows your location on the map".
 - **Have a feature request?** [Open an issue](https://github.com/maplibre/flutter-maplibre-gl/issues/new). Tell us what the feature should do and why you want the feature.
 
 ## Running in GitHub Codespaces
-When you open this project in GitHub Codespaces, you can run the example app on web with the command `flutter run -d web-server --web-hostname=0.0.0.0`
+When you open this project in GitHub Codespaces, you can run the example app on web with the command 
+```
+$ cd examples
+$ flutter run -d web-server --web-hostname=0.0.0.0
+```
 
 Codespaces should automatically take care of the necessary port forwarding, so that you can view the running web app on your local device or in a new tab.
 

--- a/example/assets/osm_style.json
+++ b/example/assets/osm_style.json
@@ -1,0 +1,23 @@
+{
+    "version": 8,
+    "sources": {
+      "OSM": {
+        "type": "raster",
+        "tiles": [
+          "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        ],
+        "tileSize": 256,
+        "attribution": "© OpenStreetMap contributors",
+        "maxzoom": 18
+      }
+    },
+    "layers": [
+      {
+        "id": "OSM-layer",
+        "source": "OSM",
+        "type": "raster"
+      }
+    ]
+  }

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -22,7 +22,7 @@ class AttributionBody extends StatefulWidget {
 
 class _AttributionBodyState extends State<AttributionBody> {
   AttributionButtonPosition? attributionButtonPosition;
-  bool useDefaultAttributionPosition = false;
+  bool useDefaultAttributionPosition = true;
 
   @override
   Widget build(BuildContext context) {
@@ -31,8 +31,8 @@ class _AttributionBodyState extends State<AttributionBody> {
         const Text("Set attribution position"),
         Row(
           children: [
-            buildPositionButton(null),
             buildDefaultPositionButton(),
+            buildPositionButton(null),
             buildPositionButton(AttributionButtonPosition.TopRight),
             buildPositionButton(AttributionButtonPosition.TopLeft),
             buildPositionButton(AttributionButtonPosition.BottomRight),

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -68,7 +68,7 @@ class _AttributionBodyState extends State<AttributionBody> {
           useDefaultAttributionPosition = false;
         });
       },
-      child: Text(position?.name ?? "Null, same as default"),
+      child: Text(position?.name ?? "Null (=platform default)"),
     );
   }
 

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -29,7 +29,7 @@ class _AttributionBodyState extends State<AttributionBody> {
     return Column(
       children: [
         const Text("Set attribution position"),
-        Row(
+        Wrap(
           children: [
             buildDefaultPositionButton(),
             buildPositionButton(null),
@@ -84,7 +84,7 @@ class _AttributionBodyState extends State<AttributionBody> {
           target: LatLng(-33.852, 151.211),
           zoom: 11.0,
         ),
-        styleString: "/assets/assets/osm_style.json",
+        styleString: "/assets/osm_style.json",
       );
     } else {
       return MaplibreMap(
@@ -93,7 +93,7 @@ class _AttributionBodyState extends State<AttributionBody> {
           target: LatLng(-33.852, 151.211),
           zoom: 11.0,
         ),
-        styleString: "/assets/assets/osm_style.json",
+        styleString: "/assets/osm_style.json",
         attributionButtonPosition: attributionButtonPosition,
       );
     }

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -69,7 +69,7 @@ class _AttributionBodyState extends State<AttributionBody> {
           useDefaultAttributionPosition = false;
         });
       },
-      child: Text(position?.name ?? "None"),
+      child: Text(position?.name ?? "Null, same as default"),
     );
   }
 

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -4,7 +4,8 @@ import 'package:maplibre_gl/mapbox_gl.dart';
 import 'page.dart';
 
 class AttributionPage extends ExamplePage {
-  const AttributionPage({super.key}) : super(const Icon(Icons.thumb_up), 'Attribution');
+  const AttributionPage({super.key})
+      : super(const Icon(Icons.thumb_up), 'Attribution');
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -22,6 +22,7 @@ class AttributionBody extends StatefulWidget {
 
 class _AttributionBodyState extends State<AttributionBody> {
   AttributionButtonPosition? attributionButtonPosition;
+  bool useDefaultAttributionPosition = false;
 
   @override
   Widget build(BuildContext context) {
@@ -30,54 +31,71 @@ class _AttributionBodyState extends State<AttributionBody> {
         const Text("Set attribution position"),
         Row(
           children: [
-            ElevatedButton(
-              onPressed: () {
-                setState(() {
-                  attributionButtonPosition =
-                      AttributionButtonPosition.TopRight;
-                });
-              },
-              child: const Text('TopRight'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                setState(() {
-                  attributionButtonPosition = AttributionButtonPosition.TopLeft;
-                });
-              },
-              child: const Text('TopLeft'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                setState(() {
-                  attributionButtonPosition =
-                      AttributionButtonPosition.BottomRight;
-                });
-              },
-              child: const Text('BottomRight'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                setState(() {
-                  attributionButtonPosition =
-                      AttributionButtonPosition.BottomLeft;
-                });
-              },
-              child: const Text('BottomLeft'),
-            ),
+            buildPositionButton(null),
+            buildDefaultPositionButton(),
+            buildPositionButton(AttributionButtonPosition.TopRight),
+            buildPositionButton(AttributionButtonPosition.TopLeft),
+            buildPositionButton(AttributionButtonPosition.BottomRight),
+            buildPositionButton(AttributionButtonPosition.BottomLeft),
           ],
         ),
         Expanded(
-          child: MaplibreMap(
-            initialCameraPosition: const CameraPosition(
-              target: LatLng(-33.852, 151.211),
-              zoom: 11.0,
-            ),
-            styleString: "/assets/assets/osm_style.json",
-            attributionButtonPosition: attributionButtonPosition,
+          child: buildMap(
+            attributionButtonPosition,
+            useDefaultAttributionPosition,
           ),
         ),
       ],
     );
+  }
+
+  ElevatedButton buildDefaultPositionButton() {
+    return ElevatedButton(
+      onPressed: () {
+        setState(() {
+          attributionButtonPosition = null;
+          useDefaultAttributionPosition = true;
+        });
+      },
+      child: const Text("Default"),
+    );
+  }
+
+  ElevatedButton buildPositionButton(AttributionButtonPosition? position) {
+    return ElevatedButton(
+      onPressed: () {
+        setState(() {
+          attributionButtonPosition = position;
+          useDefaultAttributionPosition = false;
+        });
+      },
+      child: Text(position?.name ?? "None"),
+    );
+  }
+
+  MaplibreMap buildMap(
+    AttributionButtonPosition? attributionButtonPosition,
+    bool useDefaultAttributionPosition,
+  ) {
+    if (useDefaultAttributionPosition) {
+      return MaplibreMap(
+        key: UniqueKey(),
+        initialCameraPosition: const CameraPosition(
+          target: LatLng(-33.852, 151.211),
+          zoom: 11.0,
+        ),
+        styleString: "/assets/assets/osm_style.json",
+      );
+    } else {
+      return MaplibreMap(
+        key: UniqueKey(),
+        initialCameraPosition: const CameraPosition(
+          target: LatLng(-33.852, 151.211),
+          zoom: 11.0,
+        ),
+        styleString: "/assets/assets/osm_style.json",
+        attributionButtonPosition: attributionButtonPosition,
+      );
+    }
   }
 }

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/mapbox_gl.dart';
+
+import 'page.dart';
+
+class AttributionPage extends ExamplePage {
+  const AttributionPage({super.key})
+      : super(const Icon(Icons.thumb_up), 'Attribution');
+
+  @override
+  Widget build(BuildContext context) {
+    return const AttributionBody();
+  }
+}
+
+class AttributionBody extends StatefulWidget {
+  const AttributionBody({super.key});
+
+  @override
+  State<AttributionBody> createState() => _AttributionBodyState();
+}
+
+class _AttributionBodyState extends State<AttributionBody> {
+  AttributionButtonPosition? attributionButtonPosition;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Text("Set attribution position"),
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  attributionButtonPosition =
+                      AttributionButtonPosition.TopRight;
+                });
+              },
+              child: const Text('TopRight'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  attributionButtonPosition = AttributionButtonPosition.TopLeft;
+                });
+              },
+              child: const Text('TopLeft'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  attributionButtonPosition =
+                      AttributionButtonPosition.BottomRight;
+                });
+              },
+              child: const Text('BottomRight'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  attributionButtonPosition =
+                      AttributionButtonPosition.BottomLeft;
+                });
+              },
+              child: const Text('BottomLeft'),
+            ),
+          ],
+        ),
+        Expanded(
+          child: MaplibreMap(
+            initialCameraPosition: const CameraPosition(
+              target: LatLng(-33.852, 151.211),
+              zoom: 11.0,
+            ),
+            styleString: "/assets/assets/osm_style.json",
+            attributionButtonPosition: attributionButtonPosition,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -4,8 +4,7 @@ import 'package:maplibre_gl/mapbox_gl.dart';
 import 'page.dart';
 
 class AttributionPage extends ExamplePage {
-  const AttributionPage({super.key})
-      : super(const Icon(Icons.thumb_up), 'Attribution');
+  const AttributionPage({super.key}) : super(const Icon(Icons.thumb_up), 'Attribution');
 
   @override
   Widget build(BuildContext context) {
@@ -84,7 +83,7 @@ class _AttributionBodyState extends State<AttributionBody> {
           target: LatLng(-33.852, 151.211),
           zoom: 11.0,
         ),
-        styleString: "/assets/osm_style.json",
+        styleString: "assets/osm_style.json",
       );
     } else {
       return MaplibreMap(
@@ -93,7 +92,7 @@ class _AttributionBodyState extends State<AttributionBody> {
           target: LatLng(-33.852, 151.211),
           zoom: 11.0,
         ),
-        styleString: "/assets/osm_style.json",
+        styleString: "assets/osm_style.json",
         attributionButtonPosition: attributionButtonPosition,
       );
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:location/location.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:maplibre_gl_example/attribution.dart';
 import 'package:maplibre_gl_example/get_map_informations.dart';
 import 'package:maplibre_gl_example/given_bounds.dart';
 import 'package:maplibre_gl_example/localized_map.dart';
@@ -58,6 +59,7 @@ final List<ExamplePage> _allPages = <ExamplePage>[
   const GivenBoundsPage(),
   const GetMapInfoPage(),
   const NoLocationPermissionPage(),
+  const AttributionPage(),
 ];
 
 class MapsDemo extends StatefulWidget {

--- a/example/lib/no_location_permission_page.dart
+++ b/example/lib/no_location_permission_page.dart
@@ -21,7 +21,8 @@ class NoLocationPermissionBody extends StatefulWidget {
   const NoLocationPermissionBody({super.key});
 
   @override
-  State<NoLocationPermissionBody> createState() => _NoLocationPermissionBodyState();
+  State<NoLocationPermissionBody> createState() =>
+      _NoLocationPermissionBodyState();
 }
 
 class _NoLocationPermissionBodyState extends State<NoLocationPermissionBody> {

--- a/example/lib/no_location_permission_page.dart
+++ b/example/lib/no_location_permission_page.dart
@@ -21,8 +21,7 @@ class NoLocationPermissionBody extends StatefulWidget {
   const NoLocationPermissionBody({super.key});
 
   @override
-  State<NoLocationPermissionBody> createState() =>
-      _NoLocationPermissionBodyState();
+  State<NoLocationPermissionBody> createState() => _NoLocationPermissionBodyState();
 }
 
 class _NoLocationPermissionBodyState extends State<NoLocationPermissionBody> {
@@ -33,7 +32,7 @@ class _NoLocationPermissionBodyState extends State<NoLocationPermissionBody> {
         target: LatLng(-33.852, 151.211),
         zoom: 11.0,
       ),
-      styleString: "/assets/osm_style.json",
+      styleString: "assets/osm_style.json",
     );
   }
 }

--- a/example/lib/no_location_permission_page.dart
+++ b/example/lib/no_location_permission_page.dart
@@ -33,7 +33,7 @@ class _NoLocationPermissionBodyState extends State<NoLocationPermissionBody> {
         target: LatLng(-33.852, 151.211),
         zoom: 11.0,
       ),
-      styleString: "/assets/assets/osm_style.json",
+      styleString: "/assets/osm_style.json",
     );
   }
 }

--- a/example/lib/no_location_permission_page.dart
+++ b/example/lib/no_location_permission_page.dart
@@ -33,29 +33,7 @@ class _NoLocationPermissionBodyState extends State<NoLocationPermissionBody> {
         target: LatLng(-33.852, 151.211),
         zoom: 11.0,
       ),
-      styleString: '''{
-        "version": 8,
-        "sources": {
-          "OSM": {
-            "type": "raster",
-            "tiles": [
-              "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-              "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-              "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            ],
-            "tileSize": 256,
-            "attribution": "© OpenStreetMap contributors",
-            "maxzoom": 18
-          }
-        },
-        "layers": [
-          {
-            "id": "OSM-layer",
-            "source": "OSM",
-            "type": "raster"
-          }
-        ]
-      }''',
+      styleString: "/assets/assets/osm_style.json",
     );
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -72,6 +72,7 @@ flutter:
     - assets/symbols/3.0x/custom-icon.png
     - assets/symbols/custom-marker.png
     - assets/style.json
+    - assets/osm_style.json
     - assets/sydney0.png
     - assets/sydney1.png
 

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -54,7 +54,9 @@ class MaplibreMap extends StatefulWidget {
       AnnotationType.circle,
     ],
   })  : assert(
-          myLocationRenderMode != MyLocationRenderMode.NORMAL ? myLocationEnabled : true,
+          myLocationRenderMode != MyLocationRenderMode.NORMAL
+              ? myLocationEnabled
+              : true,
           "$myLocationRenderMode requires [myLocationEnabled] set to true.",
         ),
         assert(annotationOrder.length <= 4),
@@ -222,30 +224,37 @@ class MaplibreMap extends StatefulWidget {
   /// Set `MapboxMap.useHybridComposition` to `false` in order use Virtual-Display
   /// (better for Android 9 and below but may result in errors on Android 12)
   /// or leave it `true` (default) to use Hybrid composition (Slower on Android 9 and below).
-  static bool get useHybridComposition => MethodChannelMaplibreGl.useHybridComposition;
+  static bool get useHybridComposition =>
+      MethodChannelMaplibreGl.useHybridComposition;
 
-  static set useHybridComposition(bool useHybridComposition) => MethodChannelMaplibreGl.useHybridComposition = useHybridComposition;
+  static set useHybridComposition(bool useHybridComposition) =>
+      MethodChannelMaplibreGl.useHybridComposition = useHybridComposition;
 
   @override
   State createState() => _MaplibreMapState();
 }
 
 class _MaplibreMapState extends State<MaplibreMap> {
-  final Completer<MaplibreMapController> _controller = Completer<MaplibreMapController>();
+  final Completer<MaplibreMapController> _controller =
+      Completer<MaplibreMapController>();
 
   late _MapboxMapOptions _mapboxMapOptions;
-  final MapLibreGlPlatform _mapboxGlPlatform = MapLibreGlPlatform.createInstance();
+  final MapLibreGlPlatform _mapboxGlPlatform =
+      MapLibreGlPlatform.createInstance();
 
   @override
   Widget build(BuildContext context) {
-    assert(widget.annotationOrder.toSet().length == widget.annotationOrder.length, "annotationOrder must not have duplicate types");
+    assert(
+        widget.annotationOrder.toSet().length == widget.annotationOrder.length,
+        "annotationOrder must not have duplicate types");
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
       //'onAttributionClickOverride': widget.onAttributionClick != null,
       'dragEnabled': widget.dragEnabled,
     };
-    return _mapboxGlPlatform.buildView(creationParams, onPlatformViewCreated, widget.gestureRecognizers);
+    return _mapboxGlPlatform.buildView(
+        creationParams, onPlatformViewCreated, widget.gestureRecognizers);
   }
 
   @override
@@ -267,7 +276,8 @@ class _MaplibreMapState extends State<MaplibreMap> {
   void didUpdateWidget(MaplibreMap oldWidget) {
     super.didUpdateWidget(oldWidget);
     final _MapboxMapOptions newOptions = _MapboxMapOptions.fromWidget(widget);
-    final Map<String, dynamic> updates = _mapboxMapOptions.updatesMap(newOptions);
+    final Map<String, dynamic> updates =
+        _mapboxMapOptions.updatesMap(newOptions);
     _updateOptions(updates);
     _mapboxMapOptions = newOptions;
   }
@@ -346,7 +356,8 @@ class _MapboxMapOptions {
       tiltGesturesEnabled: map.tiltGesturesEnabled,
       trackCameraPosition: map.trackCameraPosition,
       zoomGesturesEnabled: map.zoomGesturesEnabled,
-      doubleClickZoomEnabled: map.doubleClickZoomEnabled ?? map.zoomGesturesEnabled,
+      doubleClickZoomEnabled:
+          map.doubleClickZoomEnabled ?? map.zoomGesturesEnabled,
       myLocationEnabled: map.myLocationEnabled,
       myLocationTrackingMode: map.myLocationTrackingMode,
       myLocationRenderMode: map.myLocationRenderMode,
@@ -394,7 +405,13 @@ class _MapboxMapOptions {
 
   final Point? attributionButtonMargins;
 
-  final _gestureGroup = {'rotateGesturesEnabled', 'scrollGesturesEnabled', 'tiltGesturesEnabled', 'zoomGesturesEnabled', 'doubleClickZoomEnabled'};
+  final _gestureGroup = {
+    'rotateGesturesEnabled',
+    'scrollGesturesEnabled',
+    'tiltGesturesEnabled',
+    'zoomGesturesEnabled',
+    'doubleClickZoomEnabled'
+  };
 
   Map<String, dynamic> toMap() {
     final Map<String, dynamic> optionsMap = <String, dynamic>{};
@@ -432,7 +449,8 @@ class _MapboxMapOptions {
     addIfNonNull('compassViewPosition', compassViewPosition?.index);
     addIfNonNull('compassViewMargins', pointToArray(compassViewMargins));
     addIfNonNull('attributionButtonPosition', attributionButtonPosition?.index);
-    addIfNonNull('attributionButtonMargins', pointToArray(attributionButtonMargins));
+    addIfNonNull(
+        'attributionButtonMargins', pointToArray(attributionButtonMargins));
     return optionsMap;
   }
 
@@ -443,7 +461,8 @@ class _MapboxMapOptions {
     // if any gesture is updated also all other gestures have to the saved to
     // the update
 
-    final gesturesRequireUpdate = _gestureGroup.any((key) => newOptionsMap[key] != prevOptionsMap[key]);
+    final gesturesRequireUpdate =
+        _gestureGroup.any((key) => newOptionsMap[key] != prevOptionsMap[key]);
 
     return newOptionsMap
       ..removeWhere((String key, dynamic value) {

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -54,9 +54,7 @@ class MaplibreMap extends StatefulWidget {
       AnnotationType.circle,
     ],
   })  : assert(
-          myLocationRenderMode != MyLocationRenderMode.NORMAL
-              ? myLocationEnabled
-              : true,
+          myLocationRenderMode != MyLocationRenderMode.NORMAL ? myLocationEnabled : true,
           "$myLocationRenderMode requires [myLocationEnabled] set to true.",
         ),
         assert(annotationOrder.length <= 4),
@@ -176,6 +174,8 @@ class MaplibreMap extends StatefulWidget {
   final Point? compassViewMargins;
 
   /// Set the position for the MapLibre Attribution Button
+  /// When set to null, the default value of the underlying MapLibre libraries is used,
+  /// which differs depending on the operating system the app is being run on.
   final AttributionButtonPosition? attributionButtonPosition;
 
   /// Set the layout margins for the MapLibre Attribution Buttons. If you set this
@@ -222,37 +222,30 @@ class MaplibreMap extends StatefulWidget {
   /// Set `MapboxMap.useHybridComposition` to `false` in order use Virtual-Display
   /// (better for Android 9 and below but may result in errors on Android 12)
   /// or leave it `true` (default) to use Hybrid composition (Slower on Android 9 and below).
-  static bool get useHybridComposition =>
-      MethodChannelMaplibreGl.useHybridComposition;
+  static bool get useHybridComposition => MethodChannelMaplibreGl.useHybridComposition;
 
-  static set useHybridComposition(bool useHybridComposition) =>
-      MethodChannelMaplibreGl.useHybridComposition = useHybridComposition;
+  static set useHybridComposition(bool useHybridComposition) => MethodChannelMaplibreGl.useHybridComposition = useHybridComposition;
 
   @override
   State createState() => _MaplibreMapState();
 }
 
 class _MaplibreMapState extends State<MaplibreMap> {
-  final Completer<MaplibreMapController> _controller =
-      Completer<MaplibreMapController>();
+  final Completer<MaplibreMapController> _controller = Completer<MaplibreMapController>();
 
   late _MapboxMapOptions _mapboxMapOptions;
-  final MapLibreGlPlatform _mapboxGlPlatform =
-      MapLibreGlPlatform.createInstance();
+  final MapLibreGlPlatform _mapboxGlPlatform = MapLibreGlPlatform.createInstance();
 
   @override
   Widget build(BuildContext context) {
-    assert(
-        widget.annotationOrder.toSet().length == widget.annotationOrder.length,
-        "annotationOrder must not have duplicate types");
+    assert(widget.annotationOrder.toSet().length == widget.annotationOrder.length, "annotationOrder must not have duplicate types");
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition.toMap(),
       'options': _MapboxMapOptions.fromWidget(widget).toMap(),
       //'onAttributionClickOverride': widget.onAttributionClick != null,
       'dragEnabled': widget.dragEnabled,
     };
-    return _mapboxGlPlatform.buildView(
-        creationParams, onPlatformViewCreated, widget.gestureRecognizers);
+    return _mapboxGlPlatform.buildView(creationParams, onPlatformViewCreated, widget.gestureRecognizers);
   }
 
   @override
@@ -274,8 +267,7 @@ class _MaplibreMapState extends State<MaplibreMap> {
   void didUpdateWidget(MaplibreMap oldWidget) {
     super.didUpdateWidget(oldWidget);
     final _MapboxMapOptions newOptions = _MapboxMapOptions.fromWidget(widget);
-    final Map<String, dynamic> updates =
-        _mapboxMapOptions.updatesMap(newOptions);
+    final Map<String, dynamic> updates = _mapboxMapOptions.updatesMap(newOptions);
     _updateOptions(updates);
     _mapboxMapOptions = newOptions;
   }
@@ -354,8 +346,7 @@ class _MapboxMapOptions {
       tiltGesturesEnabled: map.tiltGesturesEnabled,
       trackCameraPosition: map.trackCameraPosition,
       zoomGesturesEnabled: map.zoomGesturesEnabled,
-      doubleClickZoomEnabled:
-          map.doubleClickZoomEnabled ?? map.zoomGesturesEnabled,
+      doubleClickZoomEnabled: map.doubleClickZoomEnabled ?? map.zoomGesturesEnabled,
       myLocationEnabled: map.myLocationEnabled,
       myLocationTrackingMode: map.myLocationTrackingMode,
       myLocationRenderMode: map.myLocationRenderMode,
@@ -403,13 +394,7 @@ class _MapboxMapOptions {
 
   final Point? attributionButtonMargins;
 
-  final _gestureGroup = {
-    'rotateGesturesEnabled',
-    'scrollGesturesEnabled',
-    'tiltGesturesEnabled',
-    'zoomGesturesEnabled',
-    'doubleClickZoomEnabled'
-  };
+  final _gestureGroup = {'rotateGesturesEnabled', 'scrollGesturesEnabled', 'tiltGesturesEnabled', 'zoomGesturesEnabled', 'doubleClickZoomEnabled'};
 
   Map<String, dynamic> toMap() {
     final Map<String, dynamic> optionsMap = <String, dynamic>{};
@@ -447,8 +432,7 @@ class _MapboxMapOptions {
     addIfNonNull('compassViewPosition', compassViewPosition?.index);
     addIfNonNull('compassViewMargins', pointToArray(compassViewMargins));
     addIfNonNull('attributionButtonPosition', attributionButtonPosition?.index);
-    addIfNonNull(
-        'attributionButtonMargins', pointToArray(attributionButtonMargins));
+    addIfNonNull('attributionButtonMargins', pointToArray(attributionButtonMargins));
     return optionsMap;
   }
 
@@ -459,8 +443,7 @@ class _MapboxMapOptions {
     // if any gesture is updated also all other gestures have to the saved to
     // the update
 
-    final gesturesRequireUpdate =
-        _gestureGroup.any((key) => newOptionsMap[key] != prevOptionsMap[key]);
+    final gesturesRequireUpdate = _gestureGroup.any((key) => newOptionsMap[key] != prevOptionsMap[key]);
 
     return newOptionsMap
       ..removeWhere((String key, dynamic value) {

--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -175,10 +175,10 @@ class MaplibreMap extends StatefulWidget {
   /// Set the layout margins for the Mapbox Compass
   final Point? compassViewMargins;
 
-  /// Set the position for the Mapbox Attribution Button
+  /// Set the position for the MapLibre Attribution Button
   final AttributionButtonPosition? attributionButtonPosition;
 
-  /// Set the layout margins for the Mapbox Attribution Buttons. If you set this
+  /// Set the layout margins for the MapLibre Attribution Buttons. If you set this
   /// value, you may also want to set [attributionButtonPosition] to harmonize
   /// the layout between iOS and Android, since the underlying frameworks have
   /// different defaults.

--- a/maplibre_gl_web/lib/mapbox_gl_web.dart
+++ b/maplibre_gl_web/lib/mapbox_gl_web.dart
@@ -27,6 +27,7 @@ import 'package:maplibre_gl_web/src/geo/lng_lat_bounds.dart';
 import 'package:maplibre_gl_web/src/layer_tools.dart';
 import 'package:maplibre_gl_web/src/style/sources/geojson_source.dart';
 import 'package:maplibre_gl_web/src/ui/camera.dart';
+import 'package:maplibre_gl_web/src/ui/control/attribution_control.dart';
 import 'package:maplibre_gl_web/src/ui/control/geolocate_control.dart';
 import 'package:maplibre_gl_web/src/ui/control/navigation_control.dart';
 import 'package:maplibre_gl_web/src/ui/map.dart';

--- a/maplibre_gl_web/lib/src/convert.dart
+++ b/maplibre_gl_web/lib/src/convert.dart
@@ -70,6 +70,8 @@ class Convert {
       final position = AttributionButtonPosition
           .values[options['attributionButtonPosition']];
       sink.setAttributionButtonAlignment(position);
+    } else {
+      sink.setAttributionButtonAlignment(AttributionButtonPosition.BottomRight);
     }
     if (options.containsKey('attributionButtonMargins')) {
       sink.setAttributionButtonMargins(options['attributionButtonMargins'][0],

--- a/maplibre_gl_web/lib/src/interop/ui/control/attribution_control_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/ui/control/attribution_control_interop.dart
@@ -1,0 +1,38 @@
+@JS('maplibregl')
+library mapboxgl.interop.ui.control.navigation_control;
+
+import 'package:js/js.dart';
+import 'package:maplibre_gl_web/src/interop/ui/map_interop.dart';
+
+@JS()
+@anonymous
+class AttributionControlOptionsJsImpl {
+  external bool get compact;
+
+  external List<String>? get customAttribution;
+
+  external factory AttributionControlOptionsJsImpl(
+      {bool? compact, List<String>? customAttribution});
+}
+
+/// A `AttributionControl` control contains attributions.
+///
+/// @implements {IControl}
+/// @param {Object} [options]
+/// @param {Boolean} [options.compact] If `true`, the attribution control will always collapse when moving the map. If `false`,force the expanded attribution control. The default is a responsive attribution that collapses when the user moves the map on maps less than 640 pixels wide.
+/// @param {List<String>} [options.customAttribution] Attributions to show in addition to any other attributions.
+/// @example
+/// var attribution = new mapboxgl.AttributionControl();
+/// map.addControl(attribution, 'top-left');
+/// @see [Display map attribution controls](https://maplibre.org/maplibre-gl-js/docs/examples/attribution-position/)
+@JS('AttributionControl')
+class AttributionControlJsImpl {
+  external AttributionControlOptionsJsImpl get options;
+
+  external factory AttributionControlJsImpl(
+      AttributionControlOptionsJsImpl options);
+
+  external onAdd(MapboxMapJsImpl map);
+
+  external onRemove();
+}

--- a/maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -594,9 +594,9 @@ class MaplibreMapController extends MapLibreGlPlatform
     }
   }
 
-  void _updateAttributionButton({
-    AttributionButtonPosition? position,
-  }) {
+  void _updateAttributionButton(
+    AttributionButtonPosition position,
+  ) {
     String? positionString;
     switch (position) {
       case AttributionButtonPosition.TopRight:
@@ -611,18 +611,11 @@ class MaplibreMapController extends MapLibreGlPlatform
       case AttributionButtonPosition.BottomLeft:
         positionString = 'bottom-left';
         break;
-      default:
-        positionString = null;
     }
 
     _removeAttributionButton();
     _attributionControl = AttributionControl(AttributionControlOptions());
-
-    if (positionString == null) {
-      _map.addControl(_attributionControl);
-    } else {
-      _map.addControl(_attributionControl, positionString);
-    }
+    _map.addControl(_attributionControl, positionString);
   }
 
   void _removeAttributionButton() {
@@ -672,7 +665,7 @@ class MaplibreMapController extends MapLibreGlPlatform
 
   @override
   void setAttributionButtonAlignment(AttributionButtonPosition position) {
-    _updateAttributionButton(position: position);
+    _updateAttributionButton(position);
   }
 
   @override

--- a/maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart
@@ -25,6 +25,7 @@ class MaplibreMapController extends MapLibreGlPlatform
 
   String? _navigationControlPosition;
   NavigationControl? _navigationControl;
+  AttributionControl? _attributionControl;
   Timer? lastResizeObserverTimer;
 
   @override
@@ -73,6 +74,7 @@ class MaplibreMapController extends MapLibreGlPlatform
           zoom: camera['zoom'],
           bearing: camera['bearing'],
           pitch: camera['tilt'],
+          attributionControl: false, //avoid duplicate control
         ),
       );
       _map.on('load', _onStyleLoaded);
@@ -592,6 +594,44 @@ class MaplibreMapController extends MapLibreGlPlatform
     }
   }
 
+  void _updateAttributionButton({
+    AttributionButtonPosition? position,
+  }) {
+    String? positionString;
+    switch (position) {
+      case AttributionButtonPosition.TopRight:
+        positionString = 'top-right';
+        break;
+      case AttributionButtonPosition.TopLeft:
+        positionString = 'top-left';
+        break;
+      case AttributionButtonPosition.BottomRight:
+        positionString = 'bottom-right';
+        break;
+      case AttributionButtonPosition.BottomLeft:
+        positionString = 'bottom-left';
+        break;
+      default:
+        positionString = null;
+    }
+
+    _removeAttributionButton();
+    _attributionControl = AttributionControl(AttributionControlOptions());
+
+    if (positionString == null) {
+      _map.addControl(_attributionControl);
+    } else {
+      _map.addControl(_attributionControl, positionString);
+    }
+  }
+
+  void _removeAttributionButton() {
+    if (_attributionControl != null) {
+      _map.removeControl(_attributionControl);
+      _attributionControl = null;
+    }
+  }
+
   /*
    *  MapboxMapOptionsSink
    */
@@ -632,7 +672,7 @@ class MaplibreMapController extends MapLibreGlPlatform
 
   @override
   void setAttributionButtonAlignment(AttributionButtonPosition position) {
-    print('setAttributionButtonAlignment not available in web');
+    _updateAttributionButton(position: position);
   }
 
   @override

--- a/maplibre_gl_web/lib/src/ui/control/attribution_control.dart
+++ b/maplibre_gl_web/lib/src/ui/control/attribution_control.dart
@@ -1,0 +1,49 @@
+library mapboxgl.ui.control.Attribution_control;
+
+import 'package:maplibre_gl_web/src/interop/interop.dart';
+import 'package:maplibre_gl_web/src/interop/ui/control/attribution_control_interop.dart';
+import 'package:maplibre_gl_web/src/ui/map.dart';
+
+class AttributionControlOptions
+    extends JsObjectWrapper<AttributionControlOptionsJsImpl> {
+  factory AttributionControlOptions({
+    bool? compact,
+    List<String>? customAttribution,
+  }) =>
+      AttributionControlOptions.fromJsObject(AttributionControlOptionsJsImpl(
+        compact: compact,
+        customAttribution: customAttribution,
+      ));
+
+  /// Creates a new AttributionControlOptions from a [jsObject].
+  AttributionControlOptions.fromJsObject(
+      AttributionControlOptionsJsImpl jsObject)
+      : super.fromJsObject(jsObject);
+}
+
+/// A `AttributionControl` control contains zoom buttons and a compass.
+///
+/// @implements {IControl}
+/// @param {Object} [options]
+/// @param {Boolean} [options.compact] If `true`, the attribution control will always collapse when moving the map. If `false`,force the expanded attribution control. The default is a responsive attribution that collapses when the user moves the map on maps less than 640 pixels wide.
+/// @param {List<String>} [options.customAttribution] Attributions to show in addition to any other attributions.
+/// @example
+/// var attribution = new mapboxgl.AttributionControl();
+/// map.addControl(attribution, 'top-left');
+/// @see [Display map attribution controls](https://maplibre.org/maplibre-gl-js/docs/examples/attribution-position/)
+class AttributionControl extends JsObjectWrapper<AttributionControlJsImpl> {
+  AttributionControlOptions get options =>
+      AttributionControlOptions.fromJsObject(jsObject.options);
+
+  factory AttributionControl(AttributionControlOptions options) =>
+      AttributionControl.fromJsObject(
+          AttributionControlJsImpl(options.jsObject));
+
+  onAdd(MapboxMap map) => jsObject.onAdd(map.jsObject);
+
+  onRemove() => jsObject.onRemove();
+
+  /// Creates a new MapOptions from a [jsObject].
+  AttributionControl.fromJsObject(AttributionControlJsImpl jsObject)
+      : super.fromJsObject(jsObject);
+}


### PR DESCRIPTION
Fix for: https://github.com/maplibre/flutter-maplibre-gl/issues/283

- **implement `attributionButtonPosition` for the web target**
  - in `maplibre_gl_web/lib/src/mapbox_web_gl_platform.dart`, we default to `attributionControl: false` in the _map constructor, as the attributionControl is set later when setAttributionButtonAlignment is called. 
  - ℹ️  It's similar to the example given in https://maplibre.org/maplibre-gl-js/docs/examples/attribution-position/ that also sets attributionControl to false in order to set manually the position.
- **interop scaffolding done** 
  - Matches [maplibre-gl-js attribution_control.ts](https://github.com/maplibre/maplibre-gl-js/blob/d6fdbe449ed8f8195399490c57a2e061ba90bbb7/src/ui/control/attribution_control.ts)
  - the `compact` and `customAttribution` options are not used currently. I'm not sure if they exists in iOS/Android.
- **new "attribution" example page**
  - it uses a `osm_style.json` exposed as an asset, as the web target does not support hardcoded styles 
  - the no_location example is updated to also use `osm_style.json`, to make it work correctly in web

**Attribution example page** 
![attribution_example](https://github.com/maplibre/flutter-maplibre-gl/assets/18073057/ce464739-1ca6-46ba-b49c-09fb2fe53a23)


