### PR TITLE
feat(web): allow package:js version 0.6.x and 0.7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.18.1
+
+- Loosen the dependency constraint of [js](https://pub.dev/packages/js) to allow `0.6.x` and `0.7.x`.
+
 ## 0.18.0
 ### Breaking Change:
 Already since 0.17.0, developers do not need to adapt their Podfile for iOS apps anymore as it was previously described in the Readme. Developers who previously added these lines should remove them, since not removing these lines may cause a build failure on iOS. (This change actually already landed in 0.17.0, but it may not have been sufficiently clear that not removing these lines might break builds).

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         fileName: maplibre_gl_web.dart
 
 dependencies:
-  js: ^0.6.7
+  js: ">=0.6.7 <0.8.0"
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
### Changes
- Loosen the dependency constraint of [js](https://pub.dev/packages/js) to allow `0.6.x` and `0.7.x`.
- Update CHANGELOG.md

### Issue
- fix https://github.com/maplibre/flutter-maplibre-gl/issues/398