### PR TITLE
Use isolates to encode features

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -861,6 +861,24 @@ class MaplibreMapController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates the specified list of [line] with the given [changes]. The lines must
+  /// be current members of the [lines] set.‚
+  ///
+  /// Change listeners are notified once the line has been updated on the
+  /// platform side.
+  ///
+  /// The returned [Future] completes once listeners have been notified.
+  Future<void> updateLines(Map<Line, LineOptions> lines) async {
+    final updatedLines = lines.entries.map((entry) {
+      var line = entry.key;
+      final options = entry.value;
+      line.options = line.options.copyWith(options);
+      return line;
+    }).toList();
+    await lineManager!.setAll(updatedLines);
+    notifyListeners();
+  }
+
   /// Retrieves the current position of the line.
   /// This may be different from the value of `line.options.geometry` if the line is draggable.
   /// In that case this method provides the line's actual position, and `line.options.geometry` the last programmatically set position.

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -359,6 +359,27 @@ class MaplibreMapController extends ChangeNotifier {
         sourceId, geojsonFeature);
   }
 
+  /// Sets new geojson data to multiple existing sources
+  ///
+  /// This only works as exected if the source shas been created with
+  /// [addGeoJsonSource] before. This is very useful if you want to update
+  /// existing sources with modified data.
+  ///
+  /// The json in [geojson] has to comply with the schema for FeatureCollection
+  /// as specified in https://datatracker.ietf.org/doc/html/rfc7946#section-3.3
+  ///
+  /// The returned [Future] completes after the change has been made on the
+  /// platform side.
+  ///
+  /// This use isolates to encode the data before sending it to natif through
+  /// platform channel. Unlike [setGeoJsonFeature], it will not block the thread
+  /// when encoding the data.
+  /// But, spawning multiple isolates is expensive and can cause an the program
+  /// to crash. Never call this method multiple times in parallel.
+  Future<void> setGeoJsonFeatures(List<Source> sources) async {
+    await _maplibreGlPlatform.setFeatureForGeoJsonSources(sources);
+  }
+
   /// Add a symbol layer to the map with the given properties
   ///
   /// Consider using [addLayer] for an unified layer api.

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -217,3 +217,14 @@ abstract class MapLibreGlPlatform {
     onUserLocationUpdatedPlatform.clear();
   }
 }
+
+// Ideas for improvment:
+//   - Use a record instead
+//   - Make the class equatble
+/// Data class that represent a pair of `sourceId` and `geojsonFeature`.
+class Source {
+  const Source({required this.id, required this.geojsonFeature});
+
+  final String id;
+  final Map<String, dynamic> geojsonFeature;
+}

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -130,6 +130,8 @@ abstract class MapLibreGlPlatform {
   Future<void> setFeatureForGeoJsonSource(
       String sourceId, Map<String, dynamic> geojsonFeature);
 
+  Future<void> setFeatureForGeoJsonSources(List<Source> sources);
+
   Future<void> removeSource(String sourceId);
 
   Future<void> addSymbolLayer(

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -778,6 +778,16 @@ class MethodChannelMaplibreGl extends MapLibreGlPlatform {
     });
   }
 
+  Future<void> setFeatureForGeoJsonSources(List<Source> sources) async {
+    final encodedSources = await compute(_encodeSources, sources);
+    await Future.wait(
+      encodedSources.map(
+        (encodedSource) =>
+            _channel.invokeMethod('source#setFeature', encodedSource),
+      ),
+    );
+  }
+
   @override
   Future<void> setLayerVisibility(String layerId, bool visible) async {
     await _channel.invokeMethod('layer#setVisibility', <String, dynamic>{
@@ -814,3 +824,15 @@ class MethodChannelMaplibreGl extends MapLibreGlPlatform {
     }
   }
 }
+
+List<Map<String, String>> _encodeSources(
+  List<Source> sources,
+) =>
+    sources
+        .map(
+          (source) => {
+            'sourceId': source.id,
+            'geojsonFeature': jsonEncode(source.geojsonFeature),
+          },
+        )
+        .toList();

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1123,6 +1123,17 @@ class MaplibreMapController extends MapLibreGlPlatform
     }
   }
 
+  Future<void> setFeatureForGeoJsonSources(List<Source> sources) async {
+    await Future.wait(
+      sources.map(
+        (source) => setFeatureForGeoJsonSource(
+          source.id,
+          source.geojsonFeature,
+        ),
+      ),
+    );
+  }
+
   @override
   void resizeWebMap() {
     _onMapResize();


### PR DESCRIPTION
Fixes https://github.com/maplibre/flutter-maplibre-gl/issues/366
---

Wrapping `jsonEncode` in a `compute` allow data encoding without blocking the main isolate.
**BUT**
Spawning multiple isolate is very expensive, and can lead to crash.
So this technique is better used when encoding multiple geojsonFeature.

---
Currently, I have a performance issues on my app, when updating multiple lines.
So I coded a fix that solves only this issue.
But this principle could be applied to symbols, circles, polygones, and to the method `setGeoJsonSource`.

I willing to work on this, but first, I need review and feedbacks on this first implementation 🙏.