### PR TITLE
Fixed crash on location engine access and location request hang

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -2044,7 +2044,7 @@ final class MapLibreMapController
   }
 
   private void updateMyLocationEnabled() {
-    if (this.locationComponent == null && myLocationEnabled) {
+    if (this.locationComponent == null && mapLibreMap.getStyle() != null && myLocationEnabled) {
       enableLocationComponent(mapLibreMap.getStyle());
     }
 

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -1247,7 +1247,10 @@ final class MapLibreMapController
       case "locationComponent#getLastLocation":
         {
           Log.e(TAG, "location component: getLastLocation");
-          if (this.myLocationEnabled && locationComponent != null) {
+          if (this.myLocationEnabled
+              && locationComponent != null
+              && locationComponent.isLocationComponentActivated()
+              && locationComponent.getLocationEngine() != null) {
             Map<String, Object> reply = new HashMap<>();
 
             mapLibreMap.getLocationComponent().getLocationEngine().getLastLocation(
@@ -2054,6 +2057,7 @@ final class MapLibreMapController
   private void startListeningForLocationUpdates() {
     if (locationEngineCallback == null
         && locationComponent != null
+        && locationComponent.isLocationComponentActivated()
         && locationComponent.getLocationEngine() != null) {
       locationEngineCallback =
           new LocationEngineCallback<LocationEngineResult>() {
@@ -2075,6 +2079,7 @@ final class MapLibreMapController
   private void stopListeningForLocationUpdates() {
     if (locationEngineCallback != null
         && locationComponent != null
+        && locationComponent.isLocationComponentActivated()
         && locationComponent.getLocationEngine() != null) {
       locationComponent.getLocationEngine().removeLocationUpdates(locationEngineCallback);
       locationEngineCallback = null;

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -1273,6 +1273,11 @@ final class MapLibreMapController
                     result.error("", "", null); // ???
                   }
                 });
+          } else {
+            result.error(
+                "LOCATION DISABLED",
+                "Location is disabled or location component is unavailable",
+                null);
           }
           break;
         }


### PR DESCRIPTION
I discovered that in certain cases `getLocationEngine()` can be called even if location component was not activated (possibly if someone tried to activate it before style was loaded), causing an unhandled exception (see https://github.com/maplibre/flutter-maplibre-gl/issues/534). I have no idea why a getter call would ever need to crash, but here we are.

I added `isLocationComponentActivated()` check in every place where `getLocationEngine()` is called. It is not the most elegant solution for sure, but since there are other checks in place it seemed appropriate and allowed me to avoid wrapping the getter in another getter.

I also added missing else branch in `getLastLocation` call handler. I chose "LOCATION DISABLED" as an error code since I could not find any standardized list of error codes. Feel free to suggest alternatives.