### PR TITLE
fix "unexpected null value" error when onStyleLoadedCallback is null

### DIFF
--- a/lib/src/mapbox_map.dart
+++ b/lib/src/mapbox_map.dart
@@ -294,9 +294,9 @@ class _MaplibreMapState extends State<MaplibreMap> {
       initialCameraPosition: widget.initialCameraPosition,
       onStyleLoadedCallback: () {
         if (_controller.isCompleted) {
-          widget.onStyleLoadedCallback!();
+          widget.onStyleLoadedCallback?.call();
         } else {
-          _controller.future.then((_) => widget.onStyleLoadedCallback!());
+          _controller.future.then((_) => widget.onStyleLoadedCallback?.call());
         }
       },
       onMapClick: widget.onMapClick,


### PR DESCRIPTION
This occurred for example in the example app on the animated camera control page or the attribution page from #304 