### PR TITLE
Update Android plugin Gradle configuration

### DIFF
--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -2,13 +2,15 @@ group 'org.maplibre.maplibregl'
 version '1.0-SNAPSHOT'
 
 buildscript {
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -20,7 +22,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -28,7 +30,7 @@ android {
     }
 
     compileSdkVersion 34
-    ndkVersion "20.1.5948944"
+    ndkVersion "26.1.10909125"
 
     defaultConfig {
         minSdkVersion 21

--- a/maplibre_gl/android/gradle/wrapper/gradle-wrapper.properties
+++ b/maplibre_gl/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Mar 06 23:07:28 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapsPlugin.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapsPlugin.java
@@ -4,20 +4,14 @@
 
 package org.maplibre.maplibregl;
 
-import android.app.Activity;
-import android.app.Application;
-import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.LifecycleRegistry;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * Plugin for controlling a set of MapLibreMap views to be shown as overlays on top of the Flutter
@@ -26,8 +20,6 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
  * overlay.
  */
 public class MapLibreMapsPlugin implements FlutterPlugin, ActivityAware {
-
-  private static final String VIEW_TYPE = "plugins.flutter.io/maplibre_gl";
 
   static FlutterAssets flutterAssets;
   private Lifecycle lifecycle;


### PR DESCRIPTION
We require a very recent Kotlin version (1.9.0) due to MapLibre native dependency. These changes ensure that the plugin requires the same version. Also remove unused imports and old embedding settings in the example.