### PR TITLE
Fix: missing render when coming back from background

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -320,7 +320,7 @@ final class MapboxMapController
                 if (internalListener != null) {
                   internalListener.onSurfaceTextureUpdated(surface);
                 }
-                mapView.invalidate();
+                mapView.postInvalidate();
               }
             });
   }

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -13,6 +13,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PointF;
 import android.graphics.RectF;
+import android.graphics.SurfaceTexture;
+import android.view.TextureView.SurfaceTextureListener;
 import android.location.Location;
 import android.os.Build;
 import android.util.DisplayMetrics;
@@ -21,6 +23,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.TextureView;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
@@ -221,6 +224,7 @@ final class MapboxMapController
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
+    installInvalidator();
     if (mapReadyResult != null) {
       mapReadyResult.success(null);
       mapReadyResult = null;
@@ -254,6 +258,71 @@ final class MapboxMapController
     mapView.addOnDidBecomeIdleListener(this);
 
     setStyleString(styleStringInitial);
+  }
+
+  // Returns the first TextureView found in the view hierarchy.
+  private static TextureView findTextureView(ViewGroup group) {
+    final int n = group.getChildCount();
+    for (int i = 0; i < n; i++) {
+      View view = group.getChildAt(i);
+      if (view instanceof TextureView) {
+        return (TextureView) view;
+      }
+      if (view instanceof ViewGroup) {
+        TextureView r = findTextureView((ViewGroup) view);
+        if (r != null) {
+          return r;
+        }
+      }
+    }
+    return null;
+  }
+
+  private void installInvalidator() {
+    if (mapView == null) {
+      // This should only happen in tests.
+      return;
+    }
+    TextureView textureView = findTextureView(mapView);
+    if (textureView == null) {
+      Log.i(TAG, "No TextureView found. Likely using the LEGACY renderer.");
+      return;
+    }
+    Log.i(TAG, "Installing custom TextureView driven invalidator.");
+    SurfaceTextureListener internalListener = textureView.getSurfaceTextureListener();
+    // Override the Maps internal SurfaceTextureListener with our own. Our listener
+    // mostly just invokes the internal listener callbacks but in onSurfaceTextureUpdated
+    // the mapView is invalidated which ensures that all map updates are presented to the
+    // screen.
+    final MapView mapView = this.mapView;
+    textureView.setSurfaceTextureListener(
+            new TextureView.SurfaceTextureListener() {
+              public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
+                if (internalListener != null) {
+                  internalListener.onSurfaceTextureAvailable(surface, width, height);
+                }
+              }
+
+              public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+                if (internalListener != null) {
+                  return internalListener.onSurfaceTextureDestroyed(surface);
+                }
+                return true;
+              }
+
+              public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
+                if (internalListener != null) {
+                  internalListener.onSurfaceTextureSizeChanged(surface, width, height);
+                }
+              }
+
+              public void onSurfaceTextureUpdated(SurfaceTexture surface) {
+                if (internalListener != null) {
+                  internalListener.onSurfaceTextureUpdated(surface);
+                }
+                mapView.invalidate();
+              }
+            });
   }
 
   @Override


### PR DESCRIPTION
What
====
Fix issue[ #327](https://github.com/maplibre/flutter-maplibre-gl/issues/327)

Copied from [commit on the google map flutter plugin](https://github.com/flutter/packages/commit/e393d452beaf4b216e2567bc2cee0225087f4662).
The commit concerned was fixing another fix that has inserted a second bug.

Test Plan
=====

Tested on emulator API 28 & samsung Galaxy s7-> no more rendering missed when come back from background
Tested on OnePlus 7T android 12 -> no regression seen

![Dec-27-2023 16-18-06](https://github.com/maplibre/flutter-maplibre-gl/assets/83081700/2a83d263-6cd2-4a8b-8f81-850c3a3bc9e4)

Maestro Flow to reproduce bug
====
Run this flow with the following command:
`maestro test path_to_the_file`
Careful the flow does not check if the bug is present, just follow the steps to reproduce 15 times.

```yaml
appId: ${APP_ID}
name: "Relaunch app"
env: 
      APP_ID: com.mapbox.mapboxglexample
---
# first launch
# CAREFUL, You may need to allow fine location permission on device first
- launchApp: 
        appId: ${APP_ID}
# open map
- tapOn: "Full screen map"

# Stop and launch app
- repeat: 
        times: 15
        commands: 
              - pressKey: home
              - launchApp: 
                      appId: ${APP_ID}
                      stopApp: false
              - waitForAnimationToEnd: 
                      timeout: 5000
```