### PR TITLE
fix: await calls to change overlap in example

### DIFF
--- a/example/lib/place_symbol.dart
+++ b/example/lib/place_symbol.dart
@@ -260,8 +260,8 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     setState(() {
       _iconAllowOverlap = !_iconAllowOverlap;
     });
-    controller!.setSymbolIconAllowOverlap(_iconAllowOverlap);
-    controller!.setSymbolTextAllowOverlap(_iconAllowOverlap);
+    await controller!.setSymbolIconAllowOverlap(_iconAllowOverlap);
+    await controller!.setSymbolTextAllowOverlap(_iconAllowOverlap);
   }
 
   @override


### PR DESCRIPTION
I was going nuts trying to figure out why I was getting `Layer 'XXXXX' has an invalid value` crashes in my app when I changed overlap settings having copied how I was doing it directly from the example code...and then I found #237 and decided to take the example code for a run and was able to produce the same crash