### PR TITLE
feat: allow latest `flutter_lints` version

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -45,7 +45,7 @@ dependency_overrides:
     path: ..
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   meta: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
 
 environment:
   sdk: '>=2.14.0 <3.0.0'

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -30,7 +30,7 @@ dependency_overrides:
     path: ../maplibre_gl_platform_interface
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
       ref: main
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   maplibre_gl_platform_interface:

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -12,4 +12,4 @@ dependencies:
   recase: ^4.0.0
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'


### PR DESCRIPTION
`flutter_lints: '>=3.0.0 <5.0.0'` allows v3 for old flutter versions and uses the latest v4 version on the current version.