### PR TITLE
Support newer Gradle versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Use Gradle's namespace configuration instead of Manifest package entry
+* Add JVM target for Kotlin
+
 ## 0.18.0
 ### Breaking Change:
 Already since 0.17.0, developers do not need to adapt their Podfile for iOS apps anymore as it was previously described in the Readme. Developers who previously added these lines should remove them, since not removing these lines may cause a build failure on iOS. (This change actually already landed in 0.17.0, but it may not have been sufficiently clear that not removing these lines might break builds).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,15 +40,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
     dependencies {
         implementation 'org.maplibre.gl:android-sdk:10.2.0'
         implementation 'org.maplibre.gl:android-plugin-annotation-v9:2.0.0'
         implementation 'org.maplibre.gl:android-plugin-offline-v9:2.0.0'
         implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    }
-    compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-    namespace 'com.mapbox.mapboxgl'
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.mapbox.mapboxgl'
+    }
 
     compileSdkVersion 31
     ndkVersion "20.1.5948944"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = JavaVersion.VERSION_1_8
     }
     dependencies {
         implementation 'org.maplibre.gl:android-sdk:10.2.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
+    namespace 'com.mapbox.mapboxgl'
 
     compileSdkVersion 31
     ndkVersion "20.1.5948944"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
         namespace 'com.mapbox.mapboxgl'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 34
     ndkVersion "20.1.5948944"
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.mapbox.mapboxgl">
-</manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.mapbox.mapboxgl">
+</manifest>


### PR DESCRIPTION
As in reported in #384 and changes already requested in #382, here a few changes to fix support for newer Gradle & Android versions. 

* fixes #310
* fixes #384 

This PR provide the minimal changes to support current Gradle and AGP versions. No library or plugin is updated.

- The package field in `AndroidManifest` is now auto-generated and the `namespace` configuration in the `build.gradle` is required since AGP 8.0
- I remove the `AndroidManifest` while there is now empty and useless
- I also added missing Kotlin JVM options, that was causing me failed builds
- Finally I removed a duplicated Gradle configuration