### PR TITLE
chore: fix publish ci (take 2)

### DIFF
--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -25,5 +25,5 @@ jobs:
         # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
         # see https://github.com/dart-lang/setup-dart/issues/68
       - name: Publish to pub.dev
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ./${{ inputs.working-directory }}
         run: dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Publish to pub.dev
         working-directory: ./${{ inputs.working-directory }}
         run: |
-          cd ./${{ inputs.working-directory }} && \
+          ls -la && \
           dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the OIDC
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'maplibre'
+    if: github.repository_owner == 'josxha'
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the OIDC
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'josxha'
+    if: github.repository_owner == 'maplibre'
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -24,7 +24,8 @@ jobs:
         # --force skips the y/N confirmation
         # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
         # see https://github.com/dart-lang/setup-dart/issues/68
-      - name: Change to package directory
-        run: cd ${{ inputs.working-directory }}
       - name: Publish to pub.dev
-        run: dart pub publish --force --skip-validation
+        working-directory: ./${{ inputs.working-directory }}
+        run: |
+          cd ./${{ inputs.working-directory }}
+          dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Publish to pub.dev
         working-directory: ./${{ inputs.working-directory }}
         run: |
-          cd ./${{ inputs.working-directory }}
+          cd ./${{ inputs.working-directory }} && \
           dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -24,6 +24,7 @@ jobs:
         # --force skips the y/N confirmation
         # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
         # see https://github.com/dart-lang/setup-dart/issues/68
+      - name: Change to package directory
+        run: cd ${{ inputs.working-directory }}
       - name: Publish to pub.dev
-        working-directory: ./${{ inputs.working-directory }}
         run: dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -25,7 +25,5 @@ jobs:
         # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
         # see https://github.com/dart-lang/setup-dart/issues/68
       - name: Publish to pub.dev
-        working-directory: ./${{ inputs.working-directory }}
-        run: |
-          ls -la && \
-          dart pub publish --force --skip-validation
+        working-directory: ${{ inputs.working-directory }}
+        run: dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -22,5 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         # --force skips the y/N confirmation
+        # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
+        # see https://github.com/dart-lang/setup-dart/issues/68
       - name: Publish to pub.dev
-        run: dart pub publish --force
+        run: dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -25,5 +25,5 @@ jobs:
         # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
         # see https://github.com/dart-lang/setup-dart/issues/68
       - name: Publish to pub.dev
-        working-directory: ${{ github.event.inputs.working-directory }}
+        working-directory: ${{ inputs.working-directory }}
         run: dart pub publish --force --skip-validation

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -20,11 +20,7 @@ jobs:
     if: github.repository_owner == 'josxha'
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
-        with:
-          cache: true
-      - name: Install dependencies
-        run: flutter pub get
+      - uses: dart-lang/setup-dart@v1
         # --force skips the y/N confirmation
       - name: Publish to pub.dev
-        run: flutter pub publish --force
+        run: dart pub publish --force

--- a/.github/workflows/publish-single.yml
+++ b/.github/workflows/publish-single.yml
@@ -25,4 +25,5 @@ jobs:
         # --skip-validation because of "Because maplibre_gl requires the Flutter SDK, version solving failed. Flutter users should use `flutter pub` instead of `dart pub`."
         # see https://github.com/dart-lang/setup-dart/issues/68
       - name: Publish to pub.dev
+        working-directory: ${{ github.event.inputs.working-directory }}
         run: dart pub publish --force --skip-validation

--- a/.pubignore
+++ b/.pubignore
@@ -1,4 +1,1 @@
 scripts
-screenshot.png
-maplibre_gl_web
-maplibre_gl_platform_interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ use the `maplibre_gl` package directly from pub.dev from now on. Check the
 * (web) Fix flickering when the style takes time to load
 
 **Full Changelog**:
-[0.18.0...0.19.0](https://github.com/maplibre/flutter-maplibre-gl/compare/0.18.0...0.19.0)
+[0.18.0...v0.19.0](https://github.com/maplibre/flutter-maplibre-gl/compare/0.18.0...v0.19.0)
 
 ## 0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,8 +184,8 @@ at the end for a full changelog.
 * attributionButtonPosition for web by @ouvreboite
   in [#304](https://github.com/maplibre/flutter-maplibre-gl/pull/304)
 
-**Full Changelog
-**: https://github.com/maplibre/flutter-maplibre-gl/compare/0.16.0...0.17.0
+**Full Changelog**: 
+https://github.com/maplibre/flutter-maplibre-gl/compare/0.16.0...0.17.0
 
 ## 0.16.0, Jun 28, 2022
 


### PR DESCRIPTION
Fixes in this pull request:
- the publish-single.yml workflow made no usage of the working-directory before
- use setup-dart because setup-flutter doesn't support automatic publishing 😥
- Use --skip-validation so that the missing flutter sdk causes no problem
- Remove `pub get` since without a validation we don't need to fetch dependencies
- and last but not least the trickiest one: Remove the packages from the .pubignore file because pub isn't able to see its contents otherwise
  - error message with the previous .pubignore: https://github.com/josxha/flutter-maplibre-gl/actions/runs/9181958689/job/25249862399
  - output after the packages are no longer ignored: https://github.com/josxha/flutter-maplibre-gl/actions/runs/9181975713/job/25249917620