### PR TITLE
feat!: rename `Maplibre` to `MapLibre`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,21 @@
 
 ### Breaking changes
 
-* All Dart enums have been migrated from mixed cases to lower camelcase 
+* All Dart enums have been migrated from mixed cases to lower camelcase
   according to the `camel_case_types` lint rule.
 * Move `MapLibreStyles` to the main `maplibre_gl` package. You can now use the  
   demo style without adding `maplibre_gl_platform_interface` as a dependency.
 * Updated maplibre-native for ios to v6.4.2. This introduces the new
-  iOS Metal renderer and the OpenGL ES renderer now uses OpenGL ES 3.0. Only 
+  iOS Metal renderer and the OpenGL ES renderer now uses OpenGL ES 3.0. Only
   iOS Devices with an Apple A7 GPU or later are supported onwards. See the
   [maplibre-native changelog](https://github.com/maplibre/maplibre-native/blob/main/platform/ios/CHANGELOG.md#600)
   for more information.
-* Updated maplibre-native for android to v11.0.0. This version uses 
-  OpenGL ES 3.0.
+* Updated maplibre-native for android to v11.0.0. This version uses
+  OpenGL ES 3.0. See the
+  [maplibre-native changelog](https://github.com/maplibre/maplibre-native/blob/main/platform/android/CHANGELOG.md#1100)
+  for more information.
 * Renamed the method channel to `plugins.flutter.io/maplibre_gl_*` in all packages.
+* Renamed `Maplibre` to `MapLibre` to be in line with maplibre-native.
 
 ## 0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * All Dart enums have been migrated from mixed cases to lower camelcase 
   according to the `camel_case_types` lint rule.
-* Move `MaplibreStyles` to the main `maplibre_gl` package. You can now use the  
+* Move `MapLibreStyles` to the main `maplibre_gl` package. You can now use the  
   demo style without adding `maplibre_gl_platform_interface` as a dependency.
 * Updated maplibre-native for ios to v6.4.2. This introduces the new
   iOS Metal renderer and the OpenGL ES renderer now uses OpenGL ES 3.0. Only 
@@ -110,7 +110,7 @@ builds).
 ```dart
 @override
 Widget build() {
-  return MaplibreMap(
+  return MapLibreMap(
     myLocationRenderMode: MyLocationRenderMode.COMPASS,
     // ...
   );
@@ -158,7 +158,7 @@ at the end for a full changelog.
   in [#179](https://github.com/maplibre/flutter-maplibre-gl/pull/179)
 * Reenable textureMode which was disabled in f8b2d1 by @maxammann
   in [#194](https://github.com/maplibre/flutter-maplibre-gl/pull/194)
-* android: Bump Maplibre SDK to 9.6.0 & OkHttp to 4.9.3 by @mariusvn
+* android: Bump MapLibre SDK to 9.6.0 & OkHttp to 4.9.3 by @mariusvn
   in [#184](https://github.com/maplibre/flutter-maplibre-gl/pull/184)
 * Added getSourceIds to the controller by @mariusvn
   in [#197](https://github.com/maplibre/flutter-maplibre-gl/pull/197)
@@ -166,7 +166,7 @@ at the end for a full changelog.
   in [#205](https://github.com/maplibre/flutter-maplibre-gl/pull/205)
 * Fix crash android dispose nullpointerdereference by @GaelleJoubert
   in [#203](https://github.com/maplibre/flutter-maplibre-gl/pull/203)
-* Migrate links in README, pubspec to Maplibre by @kuhnroyal
+* Migrate links in README, pubspec to MapLibre by @kuhnroyal
   in [#224](https://github.com/maplibre/flutter-maplibre-gl/pull/224)
 * Update LICENSE file by @mariusvn
   in [#230](https://github.com/maplibre/flutter-maplibre-gl/pull/230)
@@ -209,7 +209,7 @@ https://github.com/maplibre/flutter-maplibre-gl/compare/0.16.0...0.17.0
 * cherry-picked all commits from upstream up
   to [https://github.com/flutter-mapbox-gl/maps/commit/3496907955cd4b442e4eb905d67e8d46692174f1),
   including up to release 0.16.0 from upstream
-* updated Maplibre GL JS for web
+* updated MapLibre GL JS for web
 
 ## 0.15.1, May 24, 2022
 
@@ -267,11 +267,11 @@ https://github.com/maplibre/flutter-maplibre-gl/compare/0.16.0...0.17.0
 ## 0.13.0, Oct 6, 2021
 
 🎉 The first release of flutter-maplibre-gl with the complete transition to
-Maplibre libraries. 🎉
+MapLibre libraries. 🎉
 
 Further improvements:
 
-* Update to Maplibre-Android-SDK 9.4.2
+* Update to MapLibre-Android-SDK 9.4.2
 * Update to MapLibre-iOS-SDK 5.12.0
 * Fix onUserLocationUpdated not firing on
   android [#14](https://github.com/m0nac0/flutter-maplibre-gl/pull/14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
   OpenGL ES 3.0. See the
   [maplibre-native changelog](https://github.com/maplibre/maplibre-native/blob/main/platform/android/CHANGELOG.md#1100)
   for more information.
-* Renamed the method channel to `plugins.flutter.io/maplibre_gl_*` in all packages.
-* Renamed `Maplibre` to `MapLibre` to be in line with maplibre-native.
+* Renamed the method channel to `plugins.flutter.io/maplibre_gl_*` in all
+  packages.
+* Renamed `Maplibre` to `MapLibre` to be in line with maplibre-native 
+  (affects for example the classes MaplibreMap and MaplibreMapController).
 
 ## 0.19.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flutter Maplibre GL
+# Flutter MapLibre GL
 
 [![Pub Version](https://img.shields.io/pub/v/maplibre_gl)](https://pub.dev/packages/maplibre_gl)
 [![likes](https://img.shields.io/pub/likes/maplibre_gl?logo=flutter)](https://pub.dev/packages/maplibre_gl)
@@ -126,7 +126,7 @@ your `web/index.html` file:
 
 ## Map Styles
 
-Map styles can be supplied by setting the `styleString` in the `MaplibreMap`
+Map styles can be supplied by setting the `styleString` in the `MapLibreMap`
 constructor. The following formats are supported:
 
 1. Passing the URL of the map style. This should be a custom map style served

--- a/example/lib/animate_camera.dart
+++ b/example/lib/animate_camera.dart
@@ -25,9 +25,9 @@ class AnimateCamera extends StatefulWidget {
 }
 
 class AnimateCameraState extends State<AnimateCamera> {
-  late MaplibreMapController mapController;
+  late MapLibreMapController mapController;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     mapController = controller;
   }
 
@@ -41,7 +41,7 @@ class AnimateCameraState extends State<AnimateCamera> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition:
                   const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/annotation_order_maps.dart
+++ b/example/lib/annotation_order_maps.dart
@@ -21,8 +21,8 @@ class AnnotationOrderBody extends StatefulWidget {
 }
 
 class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
-  late MaplibreMapController controllerOne;
-  late MaplibreMapController controllerTwo;
+  late MapLibreMapController controllerOne;
+  late MapLibreMapController controllerTwo;
 
   final LatLng center = const LatLng(36.580664, 32.5563837);
 
@@ -44,7 +44,7 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
                   child: SizedBox(
                     width: 250.0,
                     height: 250.0,
-                    child: MaplibreMap(
+                    child: MapLibreMap(
                       onMapCreated: onMapCreatedOne,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerOne),
                       initialCameraPosition: CameraPosition(
@@ -78,7 +78,7 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
                   child: SizedBox(
                     width: 250.0,
                     height: 250.0,
-                    child: MaplibreMap(
+                    child: MapLibreMap(
                       onMapCreated: onMapCreatedTwo,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerTwo),
                       initialCameraPosition: CameraPosition(
@@ -102,15 +102,15 @@ class _AnnotationOrderBodyState extends State<AnnotationOrderBody> {
     );
   }
 
-  void onMapCreatedOne(MaplibreMapController controller) {
+  void onMapCreatedOne(MapLibreMapController controller) {
     controllerOne = controller;
   }
 
-  void onMapCreatedTwo(MaplibreMapController controller) {
+  void onMapCreatedTwo(MapLibreMapController controller) {
     controllerTwo = controller;
   }
 
-  void onStyleLoaded(MaplibreMapController controller) async {
+  void onStyleLoaded(MapLibreMapController controller) async {
     await addImageFromAsset(
         controller, "custom-marker", "assets/symbols/custom-marker.png");
     controller.addSymbol(

--- a/example/lib/attribution.dart
+++ b/example/lib/attribution.dart
@@ -73,12 +73,12 @@ class _AttributionBodyState extends State<AttributionBody> {
     );
   }
 
-  MaplibreMap buildMap(
+  MapLibreMap buildMap(
     AttributionButtonPosition? attributionButtonPosition,
     bool useDefaultAttributionPosition,
   ) {
     if (useDefaultAttributionPosition) {
-      return MaplibreMap(
+      return MapLibreMap(
         key: UniqueKey(),
         initialCameraPosition: const CameraPosition(
           target: LatLng(-33.852, 151.211),
@@ -87,7 +87,7 @@ class _AttributionBodyState extends State<AttributionBody> {
         styleString: "assets/osm_style.json",
       );
     } else {
-      return MaplibreMap(
+      return MapLibreMap(
         key: UniqueKey(),
         initialCameraPosition: const CameraPosition(
           target: LatLng(-33.852, 151.211),

--- a/example/lib/click_annotations.dart
+++ b/example/lib/click_annotations.dart
@@ -30,9 +30,9 @@ class ClickAnnotationBodyState extends State<ClickAnnotationBody> {
 
   static const LatLng center = LatLng(-33.88, 151.16);
 
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
     controller.onFillTapped.add(_onFillTapped);
     controller.onCircleTapped.add(_onCircleTapped);
@@ -139,7 +139,7 @@ class ClickAnnotationBodyState extends State<ClickAnnotationBody> {
 
   @override
   Widget build(BuildContext context) {
-    return MaplibreMap(
+    return MapLibreMap(
       annotationOrder: const [
         AnnotationType.fill,
         AnnotationType.line,

--- a/example/lib/custom_marker.dart
+++ b/example/lib/custom_marker.dart
@@ -30,7 +30,7 @@ class CustomMarker extends StatefulWidget {
 class CustomMarkerState extends State<CustomMarker> {
   final _rnd = Random();
 
-  late MaplibreMapController _mapController;
+  late MapLibreMapController _mapController;
   final _markers = <Marker>[];
   final _markerStates = <MarkerState>[];
 
@@ -38,7 +38,7 @@ class CustomMarkerState extends State<CustomMarker> {
     _markerStates.add(markerState);
   }
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     _mapController = controller;
     controller.addListener(() {
       if (controller.isCameraMoving) {
@@ -90,7 +90,7 @@ class CustomMarkerState extends State<CustomMarker> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Stack(children: [
-        MaplibreMap(
+        MapLibreMap(
           trackCameraPosition: true,
           onMapCreated: _onMapCreated,
           onMapLongClick: _onMapLongClickCallback,

--- a/example/lib/full_map.dart
+++ b/example/lib/full_map.dart
@@ -21,10 +21,10 @@ class FullMap extends StatefulWidget {
 }
 
 class FullMapState extends State<FullMap> {
-  MaplibreMapController? mapController;
+  MapLibreMapController? mapController;
   var isLight = true;
 
-  _onMapCreated(MaplibreMapController controller) {
+  _onMapCreated(MapLibreMapController controller) {
     mapController = controller;
   }
 
@@ -52,7 +52,7 @@ class FullMapState extends State<FullMap> {
         // ),
         // ),
         // ),
-        body: MaplibreMap(
+        body: MapLibreMap(
       onMapCreated: _onMapCreated,
       initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),
       onStyleLoadedCallback: _onStyleLoadedCallback,

--- a/example/lib/get_map_informations.dart
+++ b/example/lib/get_map_informations.dart
@@ -21,10 +21,10 @@ class GetMapInfoBody extends StatefulWidget {
 }
 
 class _GetMapInfoBodyState extends State<GetMapInfoBody> {
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
   String data = '';
 
-  void onMapCreated(MaplibreMapController controller) {
+  void onMapCreated(MapLibreMapController controller) {
     setState(() {
       this.controller = controller;
     });
@@ -60,7 +60,7 @@ class _GetMapInfoBodyState extends State<GetMapInfoBody> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),
                 zoom: 11.0,

--- a/example/lib/given_bounds.dart
+++ b/example/lib/given_bounds.dart
@@ -25,9 +25,9 @@ class GivenBounds extends StatefulWidget {
 }
 
 class GivenBoundsState extends State<GivenBounds> {
-  late MaplibreMapController mapController;
+  late MapLibreMapController mapController;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     mapController = controller;
   }
 
@@ -41,7 +41,7 @@ class GivenBoundsState extends State<GivenBounds> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition:
                   const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/layer.dart
+++ b/example/lib/layer.dart
@@ -24,7 +24,7 @@ class LayerBody extends StatefulWidget {
 class LayerState extends State {
   static const LatLng center = LatLng(-33.86711, 151.1947171);
 
-  late MaplibreMapController controller;
+  late MapLibreMapController controller;
   Timer? bikeTimer;
   Timer? filterTimer;
   int filteredId = 0;
@@ -43,7 +43,7 @@ class LayerState extends State {
       Center(
         child: SizedBox(
             height: 400.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               dragEnabled: false,
               myLocationEnabled: true,
               onMapCreated: _onMapCreated,
@@ -139,7 +139,7 @@ class LayerState extends State {
     ]);
   }
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
 
     controller.onFeatureTapped.add(onFeatureTap);

--- a/example/lib/line.dart
+++ b/example/lib/line.dart
@@ -31,12 +31,12 @@ class LineBodyState extends State<LineBody> {
 
   static const LatLng center = LatLng(-33.86711, 151.1947171);
 
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
   int _lineCount = 0;
   Line? _selectedLine;
   final String _linePatternImage = "assets/fill/cat_silhouette_pattern.png";
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
     controller.onLineTapped.add(_onLineTapped);
   }
@@ -154,7 +154,7 @@ class LineBodyState extends State<LineBody> {
         Center(
           child: SizedBox(
             height: 400.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: _onStyleLoadedCallback,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/local_style.dart
+++ b/example/lib/local_style.dart
@@ -24,7 +24,7 @@ class LocalStyle extends StatefulWidget {
 }
 
 class LocalStyleState extends State<LocalStyle> {
-  MaplibreMapController? mapController;
+  MapLibreMapController? mapController;
   String? styleAbsoluteFilePath;
 
   @override
@@ -49,7 +49,7 @@ class LocalStyleState extends State<LocalStyle> {
     });
   }
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     mapController = controller;
   }
 
@@ -64,7 +64,7 @@ class LocalStyleState extends State<LocalStyle> {
     }
 
     return Scaffold(
-        body: MaplibreMap(
+        body: MapLibreMap(
       styleString: styleAbsoluteFilePath,
       onMapCreated: _onMapCreated,
       initialCameraPosition: const CameraPosition(target: LatLng(0.0, 0.0)),

--- a/example/lib/localized_map.dart
+++ b/example/lib/localized_map.dart
@@ -23,7 +23,7 @@ class LocalizedMap extends StatefulWidget {
 }
 
 class LocalizedMapState extends State<LocalizedMap> {
-  final _mapReadyCompleter = Completer<MaplibreMapController>();
+  final _mapReadyCompleter = Completer<MapLibreMapController>();
 
   var _mapLanguage = "en";
 
@@ -51,7 +51,7 @@ class LocalizedMapState extends State<LocalizedMap> {
             }).toList(),
           ),
           Expanded(
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition:
                   const CameraPosition(target: LatLng(0.0, 0.0)),
@@ -63,7 +63,7 @@ class LocalizedMapState extends State<LocalizedMap> {
     );
   }
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     _mapReadyCompleter.complete(controller);
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,9 +78,9 @@ class _MapsDemoState extends State<MapsDemo> {
       final androidInfo = await DeviceInfoPlugin().androidInfo;
       final sdkVersion = androidInfo.version.sdkInt;
       if (sdkVersion >= 29) {
-        MaplibreMap.useHybridComposition = true;
+        MapLibreMap.useHybridComposition = true;
       } else {
-        MaplibreMap.useHybridComposition = false;
+        MapLibreMap.useHybridComposition = false;
       }
     }
   }
@@ -106,7 +106,7 @@ class _MapsDemoState extends State<MapsDemo> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Maplibre examples')),
+      appBar: AppBar(title: const Text('MapLibre examples')),
       body: ListView.builder(
         itemCount: _allPages.length + 1,
         itemBuilder: (_, int index) => index == _allPages.length

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -39,7 +39,7 @@ class MapUiBodyState extends State<MapUiBody> {
     zoom: 11.0,
   );
 
-  MaplibreMapController? mapController;
+  MapLibreMapController? mapController;
   CameraPosition _position = _kInitialPosition;
   bool _isMoving = false;
   bool _compassEnabled = true;
@@ -50,9 +50,9 @@ class MapUiBodyState extends State<MapUiBody> {
 
   // Style string can a reference to a local or remote resources.
   // On Android the raw JSON can also be passed via a styleString, on iOS this is not supported.
-  final List<String> _styleStrings = [MaplibreStyles.demo, "assets/style.json"];
+  final List<String> _styleStrings = [MapLibreStyles.demo, "assets/style.json"];
   final List<String> _styleStringLabels = [
-    "Maplibre demo style",
+    "MapLibre demo style",
     "Local style file"
   ];
   bool _rotateGesturesEnabled = true;
@@ -343,7 +343,7 @@ class MapUiBodyState extends State<MapUiBody> {
 
   @override
   Widget build(BuildContext context) {
-    final MaplibreMap maplibreMap = MaplibreMap(
+    final MapLibreMap maplibreMap = MapLibreMap(
       onMapCreated: onMapCreated,
       initialCameraPosition: _kInitialPosition,
       trackCameraPosition: true,
@@ -458,7 +458,7 @@ class MapUiBodyState extends State<MapUiBody> {
     );
   }
 
-  void onMapCreated(MaplibreMapController controller) {
+  void onMapCreated(MapLibreMapController controller) {
     mapController = controller;
     mapController!.addListener(_onMapChanged);
     _extractMapInfo();

--- a/example/lib/move_camera.dart
+++ b/example/lib/move_camera.dart
@@ -25,9 +25,9 @@ class MoveCamera extends StatefulWidget {
 }
 
 class MoveCameraState extends State<MoveCamera> {
-  late MaplibreMapController mapController;
+  late MapLibreMapController mapController;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     mapController = controller;
   }
 
@@ -41,7 +41,7 @@ class MoveCameraState extends State<MoveCamera> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               onCameraIdle: () => debugPrint("onCameraIdle"),
               initialCameraPosition:

--- a/example/lib/no_location_permission_page.dart
+++ b/example/lib/no_location_permission_page.dart
@@ -28,7 +28,7 @@ class NoLocationPermissionBody extends StatefulWidget {
 class _NoLocationPermissionBodyState extends State<NoLocationPermissionBody> {
   @override
   Widget build(BuildContext context) {
-    return MaplibreMap(
+    return MapLibreMap(
       initialCameraPosition: const CameraPosition(
         target: LatLng(-33.852, 151.211),
         zoom: 11.0,

--- a/example/lib/offline_region_map.dart
+++ b/example/lib/offline_region_map.dart
@@ -19,7 +19,7 @@ class _OfflineRegionMapState extends State<OfflineRegionMap> {
       appBar: AppBar(
         title: Text('Offline Region: ${widget.item.name}'),
       ),
-      body: MaplibreMap(
+      body: MapLibreMap(
         initialCameraPosition: CameraPosition(
           target: _center,
           zoom: widget.item.offlineRegionDefinition.minZoom,

--- a/example/lib/offline_regions.dart
+++ b/example/lib/offline_regions.dart
@@ -25,19 +25,19 @@ final List<OfflineRegionDefinition> regionDefinitions = [
     bounds: hawaiiBounds,
     minZoom: 3.0,
     maxZoom: 8.0,
-    mapStyleUrl: MaplibreStyles.demo,
+    mapStyleUrl: MapLibreStyles.demo,
   ),
   OfflineRegionDefinition(
     bounds: santiagoBounds,
     minZoom: 10.0,
     maxZoom: 16.0,
-    mapStyleUrl: MaplibreStyles.demo,
+    mapStyleUrl: MapLibreStyles.demo,
   ),
   OfflineRegionDefinition(
     bounds: aucklandBounds,
     minZoom: 13.0,
     maxZoom: 16.0,
-    mapStyleUrl: MaplibreStyles.demo,
+    mapStyleUrl: MapLibreStyles.demo,
   ),
 ];
 

--- a/example/lib/place_batch.dart
+++ b/example/lib/place_batch.dart
@@ -71,9 +71,9 @@ class BatchAddBodyState extends State<BatchAddBody> {
 
   static const LatLng center = LatLng(-33.86711, 151.1947171);
 
-  late MaplibreMapController controller;
+  late MapLibreMapController controller;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
   }
 
@@ -148,7 +148,7 @@ class BatchAddBodyState extends State<BatchAddBody> {
         Center(
           child: SizedBox(
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: () => addImageFromAsset(controller,
                   "custom-marker", "assets/symbols/custom-marker.png"),

--- a/example/lib/place_circle.dart
+++ b/example/lib/place_circle.dart
@@ -32,11 +32,11 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
 
   static const LatLng center = LatLng(-33.86711, 151.1947171);
 
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
   int _circleCount = 0;
   Circle? _selectedCircle;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
     controller.onCircleTapped.add(_onCircleTapped);
   }
@@ -196,7 +196,7 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),

--- a/example/lib/place_fill.dart
+++ b/example/lib/place_fill.dart
@@ -49,11 +49,11 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
     ]
   ];
 
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
   int _fillCount = 0;
   Fill? _selectedFill;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
     controller.onFillTapped.add(_onFillTapped);
     this.controller!.onFeatureDrag.add(_onFeatureDrag);
@@ -194,7 +194,7 @@ class PlaceFillBodyState extends State<PlaceFillBody> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: _onStyleLoaded,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/place_source.dart
+++ b/example/lib/place_source.dart
@@ -36,9 +36,9 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   bool sourceAdded = false;
   bool layerAdded = false;
   bool imageFlag = false;
-  late MaplibreMapController controller;
+  late MapLibreMapController controller;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
   }
 
@@ -112,7 +112,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               initialCameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),

--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -35,12 +35,12 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
 
   static const LatLng center = LatLng(-33.86711, 151.1947171);
 
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
   int _symbolCount = 0;
   Symbol? _selectedSymbol;
   bool _iconAllowOverlap = false;
 
-  void _onMapCreated(MaplibreMapController controller) {
+  void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
     controller.onSymbolTapped.add(_onSymbolTapped);
   }
@@ -274,7 +274,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
           child: SizedBox(
             width: 300.0,
             height: 200.0,
-            child: MaplibreMap(
+            child: MapLibreMap(
               onMapCreated: _onMapCreated,
               onStyleLoadedCallback: _onStyleLoaded,
               initialCameraPosition: const CameraPosition(

--- a/example/lib/scrolling_map.dart
+++ b/example/lib/scrolling_map.dart
@@ -29,8 +29,8 @@ class ScrollingMapBody extends StatefulWidget {
 }
 
 class _ScrollingMapBodyState extends State<ScrollingMapBody> {
-  late MaplibreMapController controllerOne;
-  late MaplibreMapController controllerTwo;
+  late MapLibreMapController controllerOne;
+  late MapLibreMapController controllerTwo;
 
   final LatLng center = const LatLng(32.080664, 34.9563837);
 
@@ -51,7 +51,7 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
                   child: SizedBox(
                     width: 300.0,
                     height: 300.0,
-                    child: MaplibreMap(
+                    child: MapLibreMap(
                       onMapCreated: onMapCreatedOne,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerOne),
                       initialCameraPosition: CameraPosition(
@@ -86,7 +86,7 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
                   child: SizedBox(
                     width: 300.0,
                     height: 300.0,
-                    child: MaplibreMap(
+                    child: MapLibreMap(
                       onMapCreated: onMapCreatedTwo,
                       onStyleLoadedCallback: () => onStyleLoaded(controllerTwo),
                       initialCameraPosition: CameraPosition(
@@ -110,15 +110,15 @@ class _ScrollingMapBodyState extends State<ScrollingMapBody> {
     );
   }
 
-  void onMapCreatedOne(MaplibreMapController controller) {
+  void onMapCreatedOne(MapLibreMapController controller) {
     controllerOne = controller;
   }
 
-  void onMapCreatedTwo(MaplibreMapController controller) {
+  void onMapCreatedTwo(MapLibreMapController controller) {
     controllerTwo = controller;
   }
 
-  void onStyleLoaded(MaplibreMapController controller) async {
+  void onStyleLoaded(MapLibreMapController controller) async {
     await addImageFromAsset(
         controller, "custom-marker", "assets/symbols/custom-marker.png");
     controller.addSymbol(SymbolOptions(

--- a/example/lib/sources.dart
+++ b/example/lib/sources.dart
@@ -7,7 +7,7 @@ import 'page.dart';
 class StyleInfo {
   final String name;
   final String baseStyle;
-  final Future<void> Function(MaplibreMapController) addDetails;
+  final Future<void> Function(MapLibreMapController) addDetails;
   final CameraPosition position;
 
   const StyleInfo(
@@ -34,15 +34,15 @@ class FullMap extends StatefulWidget {
 }
 
 class FullMapState extends State<FullMap> {
-  MaplibreMapController? controller;
+  MapLibreMapController? controller;
   final watercolorRasterId = "watercolorRaster";
   int selectedStyleId = 0;
 
-  _onMapCreated(MaplibreMapController controller) {
+  _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
   }
 
-  static Future<void> addRaster(MaplibreMapController controller) async {
+  static Future<void> addRaster(MapLibreMapController controller) async {
     await controller.addSource(
       "watercolor",
       const RasterSourceProperties(
@@ -58,7 +58,7 @@ class FullMapState extends State<FullMap> {
   }
 
   static Future<void> addGeojsonCluster(
-      MaplibreMapController controller) async {
+      MapLibreMapController controller) async {
     await controller.addSource(
         "earthquakes",
         const GeojsonSourceProperties(
@@ -99,11 +99,11 @@ class FullMapState extends State<FullMap> {
         ));
   }
 
-  static Future<void> addVector(MaplibreMapController controller) async {
+  static Future<void> addVector(MapLibreMapController controller) async {
     await controller.addSource(
         "terrain",
         const VectorSourceProperties(
-          url: MaplibreStyles.demo,
+          url: MapLibreStyles.demo,
         ));
 
     await controller.addLayer(
@@ -118,7 +118,7 @@ class FullMapState extends State<FullMap> {
         sourceLayer: "countries");
   }
 
-  static Future<void> addImage(MaplibreMapController controller) async {
+  static Future<void> addImage(MapLibreMapController controller) async {
     await controller.addSource(
         "radar",
         const ImageSourceProperties(
@@ -137,7 +137,7 @@ class FullMapState extends State<FullMap> {
     );
   }
 
-  static Future<void> addVideo(MaplibreMapController controller) async {
+  static Future<void> addVideo(MapLibreMapController controller) async {
     await controller.addSource(
         "video",
         const VideoSourceProperties(urls: [
@@ -157,7 +157,7 @@ class FullMapState extends State<FullMap> {
     );
   }
 
-  static Future<void> addHeatMap(MaplibreMapController controller) async {
+  static Future<void> addHeatMap(MapLibreMapController controller) async {
     await controller.addSource(
         'earthquakes-heatmap-source',
         const GeojsonSourceProperties(
@@ -234,7 +234,7 @@ class FullMapState extends State<FullMap> {
     );
   }
 
-  static Future<void> addDem(MaplibreMapController controller) async {
+  static Future<void> addDem(MapLibreMapController controller) async {
     // TODO: adapt example?
     // await controller.addSource(
     //     "dem",
@@ -253,13 +253,13 @@ class FullMapState extends State<FullMap> {
   final _stylesAndLoaders = [
     const StyleInfo(
       name: "Vector",
-      baseStyle: MaplibreStyles.demo,
+      baseStyle: MapLibreStyles.demo,
       addDetails: addVector,
       position: CameraPosition(target: LatLng(33.3832, -118.4333), zoom: 6),
     ),
     const StyleInfo(
       name: "Default style",
-      // Using the raw github file version of MaplibreStyles.DEMO here, because we need to
+      // Using the raw github file version of MapLibreStyles.DEMO here, because we need to
       // specify a different baseStyle for consecutive elements in this list,
       // otherwise the map will not update
       baseStyle:
@@ -269,7 +269,7 @@ class FullMapState extends State<FullMap> {
     ),
     const StyleInfo(
       name: "Geojson cluster",
-      baseStyle: MaplibreStyles.demo,
+      baseStyle: MapLibreStyles.demo,
       addDetails: addGeojsonCluster,
       position: CameraPosition(target: LatLng(33.5, -118.1), zoom: 5),
     ),
@@ -334,7 +334,7 @@ class FullMapState extends State<FullMap> {
         ),
         body: Stack(
           children: [
-            MaplibreMap(
+            MapLibreMap(
               styleString: styleInfo.baseStyle,
               onMapCreated: _onMapCreated,
               initialCameraPosition: styleInfo.position,

--- a/example/lib/util.dart
+++ b/example/lib/util.dart
@@ -3,7 +3,7 @@ import 'package:maplibre_gl/maplibre_gl.dart';
 
 /// Adds an asset image to the currently displayed style
 Future<void> addImageFromAsset(
-    MaplibreMapController controller, String name, String assetName) async {
+    MapLibreMapController controller, String name, String assetName) async {
   final ByteData bytes = await rootBundle.load(assetName);
   final Uint8List list = bytes.buffer.asUint8List();
   return controller.addImage(name, list);

--- a/lib/maplibre_gl.dart
+++ b/lib/maplibre_gl.dart
@@ -79,7 +79,7 @@ export 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
         VideoSourceProperties,
         ImageSourceProperties,
         MapLibreGlPlatform,
-        MethodChannelMapLibreGl,
+        MapLibreMethodChannel,
         OnPlatformViewCreatedCallback;
 
 part 'src/controller.dart';

--- a/lib/maplibre_gl.dart
+++ b/lib/maplibre_gl.dart
@@ -2,24 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// This library contains the Maplibre GL plugin for Flutter.
+/// This library contains the MapLibre GL plugin for Flutter.
 ///
-/// To display a map, add a [MaplibreMap] widget to the widget tree.
+/// To display a map, add a [MapLibreMap] widget to the widget tree.
 ///
-/// In this plugin, the map is configured through the parameters passed to the [MaplibreMap] constructor and through the [MaplibreMapController].
-/// The [MaplibreMapController] is provided at runtime by the [MaplibreMap.onMapCreated] callback.
+/// In this plugin, the map is configured through the parameters passed to the [MapLibreMap] constructor and through the [MapLibreMapController].
+/// The [MapLibreMapController] is provided at runtime by the [MapLibreMap.onMapCreated] callback.
 /// The controller also allows adding annotations (icons, lines etc.) to the map at runtime and provides some callbacks to get notified when the user clicks those.
 ///
 /// The visual appearance of the map is configured through a MapLibre style passed to the
-/// [styleString] parameter of the [MaplibreMap] constructor.
-/// The Maplibre style is a JSON document following the specification at https://maplibre.org/maplibre-style-spec/.
-/// The following is supposed to serve as a short introduction to the Maplibre style specification:
+/// [styleString] parameter of the [MapLibreMap] constructor.
+/// The MapLibre style is a JSON document following the specification at https://maplibre.org/maplibre-style-spec/.
+/// The following is supposed to serve as a short introduction to the MapLibre style specification:
 /// The style document contains (among other things) sources and layers.
 /// Sources determine which data is displayed on the map, layers determine how the data is displayed.
 ///
 /// Typical types of sources are raster and vector tiles, as well as GeoJson data.
 /// For raster and vector tiles, the entire world is divided into a set of tiles in different zoom levels.
-/// Depending on the map's zoom level and viewport, the Maplibre client libraries decide, which tiles are needed to fill the viewport and request them from the source.
+/// Depending on the map's zoom level and viewport, the MapLibre client libraries decide, which tiles are needed to fill the viewport and request them from the source.
 ///
 /// The difference between raster and vector tiles is that raster tiles are images that are pre-rendered on a server, whereas vector tiles contain raw geometric information that is rendered on the client.
 /// Vector tiles are in the Mapbox Vector Tile (MVT) format, the de-facto standard for vector tiles that is implemented by multiple libraries.
@@ -29,8 +29,8 @@
 /// and the possibility to rotate them and keep text labels horizontal.
 /// Raster and vector tiles can be generated from a variety of sources, including OpenStreetMap data and are also available from a number of providers.
 ///
-/// Raster sources are displayed by adding a "raster" layer to the Maplibre GL style.
-/// Vector and GeoJson sources are displayed by adding a "line", "fill", "symbol" or "circle" layer to the Maplibre GL style and specifying
+/// Raster sources are displayed by adding a "raster" layer to the MapLibre GL style.
+/// Vector and GeoJson sources are displayed by adding a "line", "fill", "symbol" or "circle" layer to the MapLibre GL style and specifying
 /// which source to use (by setting the "source" property of the layer to the id of the source) as well as how to style the data by setting other properties of the layer such as "line-color" or "fill-outline-color".
 /// For example, a vector source layer (or a GeoJson source layer) with the outlines of countries could be displayed both by a fill layer to fill the countries with a color and by a line layer to draw the outlines of the countries.
 library maplibre_gl;
@@ -79,7 +79,7 @@ export 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
         VideoSourceProperties,
         ImageSourceProperties,
         MapLibreGlPlatform,
-        MethodChannelMaplibreGl,
+        MethodChannelMapLibreGl,
         OnPlatformViewCreatedCallback;
 
 part 'src/controller.dart';

--- a/lib/maplibre_gl.dart
+++ b/lib/maplibre_gl.dart
@@ -78,7 +78,7 @@ export 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.da
         GeojsonSourceProperties,
         VideoSourceProperties,
         ImageSourceProperties,
-        MapLibreGlPlatform,
+        MapLibrePlatform,
         MapLibreMethodChannel,
         OnPlatformViewCreatedCallback;
 

--- a/lib/src/annotation_manager.dart
+++ b/lib/src/annotation_manager.dart
@@ -1,7 +1,7 @@
 part of '../maplibre_gl.dart';
 
 abstract class AnnotationManager<T extends Annotation> {
-  final MaplibreMapController controller;
+  final MapLibreMapController controller;
   final _idToAnnotation = <String, T>{};
   final _idToLayerIndex = <String, int>{};
 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -74,7 +74,7 @@ typedef MaplibreMapController = MapLibreMapController;
 /// Listeners are notified after changes have been applied on the platform side.
 class MapLibreMapController extends ChangeNotifier {
   MapLibreMapController({
-    required MapLibreGlPlatform maplibreGlPlatform,
+    required MapLibrePlatform maplibrePlatform,
     required CameraPosition initialCameraPosition,
     required Iterable<AnnotationType> annotationOrder,
     required Iterable<AnnotationType> annotationConsumeTapEvents,
@@ -87,17 +87,17 @@ class MapLibreMapController extends ChangeNotifier {
     this.onMapIdle,
     this.onUserLocationUpdated,
     this.onCameraIdle,
-  }) : _maplibreGlPlatform = maplibreGlPlatform {
+  }) : _maplibrePlatform = maplibrePlatform {
     _cameraPosition = initialCameraPosition;
 
-    _maplibreGlPlatform.onFeatureTappedPlatform.add((payload) {
+    _maplibrePlatform.onFeatureTappedPlatform.add((payload) {
       for (final fun
           in List<OnFeatureInteractionCallback>.from(onFeatureTapped)) {
         fun(payload["id"], payload["point"], payload["latLng"]);
       }
     });
 
-    _maplibreGlPlatform.onFeatureDraggedPlatform.add((payload) {
+    _maplibrePlatform.onFeatureDraggedPlatform.add((payload) {
       for (final fun in List<OnFeatureDragnCallback>.from(onFeatureDrag)) {
         final DragEventType enmDragEventType = DragEventType.values
             .firstWhere((element) => element.name == payload["eventType"]);
@@ -110,17 +110,17 @@ class MapLibreMapController extends ChangeNotifier {
       }
     });
 
-    _maplibreGlPlatform.onCameraMoveStartedPlatform.add((_) {
+    _maplibrePlatform.onCameraMoveStartedPlatform.add((_) {
       _isCameraMoving = true;
       notifyListeners();
     });
 
-    _maplibreGlPlatform.onCameraMovePlatform.add((cameraPosition) {
+    _maplibrePlatform.onCameraMovePlatform.add((cameraPosition) {
       _cameraPosition = cameraPosition;
       notifyListeners();
     });
 
-    _maplibreGlPlatform.onCameraIdlePlatform.add((cameraPosition) {
+    _maplibrePlatform.onCameraIdlePlatform.add((cameraPosition) {
       _isCameraMoving = false;
       if (cameraPosition != null) {
         _cameraPosition = cameraPosition;
@@ -131,7 +131,7 @@ class MapLibreMapController extends ChangeNotifier {
       notifyListeners();
     });
 
-    _maplibreGlPlatform.onMapStyleLoadedPlatform.add((_) {
+    _maplibrePlatform.onMapStyleLoadedPlatform.add((_) {
       final interactionEnabled = annotationConsumeTapEvents.toSet();
       for (var type in annotationOrder.toSet()) {
         final enableInteraction = interactionEnabled.contains(type);
@@ -162,36 +162,36 @@ class MapLibreMapController extends ChangeNotifier {
       }
     });
 
-    _maplibreGlPlatform.onMapClickPlatform.add((dict) {
+    _maplibrePlatform.onMapClickPlatform.add((dict) {
       if (onMapClick != null) {
         onMapClick!(dict['point'], dict['latLng']);
       }
     });
 
-    _maplibreGlPlatform.onMapLongClickPlatform.add((dict) {
+    _maplibrePlatform.onMapLongClickPlatform.add((dict) {
       if (onMapLongClick != null) {
         onMapLongClick!(dict['point'], dict['latLng']);
       }
     });
 
-    _maplibreGlPlatform.onCameraTrackingChangedPlatform.add((mode) {
+    _maplibrePlatform.onCameraTrackingChangedPlatform.add((mode) {
       if (onCameraTrackingChanged != null) {
         onCameraTrackingChanged!(mode);
       }
     });
 
-    _maplibreGlPlatform.onCameraTrackingDismissedPlatform.add((_) {
+    _maplibrePlatform.onCameraTrackingDismissedPlatform.add((_) {
       if (onCameraTrackingDismissed != null) {
         onCameraTrackingDismissed!();
       }
     });
 
-    _maplibreGlPlatform.onMapIdlePlatform.add((_) {
+    _maplibrePlatform.onMapIdlePlatform.add((_) {
       if (onMapIdle != null) {
         onMapIdle!();
       }
     });
-    _maplibreGlPlatform.onUserLocationUpdatedPlatform.add((location) {
+    _maplibrePlatform.onUserLocationUpdatedPlatform.add((location) {
       onUserLocationUpdated?.call(location);
     });
   }
@@ -265,7 +265,7 @@ class MapLibreMapController extends ChangeNotifier {
   CameraPosition? get cameraPosition => _cameraPosition;
   CameraPosition? _cameraPosition;
 
-  final MapLibreGlPlatform _maplibreGlPlatform; //ignore: unused_field
+  final MapLibrePlatform _maplibrePlatform; //ignore: unused_field
 
   /// Updates configuration options of the map user interface.
   ///
@@ -274,7 +274,7 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// The returned [Future] completes after listeners have been notified.
   Future<void> _updateMapOptions(Map<String, dynamic> optionsUpdate) async {
-    _cameraPosition = await _maplibreGlPlatform.updateMapOptions(optionsUpdate);
+    _cameraPosition = await _maplibrePlatform.updateMapOptions(optionsUpdate);
     notifyListeners();
   }
 
@@ -285,12 +285,12 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// To force resize map (without any checks) have a look at forceResizeWebMap()
   void resizeWebMap() {
-    _maplibreGlPlatform.resizeWebMap();
+    _maplibrePlatform.resizeWebMap();
   }
 
   /// Triggers a hard map resize event on web and does not check if it is required or not.
   void forceResizeWebMap() {
-    _maplibreGlPlatform.forceResizeWebMap();
+    _maplibrePlatform.forceResizeWebMap();
   }
 
   /// Starts an animated change of the map camera position.
@@ -303,7 +303,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// Note: this currently always returns immediately with a value of null on iOS
   Future<bool?> animateCamera(CameraUpdate cameraUpdate,
       {Duration? duration}) async {
-    return _maplibreGlPlatform.animateCamera(cameraUpdate, duration: duration);
+    return _maplibrePlatform.animateCamera(cameraUpdate, duration: duration);
   }
 
   /// Instantaneously re-position the camera.
@@ -314,7 +314,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// It returns true if the camera was successfully moved and false if the movement was canceled.
   /// Note: this currently always returns immediately with a value of null on iOS
   Future<bool?> moveCamera(CameraUpdate cameraUpdate) async {
-    return _maplibreGlPlatform.moveCamera(cameraUpdate);
+    return _maplibrePlatform.moveCamera(cameraUpdate);
   }
 
   /// Adds a new geojson source
@@ -330,7 +330,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// platform side.
   Future<void> addGeoJsonSource(String sourceId, Map<String, dynamic> geojson,
       {String? promoteId}) async {
-    await _maplibreGlPlatform.addGeoJsonSource(sourceId, geojson,
+    await _maplibrePlatform.addGeoJsonSource(sourceId, geojson,
         promoteId: promoteId);
   }
 
@@ -347,7 +347,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// platform side.
   Future<void> setGeoJsonSource(
       String sourceId, Map<String, dynamic> geojson) async {
-    await _maplibreGlPlatform.setGeoJsonSource(sourceId, geojson);
+    await _maplibrePlatform.setGeoJsonSource(sourceId, geojson);
   }
 
   /// Sets new geojson data to and existing source
@@ -363,7 +363,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// platform side.
   Future<void> setGeoJsonFeature(
       String sourceId, Map<String, dynamic> geojsonFeature) async {
-    await _maplibreGlPlatform.setFeatureForGeoJsonSource(
+    await _maplibrePlatform.setFeatureForGeoJsonSource(
         sourceId, geojsonFeature);
   }
 
@@ -394,7 +394,7 @@ class MapLibreMapController extends ChangeNotifier {
       double? maxzoom,
       dynamic filter,
       bool enableInteraction = true}) async {
-    await _maplibreGlPlatform.addSymbolLayer(
+    await _maplibrePlatform.addSymbolLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -434,7 +434,7 @@ class MapLibreMapController extends ChangeNotifier {
       double? maxzoom,
       dynamic filter,
       bool enableInteraction = true}) async {
-    await _maplibreGlPlatform.addLineLayer(
+    await _maplibrePlatform.addLineLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -455,7 +455,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// platform side.
   Future<void> setLayerProperties(
       String layerId, LayerProperties properties) async {
-    await _maplibreGlPlatform.setLayerProperties(layerId, properties.toJson());
+    await _maplibrePlatform.setLayerProperties(layerId, properties.toJson());
   }
 
   /// Add a fill layer to the map with the given properties
@@ -485,7 +485,7 @@ class MapLibreMapController extends ChangeNotifier {
       double? maxzoom,
       dynamic filter,
       bool enableInteraction = true}) async {
-    await _maplibreGlPlatform.addFillLayer(
+    await _maplibrePlatform.addFillLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -525,7 +525,7 @@ class MapLibreMapController extends ChangeNotifier {
       double? maxzoom,
       dynamic filter,
       bool enableInteraction = true}) async {
-    await _maplibreGlPlatform.addFillExtrusionLayer(
+    await _maplibrePlatform.addFillExtrusionLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -565,7 +565,7 @@ class MapLibreMapController extends ChangeNotifier {
       double? maxzoom,
       dynamic filter,
       bool enableInteraction = true}) async {
-    await _maplibreGlPlatform.addCircleLayer(
+    await _maplibrePlatform.addCircleLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -598,7 +598,7 @@ class MapLibreMapController extends ChangeNotifier {
       String? sourceLayer,
       double? minzoom,
       double? maxzoom}) async {
-    await _maplibreGlPlatform.addRasterLayer(
+    await _maplibrePlatform.addRasterLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -629,7 +629,7 @@ class MapLibreMapController extends ChangeNotifier {
       String? sourceLayer,
       double? minzoom,
       double? maxzoom}) async {
-    await _maplibreGlPlatform.addHillshadeLayer(
+    await _maplibrePlatform.addHillshadeLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -660,7 +660,7 @@ class MapLibreMapController extends ChangeNotifier {
       String? sourceLayer,
       double? minzoom,
       double? maxzoom}) async {
-    await _maplibreGlPlatform.addHeatmapLayer(
+    await _maplibrePlatform.addHeatmapLayer(
       sourceId,
       layerId,
       properties.toJson(),
@@ -677,7 +677,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// platform side.
   Future<void> updateMyLocationTrackingMode(
       MyLocationTrackingMode myLocationTrackingMode) async {
-    return _maplibreGlPlatform
+    return _maplibrePlatform
         .updateMyLocationTrackingMode(myLocationTrackingMode);
   }
 
@@ -686,7 +686,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
   Future<void> matchMapLanguageWithDeviceDefault() async {
-    return _maplibreGlPlatform.matchMapLanguageWithDeviceDefault();
+    return _maplibrePlatform.matchMapLanguageWithDeviceDefault();
   }
 
   /// Updates the distance from the edges of the map view’s frame to the edges
@@ -702,7 +702,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// platform side.
   Future<void> updateContentInsets(EdgeInsets insets,
       [bool animated = false]) async {
-    return _maplibreGlPlatform.updateContentInsets(insets, animated);
+    return _maplibrePlatform.updateContentInsets(insets, animated);
   }
 
   /// Updates the language of the map labels to match the specified language.
@@ -720,7 +720,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
   Future<void> setMapLanguage(String language) async {
-    return _maplibreGlPlatform.setMapLanguage(language);
+    return _maplibrePlatform.setMapLanguage(language);
   }
 
   /// Enables or disables the collection of anonymized telemetry data.
@@ -728,7 +728,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
   Future<void> setTelemetryEnabled(bool enabled) async {
-    return _maplibreGlPlatform.setTelemetryEnabled(enabled);
+    return _maplibrePlatform.setTelemetryEnabled(enabled);
   }
 
   /// Retrieves whether collection of anonymized telemetry data is enabled.
@@ -736,7 +736,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// The returned [Future] completes after the query has been made on the
   /// platform side.
   Future<bool> getTelemetryEnabled() async {
-    return _maplibreGlPlatform.getTelemetryEnabled();
+    return _maplibrePlatform.getTelemetryEnabled();
   }
 
   /// Adds a symbol to the map, configured using the specified custom [options].
@@ -1106,13 +1106,13 @@ class MapLibreMapController extends ChangeNotifier {
   /// Query rendered (i.e. visible) features at a point in screen coordinates
   Future<List> queryRenderedFeatures(
       Point<double> point, List<String> layerIds, List<Object>? filter) async {
-    return _maplibreGlPlatform.queryRenderedFeatures(point, layerIds, filter);
+    return _maplibrePlatform.queryRenderedFeatures(point, layerIds, filter);
   }
 
   /// Query rendered (i.e. visible) features in a Rect in screen coordinates
   Future<List> queryRenderedFeaturesInRect(
       Rect rect, List<String> layerIds, String? filter) async {
-    return _maplibreGlPlatform.queryRenderedFeaturesInRect(
+    return _maplibrePlatform.queryRenderedFeaturesInRect(
         rect, layerIds, filter);
   }
 
@@ -1124,24 +1124,24 @@ class MapLibreMapController extends ChangeNotifier {
   /// Note: On web, this will probably only work for GeoJson source, not for vector tiles
   Future<List> querySourceFeatures(
       String sourceId, String? sourceLayerId, List<Object>? filter) async {
-    return _maplibreGlPlatform.querySourceFeatures(
+    return _maplibrePlatform.querySourceFeatures(
         sourceId, sourceLayerId, filter);
   }
 
   Future invalidateAmbientCache() async {
-    return _maplibreGlPlatform.invalidateAmbientCache();
+    return _maplibrePlatform.invalidateAmbientCache();
   }
 
   /// Get last my location
   ///
   /// Return last latlng, nullable
   Future<LatLng?> requestMyLocationLatLng() async {
-    return _maplibreGlPlatform.requestMyLocationLatLng();
+    return _maplibrePlatform.requestMyLocationLatLng();
   }
 
   /// This method returns the boundaries of the region currently displayed in the map.
   Future<LatLngBounds> getVisibleRegion() async {
-    return _maplibreGlPlatform.getVisibleRegion();
+    return _maplibrePlatform.getVisibleRegion();
   }
 
   /// Adds an image to the style currently displayed in the map, so that it can later be referred to by the provided name.
@@ -1180,7 +1180,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// }
   /// ```
   Future<void> addImage(String name, Uint8List bytes, [bool sdf = false]) {
-    return _maplibreGlPlatform.addImage(name, bytes, sdf);
+    return _maplibrePlatform.addImage(name, bytes, sdf);
   }
 
   /// If true, the icon will be visible even if it collides with other previously drawn symbols.
@@ -1207,7 +1207,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// Not implemented on web.
   Future<void> addImageSource(
       String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
-    return _maplibreGlPlatform.addImageSource(
+    return _maplibrePlatform.addImageSource(
         imageSourceId, bytes, coordinates);
   }
 
@@ -1215,25 +1215,25 @@ class MapLibreMapController extends ChangeNotifier {
   /// Not implemented on web.
   Future<void> updateImageSource(
       String imageSourceId, Uint8List? bytes, LatLngQuad? coordinates) {
-    return _maplibreGlPlatform.updateImageSource(
+    return _maplibrePlatform.updateImageSource(
         imageSourceId, bytes, coordinates);
   }
 
   /// Removes previously added image source by id
   @Deprecated("This method was renamed to removeSource")
   Future<void> removeImageSource(String imageSourceId) {
-    return _maplibreGlPlatform.removeSource(imageSourceId);
+    return _maplibrePlatform.removeSource(imageSourceId);
   }
 
   /// Removes previously added source by id
   Future<void> removeSource(String sourceId) {
-    return _maplibreGlPlatform.removeSource(sourceId);
+    return _maplibrePlatform.removeSource(sourceId);
   }
 
   /// Adds an image layer to the map's style at render time.
   Future<void> addImageLayer(String layerId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _maplibreGlPlatform.addLayer(
+    return _maplibrePlatform.addLayer(
         layerId, imageSourceId, minzoom, maxzoom);
   }
 
@@ -1241,7 +1241,7 @@ class MapLibreMapController extends ChangeNotifier {
   Future<void> addImageLayerBelow(
       String layerId, String sourceId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _maplibreGlPlatform.addLayerBelow(
+    return _maplibrePlatform.addLayerBelow(
         layerId, sourceId, imageSourceId, minzoom, maxzoom);
   }
 
@@ -1250,21 +1250,21 @@ class MapLibreMapController extends ChangeNotifier {
   Future<void> addLayerBelow(
       String layerId, String sourceId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _maplibreGlPlatform.addLayerBelow(
+    return _maplibrePlatform.addLayerBelow(
         layerId, sourceId, imageSourceId, minzoom, maxzoom);
   }
 
   /// Removes a MapLibre style layer
   Future<void> removeLayer(String layerId) {
-    return _maplibreGlPlatform.removeLayer(layerId);
+    return _maplibrePlatform.removeLayer(layerId);
   }
 
   Future<void> setFilter(String layerId, dynamic filter) {
-    return _maplibreGlPlatform.setFilter(layerId, filter);
+    return _maplibrePlatform.setFilter(layerId, filter);
   }
 
   Future<dynamic> getFilter(String layerId) {
-    return _maplibreGlPlatform.getFilter(layerId);
+    return _maplibrePlatform.getFilter(layerId);
   }
 
   /// Returns the point on the screen that corresponds to a geographical coordinate ([latLng]). The screen location is in screen pixels (not display pixels) relative to the top left of the map (not of the whole screen)
@@ -1274,27 +1274,27 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// Returns null if [latLng] is not currently visible on the map.
   Future<Point> toScreenLocation(LatLng latLng) async {
-    return _maplibreGlPlatform.toScreenLocation(latLng);
+    return _maplibrePlatform.toScreenLocation(latLng);
   }
 
   Future<List<Point>> toScreenLocationBatch(Iterable<LatLng> latLngs) async {
-    return _maplibreGlPlatform.toScreenLocationBatch(latLngs);
+    return _maplibrePlatform.toScreenLocationBatch(latLngs);
   }
 
   /// Returns the geographic location (as [LatLng]) that corresponds to a point on the screen. The screen location is specified in screen pixels (not display pixels) relative to the top left of the map (not the top left of the whole screen).
   Future<LatLng> toLatLng(Point screenLocation) async {
-    return _maplibreGlPlatform.toLatLng(screenLocation);
+    return _maplibrePlatform.toLatLng(screenLocation);
   }
 
   /// Returns the distance spanned by one pixel at the specified [latitude] and current zoom level.
   /// The distance between pixels decreases as the latitude approaches the poles. This relationship parallels the relationship between longitudinal coordinates at different latitudes.
   Future<double> getMetersPerPixelAtLatitude(double latitude) async {
-    return _maplibreGlPlatform.getMetersPerPixelAtLatitude(latitude);
+    return _maplibrePlatform.getMetersPerPixelAtLatitude(latitude);
   }
 
   /// Add a new source to the map
   Future<void> addSource(String sourceid, SourceProperties properties) async {
-    return _maplibreGlPlatform.addSource(sourceid, properties);
+    return _maplibrePlatform.addSource(sourceid, properties);
   }
 
   /// Pans and zooms the map to contain its visible area within the specified geographical bounds.
@@ -1308,7 +1308,7 @@ class MapLibreMapController extends ChangeNotifier {
     required double east,
     required int padding,
   }) async {
-    return _maplibreGlPlatform.setCameraBounds(
+    return _maplibrePlatform.setCameraBounds(
       west: west,
       north: north,
       south: south,
@@ -1413,18 +1413,18 @@ class MapLibreMapController extends ChangeNotifier {
   }
 
   Future<void> setLayerVisibility(String layerId, bool visible) async {
-    return _maplibreGlPlatform.setLayerVisibility(layerId, visible);
+    return _maplibrePlatform.setLayerVisibility(layerId, visible);
   }
 
   Future<List> getLayerIds() {
-    return _maplibreGlPlatform.getLayerIds();
+    return _maplibrePlatform.getLayerIds();
   }
 
   /// Retrieve every source ids of the map as a [String] list, including the ones added internally
   ///
   /// This method is not currently implemented on the web
   Future<List<String>> getSourceIds() async {
-    return (await _maplibreGlPlatform.getSourceIds())
+    return (await _maplibrePlatform.getSourceIds())
         .whereType<String>()
         .toList();
   }
@@ -1432,6 +1432,6 @@ class MapLibreMapController extends ChangeNotifier {
   @override
   void dispose() {
     super.dispose();
-    _maplibreGlPlatform.dispose();
+    _maplibrePlatform.dispose();
   }
 }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1207,8 +1207,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// Not implemented on web.
   Future<void> addImageSource(
       String imageSourceId, Uint8List bytes, LatLngQuad coordinates) {
-    return _maplibrePlatform.addImageSource(
-        imageSourceId, bytes, coordinates);
+    return _maplibrePlatform.addImageSource(imageSourceId, bytes, coordinates);
   }
 
   /// Update the image and/or coordinates of an image source.
@@ -1233,8 +1232,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// Adds an image layer to the map's style at render time.
   Future<void> addImageLayer(String layerId, String imageSourceId,
       {double? minzoom, double? maxzoom}) {
-    return _maplibrePlatform.addLayer(
-        layerId, imageSourceId, minzoom, maxzoom);
+    return _maplibrePlatform.addLayer(layerId, imageSourceId, minzoom, maxzoom);
   }
 
   /// Adds an image layer below the layer provided with belowLayerId to the map's style at render time.

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -32,13 +32,13 @@ typedef OnCameraIdleCallback = void Function();
 
 typedef OnMapIdleCallback = void Function();
 
-/// Controller for a single [MaplibreMap] instance running on the host platform.
+/// Controller for a single [MapLibreMap] instance running on the host platform.
 ///
 /// Some of its methods can only be called after the [onStyleLoaded] callback has been invoked.
 ///
 /// To add annotations ([Circle]s, [Line]s, [Symbol]s and [Fill]s) on the map, there are two ways:
 ///
-/// 1. *Simple way to add annotations*: Use the corresponding add* methods ([addCircle], [addLine], [addSymbol] and [addFill]) on the MaplibreMapController to add one annotation at a time to the map.
+/// 1. *Simple way to add annotations*: Use the corresponding add* methods ([addCircle], [addLine], [addSymbol] and [addFill]) on the MapLibreMapController to add one annotation at a time to the map.
 /// There are also corresponding [addCircles], [addLines] etc. methods which work the same but add multiple annotations at a time.
 ///
 /// (If you are interested how this works: under the hood, this uses AnnotationManagers to manage the annotations.
@@ -56,21 +56,21 @@ typedef OnMapIdleCallback = void Function();
 /// not for circles that are already contained in the map's style when the map is loaded or are added to that map's style with the methods from the advanced way (see below).
 /// The same of course applies for fills, lines and symbols.
 ///
-/// 2. *Advanced way to add annotations*: Modify the underlying Maplibre Style of the map to add a new data source (e.g. with the [addSource] method or the more specific methods like [addGeoJsonSource])
+/// 2. *Advanced way to add annotations*: Modify the underlying MapLibre Style of the map to add a new data source (e.g. with the [addSource] method or the more specific methods like [addGeoJsonSource])
 /// and add a new layer to display the data of that source on the map (either with the [addLayer] method or with the more specific methods like [addCircleLayer], [addLineLayer] etc.).
-/// For more information about Maplibre Styles, see the documentation of [maplibre_gl] as well as the specification at [https://maplibre.org/maplibre-style-spec/].
+/// For more information about MapLibre Styles, see the documentation of [maplibre_gl] as well as the specification at [https://maplibre.org/maplibre-style-spec/].
 ///
-/// A MaplibreMapController is also a [ChangeNotifier]. Subscribers (change listeners) are notified upon changes to any of
+/// A MapLibreMapController is also a [ChangeNotifier]. Subscribers (change listeners) are notified upon changes to any of
 ///
-/// * the configuration options of the [MaplibreMap] widget
+/// * the configuration options of the [MapLibreMap] widget
 /// * the [symbols], [lines], [circles] or [fills] properties
 /// (i.e. the collection of [Symbol]s, [Line]s, [Circle]s and [Fill]s added to this map via the "simple way" (see above))
 /// * the [isCameraMoving] property
 /// * the [cameraPosition] property
 ///
 /// Listeners are notified after changes have been applied on the platform side.
-class MaplibreMapController extends ChangeNotifier {
-  MaplibreMapController({
+class MapLibreMapController extends ChangeNotifier {
+  MapLibreMapController({
     required MapLibreGlPlatform maplibreGlPlatform,
     required CameraPosition initialCameraPosition,
     required Iterable<AnnotationType> annotationOrder,
@@ -258,7 +258,7 @@ class MaplibreMapController extends ChangeNotifier {
   bool _isCameraMoving = false;
 
   /// Returns the most recent camera position reported by the platform side.
-  /// Will be null, if [MaplibreMap.trackCameraPosition] is false.
+  /// Will be null, if [MapLibreMap.trackCameraPosition] is false.
   CameraPosition? get cameraPosition => _cameraPosition;
   CameraPosition? _cameraPosition;
 
@@ -710,7 +710,7 @@ class MaplibreMapController extends ChangeNotifier {
   /// "a lowercase language's ISO 639-1 alpha2 code (second column), a lowercase ISO 639-2 code if an ISO 639-1 code doesn't exist, or a ISO 639-3 code if neither of those exist".
   ///
   /// If your vector tiles do not follow this schema of having labels with "name:$language" for different language, this method will not work for you.
-  /// In that case, you need to adapt your Maplibre style accordingly yourself to use labels in your preferred language.
+  /// In that case, you need to adapt your MapLibre style accordingly yourself to use labels in your preferred language.
   ///
   /// Attention: This may only be called after onStyleLoaded() has been invoked.
   ///

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -32,6 +32,9 @@ typedef OnCameraIdleCallback = void Function();
 
 typedef OnMapIdleCallback = void Function();
 
+@Deprecated('MaplibreMapController was renamed to MapLibreMapController.')
+typedef MaplibreMapController = MapLibreMapController;
+
 /// Controller for a single [MapLibreMap] instance running on the host platform.
 ///
 /// Some of its methods can only be called after the [onStyleLoaded] callback has been invoked.

--- a/lib/src/maplibre_map.dart
+++ b/lib/src/maplibre_map.dart
@@ -255,8 +255,7 @@ class _MapLibreMapState extends State<MapLibreMap> {
       Completer<MapLibreMapController>();
 
   late _MapLibreMapOptions _maplibreMapOptions;
-  final MapLibrePlatform _maplibrePlatform =
-      MapLibrePlatform.createInstance();
+  final MapLibrePlatform _maplibrePlatform = MapLibrePlatform.createInstance();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/maplibre_map.dart
+++ b/lib/src/maplibre_map.dart
@@ -6,15 +6,15 @@ part of '../maplibre_gl.dart';
 
 enum AnnotationType { fill, line, circle, symbol }
 
-typedef MapCreatedCallback = void Function(MaplibreMapController controller);
+typedef MapCreatedCallback = void Function(MapLibreMapController controller);
 
 /// Shows a MapLibre map.
-/// Also refer to the documentation of [maplibre_gl] and [MaplibreMapController].
-class MaplibreMap extends StatefulWidget {
-  const MaplibreMap({
+/// Also refer to the documentation of [maplibre_gl] and [MapLibreMapController].
+class MapLibreMap extends StatefulWidget {
+  const MapLibreMap({
     super.key,
     required this.initialCameraPosition,
-    this.styleString = MaplibreStyles.demo,
+    this.styleString = MapLibreStyles.demo,
     this.onMapCreated,
     this.onStyleLoadedCallback,
     this.gestureRecognizers,
@@ -139,10 +139,10 @@ class MaplibreMap extends StatefulWidget {
   /// This takes presedence over zoomGesturesEnabled. Only supported for web.
   final bool? doubleClickZoomEnabled;
 
-  /// True if you want to be notified of map camera movements by the [MaplibreMapController]. Default is false.
+  /// True if you want to be notified of map camera movements by the [MapLibreMapController]. Default is false.
   ///
-  /// If this is set to true and the user pans/zooms/rotates the map, [MaplibreMapController] (which is a [ChangeNotifier])
-  /// will notify it's listeners and you can then get the new [MaplibreMapController].cameraPosition.
+  /// If this is set to true and the user pans/zooms/rotates the map, [MapLibreMapController] (which is a [ChangeNotifier])
+  /// will notify it's listeners and you can then get the new [MapLibreMapController].cameraPosition.
   final bool trackCameraPosition;
 
   /// True if a "My Location" layer should be shown on the map.
@@ -234,24 +234,24 @@ class MaplibreMap extends StatefulWidget {
   /// * All fade/transition animations have completed
   final OnMapIdleCallback? onMapIdle;
 
-  /// Set `MaplibreMap.useHybridComposition` to `false` in order use Virtual-Display
+  /// Set `MapLibreMap.useHybridComposition` to `false` in order use Virtual-Display
   /// (better for Android 9 and below but may result in errors on Android 12)
   /// or leave it `true` (default) to use Hybrid composition (Slower on Android 9 and below).
   static bool get useHybridComposition =>
-      MethodChannelMaplibreGl.useHybridComposition;
+      MethodChannelMapLibreGl.useHybridComposition;
 
   static set useHybridComposition(bool useHybridComposition) =>
-      MethodChannelMaplibreGl.useHybridComposition = useHybridComposition;
+      MethodChannelMapLibreGl.useHybridComposition = useHybridComposition;
 
   @override
-  State createState() => _MaplibreMapState();
+  State createState() => _MapLibreMapState();
 }
 
-class _MaplibreMapState extends State<MaplibreMap> {
-  final Completer<MaplibreMapController> _controller =
-      Completer<MaplibreMapController>();
+class _MapLibreMapState extends State<MapLibreMap> {
+  final Completer<MapLibreMapController> _controller =
+      Completer<MapLibreMapController>();
 
-  late _MaplibreMapOptions _maplibreMapOptions;
+  late _MapLibreMapOptions _maplibreMapOptions;
   final MapLibreGlPlatform _maplibreGlPlatform =
       MapLibreGlPlatform.createInstance();
 
@@ -263,7 +263,7 @@ class _MaplibreMapState extends State<MaplibreMap> {
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition.toMap(),
       'styleString': widget.styleString,
-      'options': _MaplibreMapOptions.fromWidget(widget).toMap(),
+      'options': _MapLibreMapOptions.fromWidget(widget).toMap(),
       'dragEnabled': widget.dragEnabled,
       if (widget.iosLongClickDuration != null)
         'iosLongClickDurationMilliseconds':
@@ -276,7 +276,7 @@ class _MaplibreMapState extends State<MaplibreMap> {
   @override
   void initState() {
     super.initState();
-    _maplibreMapOptions = _MaplibreMapOptions.fromWidget(widget);
+    _maplibreMapOptions = _MapLibreMapOptions.fromWidget(widget);
   }
 
   @override
@@ -289,10 +289,10 @@ class _MaplibreMapState extends State<MaplibreMap> {
   }
 
   @override
-  void didUpdateWidget(MaplibreMap oldWidget) {
+  void didUpdateWidget(MapLibreMap oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final _MaplibreMapOptions newOptions =
-        _MaplibreMapOptions.fromWidget(widget);
+    final _MapLibreMapOptions newOptions =
+        _MapLibreMapOptions.fromWidget(widget);
     final Map<String, dynamic> updates =
         _maplibreMapOptions.updatesMap(newOptions);
     _updateOptions(updates);
@@ -303,12 +303,12 @@ class _MaplibreMapState extends State<MaplibreMap> {
     if (updates.isEmpty) {
       return;
     }
-    final MaplibreMapController controller = await _controller.future;
+    final MapLibreMapController controller = await _controller.future;
     controller._updateMapOptions(updates);
   }
 
   Future<void> onPlatformViewCreated(int id) async {
-    final MaplibreMapController controller = MaplibreMapController(
+    final MapLibreMapController controller = MapLibreMapController(
       maplibreGlPlatform: _maplibreGlPlatform,
       initialCameraPosition: widget.initialCameraPosition,
       onStyleLoadedCallback: () {
@@ -336,12 +336,12 @@ class _MaplibreMapState extends State<MaplibreMap> {
   }
 }
 
-/// Configuration options for the MaplibreMap user interface.
+/// Configuration options for the MapLibreMap user interface.
 ///
 /// When used to change configuration, null values will be interpreted as
 /// "do not change this configuration option".
-class _MaplibreMapOptions {
-  _MaplibreMapOptions({
+class _MapLibreMapOptions {
+  _MapLibreMapOptions({
     this.compassEnabled,
     this.cameraTargetBounds,
     this.styleString,
@@ -362,8 +362,8 @@ class _MaplibreMapOptions {
     this.attributionButtonMargins,
   });
 
-  static _MaplibreMapOptions fromWidget(MaplibreMap map) {
-    return _MaplibreMapOptions(
+  static _MapLibreMapOptions fromWidget(MapLibreMap map) {
+    return _MapLibreMapOptions(
       compassEnabled: map.compassEnabled,
       cameraTargetBounds: map.cameraTargetBounds,
       styleString: map.styleString,
@@ -471,7 +471,7 @@ class _MaplibreMapOptions {
     return optionsMap;
   }
 
-  Map<String, dynamic> updatesMap(_MaplibreMapOptions newOptions) {
+  Map<String, dynamic> updatesMap(_MapLibreMapOptions newOptions) {
     final Map<String, dynamic> prevOptionsMap = toMap();
     final newOptionsMap = newOptions.toMap();
 

--- a/lib/src/maplibre_map.dart
+++ b/lib/src/maplibre_map.dart
@@ -8,6 +8,9 @@ enum AnnotationType { fill, line, circle, symbol }
 
 typedef MapCreatedCallback = void Function(MapLibreMapController controller);
 
+@Deprecated('MaplibreMap was renamed to MapLibreMap. ')
+typedef MaplibreMap = MapLibreMap;
+
 /// Shows a MapLibre map.
 /// Also refer to the documentation of [maplibre_gl] and [MapLibreMapController].
 class MapLibreMap extends StatefulWidget {

--- a/lib/src/maplibre_map.dart
+++ b/lib/src/maplibre_map.dart
@@ -241,10 +241,10 @@ class MapLibreMap extends StatefulWidget {
   /// (better for Android 9 and below but may result in errors on Android 12)
   /// or leave it `true` (default) to use Hybrid composition (Slower on Android 9 and below).
   static bool get useHybridComposition =>
-      MethodChannelMapLibreGl.useHybridComposition;
+      MapLibreMethodChannel.useHybridComposition;
 
   static set useHybridComposition(bool useHybridComposition) =>
-      MethodChannelMapLibreGl.useHybridComposition = useHybridComposition;
+      MapLibreMethodChannel.useHybridComposition = useHybridComposition;
 
   @override
   State createState() => _MapLibreMapState();

--- a/lib/src/maplibre_map.dart
+++ b/lib/src/maplibre_map.dart
@@ -255,8 +255,8 @@ class _MapLibreMapState extends State<MapLibreMap> {
       Completer<MapLibreMapController>();
 
   late _MapLibreMapOptions _maplibreMapOptions;
-  final MapLibreGlPlatform _maplibreGlPlatform =
-      MapLibreGlPlatform.createInstance();
+  final MapLibrePlatform _maplibrePlatform =
+      MapLibrePlatform.createInstance();
 
   @override
   Widget build(BuildContext context) {
@@ -272,7 +272,7 @@ class _MapLibreMapState extends State<MapLibreMap> {
         'iosLongClickDurationMilliseconds':
             widget.iosLongClickDuration!.inMilliseconds,
     };
-    return _maplibreGlPlatform.buildView(
+    return _maplibrePlatform.buildView(
         creationParams, onPlatformViewCreated, widget.gestureRecognizers);
   }
 
@@ -312,7 +312,7 @@ class _MapLibreMapState extends State<MapLibreMap> {
 
   Future<void> onPlatformViewCreated(int id) async {
     final MapLibreMapController controller = MapLibreMapController(
-      maplibreGlPlatform: _maplibreGlPlatform,
+      maplibrePlatform: _maplibrePlatform,
       initialCameraPosition: widget.initialCameraPosition,
       onStyleLoadedCallback: () {
         if (_controller.isCompleted) {
@@ -331,7 +331,7 @@ class _MapLibreMapState extends State<MapLibreMap> {
       annotationOrder: widget.annotationOrder,
       annotationConsumeTapEvents: widget.annotationConsumeTapEvents,
     );
-    await _maplibreGlPlatform.initPlatform(id);
+    await _maplibrePlatform.initPlatform(id);
     _controller.complete(controller);
     if (widget.onMapCreated != null) {
       widget.onMapCreated!(controller);

--- a/lib/src/maplibre_styles.dart
+++ b/lib/src/maplibre_styles.dart
@@ -1,7 +1,7 @@
 part of '../maplibre_gl.dart';
 
 /// MapLibre styles used mostly for demonstration.
-abstract class MaplibreStyles {
+abstract class MapLibreStyles {
   /// A very simple MapLibre demo style that shows only countries with their
   /// boundaries.
   static const String demo = "https://demotiles.maplibre.org/style.json";

--- a/lib/src/maplibre_styles.dart
+++ b/lib/src/maplibre_styles.dart
@@ -1,5 +1,8 @@
 part of '../maplibre_gl.dart';
 
+@Deprecated('MaplibreStyles was renamed to MapLibreStyles.')
+typedef MaplibreStyles = MapLibreStyles;
+
 /// MapLibre styles used mostly for demonstration.
 abstract class MapLibreStyles {
   /// A very simple MapLibre demo style that shows only countries with their

--- a/maplibre_gl_platform_interface/CHANGELOG.md
+++ b/maplibre_gl_platform_interface/CHANGELOG.md
@@ -23,7 +23,7 @@ see top-level CHANGELOG.md
 ## 0.13.0, Oct 6, 2021
 
 🎉 The first release of flutter-maplibre-gl with the complete transition to
-Maplibre libraries. 🎉
+MapLibre libraries. 🎉
 
 ### Changes cherry-picked/ported from tobrun/flutter-mapbox-gl:0.12.0
 

--- a/maplibre_gl_platform_interface/README.md
+++ b/maplibre_gl_platform_interface/README.md
@@ -1,1 +1,1 @@
-Contains the web platform implementation for the [Flutter Maplibre GL plugin](https://github.com/maplibre/flutter-maplibre-gl).
+Contains the web platform implementation for the [Flutter MapLibre GL plugin](https://github.com/maplibre/flutter-maplibre-gl).

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -2,19 +2,19 @@
 
 part of '../maplibre_gl_platform_interface.dart';
 
-/// The default instance of [MapLibreGlPlatform] to use.
+/// The default instance of [MapLibrePlatform] to use.
 typedef OnPlatformViewCreatedCallback = void Function(int);
 
-abstract class MapLibreGlPlatform {
+abstract class MapLibrePlatform {
   static MapLibreMethodChannel? _instance;
 
-  /// The default instance of [MapLibreGlPlatform] to use.
+  /// The default instance of [MapLibrePlatform] to use.
   ///
   /// Defaults to [MapLibreMethodChannel].
   ///
   /// Platform-specific plugins should set this with their own platform-specific
-  /// class that extends [MapLibreGlPlatform] when they register themselves.
-  static MapLibreGlPlatform Function() createInstance =
+  /// class that extends [MapLibrePlatform] when they register themselves.
+  static MapLibrePlatform Function() createInstance =
       () => _instance ?? MapLibreMethodChannel();
 
   static set instance(MapLibreMethodChannel instance) {

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -6,18 +6,18 @@ part of '../maplibre_gl_platform_interface.dart';
 typedef OnPlatformViewCreatedCallback = void Function(int);
 
 abstract class MapLibreGlPlatform {
-  static MethodChannelMaplibreGl? _instance;
+  static MethodChannelMapLibreGl? _instance;
 
-  /// The default instance of [MaplibreGlPlatform] to use.
+  /// The default instance of [MapLibreGlPlatform] to use.
   ///
-  /// Defaults to [MethodChannelMaplibreGl].
+  /// Defaults to [MethodChannelMapLibreGl].
   ///
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [MapLibreGlPlatform] when they register themselves.
   static MapLibreGlPlatform Function() createInstance =
-      () => _instance ?? MethodChannelMaplibreGl();
+      () => _instance ?? MethodChannelMapLibreGl();
 
-  static set instance(MethodChannelMaplibreGl instance) {
+  static set instance(MethodChannelMapLibreGl instance) {
     _instance = instance;
   }
 

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -6,18 +6,18 @@ part of '../maplibre_gl_platform_interface.dart';
 typedef OnPlatformViewCreatedCallback = void Function(int);
 
 abstract class MapLibreGlPlatform {
-  static MethodChannelMapLibreGl? _instance;
+  static MapLibreMethodChannel? _instance;
 
   /// The default instance of [MapLibreGlPlatform] to use.
   ///
-  /// Defaults to [MethodChannelMapLibreGl].
+  /// Defaults to [MapLibreMethodChannel].
   ///
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [MapLibreGlPlatform] when they register themselves.
   static MapLibreGlPlatform Function() createInstance =
-      () => _instance ?? MethodChannelMapLibreGl();
+      () => _instance ?? MapLibreMethodChannel();
 
-  static set instance(MethodChannelMapLibreGl instance) {
+  static set instance(MapLibreMethodChannel instance) {
     _instance = instance;
   }
 

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -1,6 +1,6 @@
 part of '../maplibre_gl_platform_interface.dart';
 
-class MethodChannelMaplibreGl extends MapLibreGlPlatform {
+class MethodChannelMapLibreGl extends MapLibreGlPlatform {
   late MethodChannel _channel;
   static bool useHybridComposition = false;
 

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -1,6 +1,6 @@
 part of '../maplibre_gl_platform_interface.dart';
 
-class MethodChannelMapLibreGl extends MapLibreGlPlatform {
+class MapLibreMethodChannel extends MapLibreGlPlatform {
   late MethodChannel _channel;
   static bool useHybridComposition = false;
 

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -1,6 +1,6 @@
 part of '../maplibre_gl_platform_interface.dart';
 
-class MapLibreMethodChannel extends MapLibreGlPlatform {
+class MapLibreMethodChannel extends MapLibrePlatform {
   late MethodChannel _channel;
   static bool useHybridComposition = false;
 

--- a/maplibre_gl_platform_interface/lib/src/ui.dart
+++ b/maplibre_gl_platform_interface/lib/src/ui.dart
@@ -41,7 +41,7 @@ enum AttributionButtonPosition {
 }
 
 /// Bounds for the map camera target.
-/// Used with [_MaplibreMapOptions] to wrap a [LatLngBounds] value. This allows
+/// Used with [_MapLibreMapOptions] to wrap a [LatLngBounds] value. This allows
 /// distinguishing between specifying an unbounded target (null `LatLngBounds`)
 /// from not specifying anything (null `CameraTargetBounds`).
 class CameraTargetBounds {
@@ -76,7 +76,7 @@ class CameraTargetBounds {
 }
 
 /// Preferred bounds for map camera zoom level.
-/// Used with [_MaplibreMapOptions] to wrap min and max zoom. This allows
+/// Used with [_MapLibreMapOptions] to wrap min and max zoom. This allows
 /// distinguishing between specifying unbounded zooming (null [minZoom] and
 /// [maxZoom]) from not specifying anything (null [MinMaxZoomPreference]).
 class MinMaxZoomPreference {

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -15,7 +15,7 @@ see top-level CHANGELOG.md
 ## 0.13.0, Oct 6, 2021
 
 🎉 The first release of flutter-maplibre-gl with the complete transition to
-Maplibre libraries. 🎉
+MapLibre libraries. 🎉
 
 ### Changes cherry-picked/ported from tobrun/flutter-mapbox-gl:0.12.0
 

--- a/maplibre_gl_web/README.md
+++ b/maplibre_gl_web/README.md
@@ -1,1 +1,1 @@
-Contains the web interfaces for the [Flutter Maplibre GL plugin](https://github.com/maplibre/flutter-maplibre-gl).
+Contains the web interfaces for the [Flutter MapLibre GL plugin](https://github.com/maplibre/flutter-maplibre-gl).

--- a/maplibre_gl_web/lib/src/maplibre_map_plugin.dart
+++ b/maplibre_gl_web/lib/src/maplibre_map_plugin.dart
@@ -3,6 +3,6 @@ part of '../maplibre_gl_web.dart';
 class MapLibreMapPlugin {
   /// Registers this class as the default instance of [MapLibreGlPlatform].
   static void registerWith(Registrar registrar) {
-    MapLibreGlPlatform.createInstance = () => MaplibreMapController();
+    MapLibreGlPlatform.createInstance = () => MapLibreMapController();
   }
 }

--- a/maplibre_gl_web/lib/src/maplibre_map_plugin.dart
+++ b/maplibre_gl_web/lib/src/maplibre_map_plugin.dart
@@ -1,8 +1,8 @@
 part of '../maplibre_gl_web.dart';
 
 class MapLibreMapPlugin {
-  /// Registers this class as the default instance of [MapLibreGlPlatform].
+  /// Registers this class as the default instance of [MapLibrePlatform].
   static void registerWith(Registrar registrar) {
-    MapLibreGlPlatform.createInstance = () => MapLibreMapController();
+    MapLibrePlatform.createInstance = () => MapLibreMapController();
   }
 }

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1,6 +1,6 @@
 part of '../maplibre_gl_web.dart';
 
-class MaplibreMapController extends MapLibreGlPlatform
+class MapLibreMapController extends MapLibreGlPlatform
     implements MapLibreMapOptionsSink {
   late html.DivElement _mapElement;
 

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1,6 +1,6 @@
 part of '../maplibre_gl_web.dart';
 
-class MapLibreMapController extends MapLibreGlPlatform
+class MapLibreMapController extends MapLibrePlatform
     implements MapLibreMapOptionsSink {
   late html.DivElement _mapElement;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: maplibre_gl
-description: A Flutter plugin for integrating Maplibre Maps inside a Flutter application on Android, iOS and web platforms.
+description: A Flutter plugin for integrating MapLibre Maps inside a Flutter application on Android, iOS and web platforms.
 version: 0.19.0+2
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues


### PR DESCRIPTION
We have currently a mix of `Maplibre` and `MapLibre`. This pull request changes all occurrences to `MapLibre` to be in line with the  underlaying packages.

I added deprecations for MaplibreMap, MaplibreMapController and MaplibreStyles to help users migrate.