### PR TITLE
make feature tap detection work for features with a null id on ios (same as android)

### DIFF
--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -989,9 +989,9 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
         let point = sender.location(in: mapView)
         let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
 
-        if let feature = firstFeatureOnLayers(at: point), let id = feature.identifier {
+        if let feature = firstFeatureOnLayers(at: point) {
             channel?.invokeMethod("feature#onTap", arguments: [
-                        "id": id,
+                        "id": feature.identifier,
                         "x": point.x,
                         "y": point.y,
                         "lng": coordinate.longitude,


### PR DESCRIPTION
Feature Id nullable on android but not on iOS.

On android the feature id can be null which works fine in our app but on iOS clicking on points of interest the reaction is the same as clicking elsewhere on the map. 

In the android code 
![Screenshot 2023-12-12 at 13 42 00](https://github.com/maplibre/flutter-maplibre-gl/assets/26603883/a532aa76-9ec4-4bf4-8da3-b673989a85e6)

null is a valid value. I adapted the iOS code to allow for the same behaviour.