### PR TITLE
chore: remove outdated copyright notices from files

### DIFF
--- a/android/src/main/java/com/mapbox/mapboxgl/Convert.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/Convert.java
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 package com.mapbox.mapboxgl;
 
 import android.content.Context;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapBuilder.java
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 package com.mapbox.mapboxgl;
 
 import android.content.Context;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapController.java
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 package com.mapbox.mapboxgl;
 
 import android.Manifest;

--- a/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
+++ b/android/src/main/java/com/mapbox/mapboxgl/MapboxMapsPlugin.java
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 package com.mapbox.mapboxgl;
 
 import android.app.Activity;

--- a/example/lib/animate_camera.dart
+++ b/example/lib/animate_camera.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 

--- a/example/lib/click_annotations.dart
+++ b/example/lib/click_annotations.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 

--- a/example/lib/given_bounds.dart
+++ b/example/lib/given_bounds.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:math';
 
 import 'package:flutter/material.dart';

--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 

--- a/example/lib/page.dart
+++ b/example/lib/page.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 
 abstract class ExamplePage extends StatelessWidget {

--- a/example/lib/place_batch.dart
+++ b/example/lib/place_batch.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 

--- a/example/lib/place_circle.dart
+++ b/example/lib/place_circle.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:async';
 import 'dart:math';
 

--- a/example/lib/place_fill.dart
+++ b/example/lib/place_fill.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'dart:async'; // ignore: unnecessary_import
 import 'dart:core';
 import 'dart:math';

--- a/example/lib/scrolling_map.dart
+++ b/example/lib/scrolling_map.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/lib/maplibre_gl.dart
+++ b/lib/maplibre_gl.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 /// This library contains the Maplibre GL plugin for Flutter.
 ///
 /// To display a map, add a [MaplibreMap] widget to the widget tree.

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl.dart';
 
 typedef OnMapClickCallback = void Function(

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl.dart';
 
 const _globalChannel = MethodChannel('plugins.flutter.io/mapbox_gl');

--- a/lib/src/maplibre_map.dart
+++ b/lib/src/maplibre_map.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl.dart';
 
 enum AnnotationType { fill, line, circle, symbol }

--- a/maplibre_gl_platform_interface/lib/src/callbacks.dart
+++ b/maplibre_gl_platform_interface/lib/src/callbacks.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 /// Callback function taking a single argument.

--- a/maplibre_gl_platform_interface/lib/src/camera.dart
+++ b/maplibre_gl_platform_interface/lib/src/camera.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 /// The position of the map "camera", the view point from which the world is

--- a/maplibre_gl_platform_interface/lib/src/circle.dart
+++ b/maplibre_gl_platform_interface/lib/src/circle.dart
@@ -1,9 +1,5 @@
 // This file is generated.
 
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 class Circle implements Annotation {

--- a/maplibre_gl_platform_interface/lib/src/fill.dart
+++ b/maplibre_gl_platform_interface/lib/src/fill.dart
@@ -1,9 +1,5 @@
 // This file is generated.
 
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 FillOptions translateFillOptions(FillOptions options, LatLng delta) {

--- a/maplibre_gl_platform_interface/lib/src/line.dart
+++ b/maplibre_gl_platform_interface/lib/src/line.dart
@@ -1,9 +1,5 @@
 // This file is generated.
 
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 class Line implements Annotation {

--- a/maplibre_gl_platform_interface/lib/src/location.dart
+++ b/maplibre_gl_platform_interface/lib/src/location.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 /// A pair of latitude and longitude coordinates, stored as degrees.

--- a/maplibre_gl_platform_interface/lib/src/symbol.dart
+++ b/maplibre_gl_platform_interface/lib/src/symbol.dart
@@ -1,9 +1,5 @@
 // This file is generated.
 
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 class Symbol implements Annotation {

--- a/maplibre_gl_platform_interface/lib/src/ui.dart
+++ b/maplibre_gl_platform_interface/lib/src/ui.dart
@@ -1,7 +1,3 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 part of '../maplibre_gl_platform_interface.dart';
 
 class MaplibreStyles {


### PR DESCRIPTION
Some files have outdated copyright notice but still references the LICENSE.md file for the license. 
This pull request removes those notices so that the license file is the only and up to date license information.