### PR TITLE
chore: fix linked Q&A page in GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: "Q&A - GitHub Discussions"
-    url: https://github.com/maplibre/maplibre-native/discussions/categories/q-a
+    url: https://github.com/maplibre/flutter-maplibre-gl/discussions/categories/q-a
     about: "If you have a question about using MapLibre on Flutter"
   - name: "Join on Slack"
     url: https://slack.openstreetmap.us/


### PR DESCRIPTION
I've just seen that I didn't used the correct Q&A page for the issues page. Sorry, my bad.
Introduced in: https://github.com/maplibre/flutter-maplibre-gl/pull/402

Additionally the config flag to enable blank issues seems not working? I set it to false the reflect the actual behavior. For questions and other discussions there are still the GH Discussions or Slack channel. Feel free to modify if you disagree.