### PR TITLE
chore: use java 17 in flutter beta ci

### DIFF
--- a/.github/workflows/flutter_beta.yml
+++ b/.github/workflows/flutter_beta.yml
@@ -1,8 +1,8 @@
 name: Flutter Beta CI
 
 on:
-  schedule:
-    - cron:  '0 0 * * *'
+  schedule: [ cron:  '0 0 * * *' ]
+  workflow_dispatch:
 
 env:
   FLUTTER_CHANNEL: 'beta'
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'gradle'
     - uses: subosito/flutter-action@v2


### PR DESCRIPTION
Since the example app uses gradle 8, the flutter beta ci fails because it still ises java 11. This pr bumps the version of java used to 17. 

Additionally it makes it possible to dispatch the workflow manually.