### PR TITLE
setConnected fully impelementation

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -79,8 +79,13 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         result.success(null);
         break;
       case "setOffline":
-        Boolean offline = (Boolean) methodCall.argument("offline");
-        ConnectivityReceiver.instance(context).setConnected(offline!=null ? !(offline) : null);
+        boolean offline = methodCall.argument("offline");
+        ConnectivityReceiver.instance(context).setConnected(offline ? false : null);
+        result.success(null);
+        break;
+      case "setConnected":
+        boolean connected = methodCall.argument("connected");
+        ConnectivityReceiver.instance(context).setConnected(connected ? true : null);
         result.success(null);
         break;
       case "mergeOfflineRegions":

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -79,13 +79,8 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         result.success(null);
         break;
       case "setOffline":
-        boolean offline = methodCall.argument("offline");
-        ConnectivityReceiver.instance(context).setConnected(offline ? false : null);
-        result.success(null);
-        break;
-      case "setConnected":
-        boolean connected = methodCall.argument("connected");
-        ConnectivityReceiver.instance(context).setConnected(connected ? true : null);
+        Boolean offline = (Boolean) methodCall.argument("offline");
+        ConnectivityReceiver.instance(context).setConnected(offline!=null ? !(offline) : null);
         result.success(null);
         break;
       case "mergeOfflineRegions":

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -79,8 +79,8 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         result.success(null);
         break;
       case "setOffline":
-        Boolean offline = methodCall.argument("offline");
-        ConnectivityReceiver.instance(context).setConnected(offline!=null ? !offline : null);
+        boolean offline = methodCall.argument("offline");
+        ConnectivityReceiver.instance(context).setConnected(!offline);
         result.success(null);
         break;
       case "mergeOfflineRegions":

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -79,8 +79,8 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         result.success(null);
         break;
       case "setOffline":
-        boolean offline = methodCall.argument("offline");
-        ConnectivityReceiver.instance(context).setConnected(offline ? false : null);
+        Boolean offline = methodCall.argument("offline");
+        ConnectivityReceiver.instance(context).setConnected(offline!=null ? !offline : null);
         result.success(null);
         break;
       case "mergeOfflineRegions":

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -80,7 +80,12 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         break;
       case "setOffline":
         boolean offline = methodCall.argument("offline");
-        ConnectivityReceiver.instance(context).setConnected(!offline);
+        ConnectivityReceiver.instance(context).setConnected(offline ? false : null);
+        result.success(null);
+        break;
+      case "setConnected":
+        boolean connected = methodCall.argument("connected");
+        ConnectivityReceiver.instance(context).setConnected(connected ? true : null);
         result.success(null);
         break;
       case "mergeOfflineRegions":

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -78,7 +78,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         installOfflineMapTiles(tilesDb);
         result.success(null);
         break;
-      case "setOffline":
+      case "setMapLibreOffline":
         Boolean offline = (Boolean) methodCall.argument("offline");
         ConnectivityReceiver.instance(context).setConnected(offline!=null ? !(offline) : null);
         result.success(null);

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1112,7 +1112,7 @@ class MapLibreMapController extends ChangeNotifier {
   }
 
   Future clearAmbientCache() async {
-    return _maplibrePlatform.clearAmbientCache();
+    return _maplibrePlatform.invalidateAmbientCache();//clearAmbientCache();
   }
 
   /// Get last my location

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -19,12 +19,19 @@ Future<void> installOfflineMapTiles(String tilesDb) async {
 
 enum DragEventType { start, drag, end }
 
-Future<dynamic> setOffline(bool? offline) => _globalChannel.invokeMethod(
+Future<dynamic> setOffline(bool offline) => _globalChannel.invokeMethod(
       'setOffline',
       <String, dynamic>{
         'offline': offline,
       },
     );
+
+Future<dynamic> setConnected(bool connected) => _globalChannel.invokeMethod(
+  'setConnected',
+  <String, dynamic>{
+    'connected': connected,
+  },
+);
 
 Future<void> setHttpHeaders(Map<String, String> headers) {
   return _globalChannel.invokeMethod(

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -19,8 +19,8 @@ Future<void> installOfflineMapTiles(String tilesDb) async {
 
 enum DragEventType { start, drag, end }
 
-Future<dynamic> setOffline(bool? offline) => _globalChannel.invokeMethod(
-      'setOffline',
+Future<dynamic> setMapLibreOffline(bool? offline) => _globalChannel.invokeMethod(
+      'setMapLibreOffline',
       <String, dynamic>{
         'offline': offline,
       },

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -26,6 +26,13 @@ Future<dynamic> setOffline(bool offline) => _globalChannel.invokeMethod(
       },
     );
 
+Future<dynamic> setConnected(bool connected) => _globalChannel.invokeMethod(
+  'setConnected',
+  <String, dynamic>{
+    'connected': connected,
+  },
+);
+
 Future<void> setHttpHeaders(Map<String, String> headers) {
   return _globalChannel.invokeMethod(
     'setHttpHeaders',

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -19,19 +19,12 @@ Future<void> installOfflineMapTiles(String tilesDb) async {
 
 enum DragEventType { start, drag, end }
 
-Future<dynamic> setOffline(bool offline) => _globalChannel.invokeMethod(
+Future<dynamic> setOffline(bool? offline) => _globalChannel.invokeMethod(
       'setOffline',
       <String, dynamic>{
         'offline': offline,
       },
     );
-
-Future<dynamic> setConnected(bool connected) => _globalChannel.invokeMethod(
-  'setConnected',
-  <String, dynamic>{
-    'connected': connected,
-  },
-);
 
 Future<void> setHttpHeaders(Map<String, String> headers) {
   return _globalChannel.invokeMethod(


### PR DESCRIPTION
Globals setOffline function was mapping "false" parameter to null when calling setConnected.
Now it accepts bool? so
null is mapped to null
true is mapped to false
and false is mapped to true. 
This has been done for Android implementation. 
For iOS I didn't find any implementation.