### PR TITLE
Add null check to layer#setVisibility on Android

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1505,7 +1505,9 @@ final class MapboxMapController
 
           Layer layer = style.getLayer(layerId);
 
-          layer.setProperties(PropertyFactory.visibility(visible ? Property.VISIBLE : Property.NONE));
+          if (layer != null) {
+            layer.setProperties(PropertyFactory.visibility(visible ? Property.VISIBLE : Property.NONE));
+          }
 
           result.success(null);
           break;


### PR DESCRIPTION
In our app there is a possibility to switch between map layers, and the amount of layers varies over time. In some cases, this leads to a NullPointerException in the current version of the library on Android. This PR fixes it. The iOS code has null checks implemented already.