### PR TITLE
Update pub.dev workflow for platform_interface

### DIFF
--- a/.github/workflows/pub-platform-interface-publish.yml
+++ b/.github/workflows/pub-platform-interface-publish.yml
@@ -4,11 +4,20 @@ on:
   push:
     tags:
       - 'pub-maplibre_gl_platform_interface-[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
 
 jobs:
   publish:
     permissions:
       id-token: write # Required for authentication using OIDC
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      working-directory: maplibre_gl_platform_interface
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository
+      - uses: actions/checkout@v4
+      # Setup Dart SDK with JWT token
+      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+      # Publishing...
+      # skip validation due to https://github.com/dart-lang/setup-dart/issues/68
+      - name: Publish to pub.dev
+        run: dart pub publish -f --skip-validation
+        working-directory: maplibre_gl_platform_interface


### PR DESCRIPTION
The first attempt failed because of https://github.com/dart-lang/setup-dart/issues/68. This uses the --skip-validation option recommended in that issue.

Apparently the workflow recommended by pub.dev actually doesn't work with Flutter plugins because it tries to do some client side validations that fail because the workflow does not setup Flutter...