### PR TITLE
chore: use major version tag for `subosito/flutter-action`

### DIFF
--- a/.github/workflows/flutter_beta.yml
+++ b/.github/workflows/flutter_beta.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: subosito/flutter-action@v2.13.0
+    - uses: subosito/flutter-action@v2
       with:
         channel: ${{ env.FLUTTER_CHANNEL }}
         cache: true
@@ -49,7 +49,7 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: 'gradle'
-    - uses: subosito/flutter-action@v2.13.0
+    - uses: subosito/flutter-action@v2
       with:
         channel: ${{ env.FLUTTER_CHANNEL }}
         cache: true
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
@@ -92,7 +92,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: subosito/flutter-action@v2.13.0
+    - uses: subosito/flutter-action@v2
       with:
         channel: ${{ env.FLUTTER_CHANNEL }}
         cache: true

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -54,7 +54,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: 'gradle'
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: subosito/flutter-action@v2.13.0
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true


### PR DESCRIPTION
### Motivation
Using the tag of the major version decreases the amount of manual maintaincence and PR by dependabot.

### Replaces
- https://github.com/maplibre/flutter-maplibre-gl/pull/395