### PR TITLE
Fix: Aligned example and maplibre_gl_web pubspec versions.

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   http: ^1.1.0
   location: ^5.0.3
-  maplibre_gl: ^0.19.0
+  maplibre_gl: ^0.20.0
   path_provider: ^2.0.15
 
 dev_dependencies:
@@ -36,3 +36,4 @@ flutter:
     - assets/osm_style.json
     - assets/sydney0.png
     - assets/sydney1.png
+    - assets/features.json

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,4 +36,3 @@ flutter:
     - assets/osm_style.json
     - assets/sydney0.png
     - assets/sydney1.png
-    - assets/features.json

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   image: ^4.0.17
   js: ">=0.6.7 <0.8.0"
-  maplibre_gl_platform_interface: ^0.19.0+2
+  maplibre_gl_platform_interface: ^0.20.0
   meta: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
Hi guys, I was trying to run the example application and I noticed that something was going wrong.
Analyzing the problem, I found that the versions of some plugins had not been updated since the new 0.20.0 update in the main branch.

With this PR I updated the versioning of the pubspec.yaml files of example and maplibre_gl_web.

I know it's a simple solution and PR, but useful, also because without it, it isn't possible to run pub gets and the code isn't aligned between folders. Also, it isn't possible to run the example application.