### PR TITLE
Migrate Objective-C plugin to Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Changes
 
+* Migrated main iOS plugin class from Objective-C to Swift.
 * Renamed iOS plugin classes from `Mapbox` to `MapLibre`.
 
 ## 0.19.0

--- a/ios/Classes/MapLibreMapsPlugin.h
+++ b/ios/Classes/MapLibreMapsPlugin.h
@@ -1,4 +1,0 @@
-#import <Flutter/Flutter.h>
-
-@interface MapLibreMapsPlugin : NSObject<FlutterPlugin>
-@end

--- a/ios/Classes/MapLibreMapsPlugin.m
+++ b/ios/Classes/MapLibreMapsPlugin.m
@@ -1,8 +1,0 @@
-#import "MapLibreMapsPlugin.h"
-#import <maplibre_gl/maplibre_gl-Swift.h>
-
-@implementation MapLibreMapsPlugin
-+ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  [SwiftMapLibreGlFlutterPlugin registerWithRegistrar:registrar];
-}
-@end

--- a/ios/Classes/MapLibreMapsPlugin.swift
+++ b/ios/Classes/MapLibreMapsPlugin.swift
@@ -3,7 +3,7 @@ import Foundation
 import MapLibre
 import UIKit
 
-public class SwiftMapLibreGlFlutterPlugin: NSObject, FlutterPlugin {
+public class MapLibreMapsPlugin: NSObject, FlutterPlugin {
     static var downloadOfflineRegionChannelHandler: OfflineChannelHandler? = nil
 
     public static func register(with registrar: FlutterPluginRegistrar) {

--- a/ios/maplibre_gl.podspec
+++ b/ios/maplibre_gl.podspec
@@ -13,10 +13,9 @@ A new Flutter plugin.
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
-  s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'MapLibre', '6.4.2'
   s.swift_version = '4.2'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
 end
 


### PR DESCRIPTION
Migrate the iOS plugin to Swift and remove old Objective-C implementation.
Rename the Swift plugin class.