### PR TITLE
feat: upgrade FGP & compatible with flutter 3.29.0

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.29.0', '' ]
+        sdk: [ '3.16.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.29.0', '' ]
+        sdk: [ '3.16.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.29.0', '' ]
+        sdk: [ '3.16.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.10.5', '' ]
+        sdk: [ '3.29.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.10.5', '' ]
+        sdk: [ '3.29.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.10.5', '' ]
+        sdk: [ '3.29.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.16.0', '' ]
+        sdk: [ '3.22.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.16.0', '' ]
+        sdk: [ '3.22.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ '3.16.0', '' ]
+        sdk: [ '3.22.0', '' ]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -5,7 +5,7 @@ gradle-wrapper.jar
 /gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
-
+/app/.cxx/
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
 key.properties

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,14 +22,10 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
     namespace "org.maplibre.example"
     compileSdkVersion 34
-    ndkVersion "26.1.10909125"
+    ndkVersion "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 
 allprojects {
     repositories {

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Feb 19 16:20:21 ICT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.2.2" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
+}
+
+include ":app"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0'
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   collection: ^1.17.1

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   collection: ^1.17.1

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   http: ^1.1.0
   location: ^5.0.3
   maplibre_gl: ^0.20.0
-  path_provider: ^2.0.15
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -26,15 +26,9 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
   private static final int BUFFER_SIZE = 1024 * 2;
   @NonNull private final Context context;
   @NonNull private final BinaryMessenger messenger;
-  @Nullable private PluginRegistry.Registrar registrar;
   @Nullable private FlutterPlugin.FlutterAssets flutterAssets;
   @Nullable private OfflineChannelHandlerImpl downloadOfflineRegionChannelHandler;
 
-  GlobalMethodHandler(@NonNull PluginRegistry.Registrar registrar) {
-    this.registrar = registrar;
-    this.context = registrar.activeContext();
-    this.messenger = registrar.messenger();
-  }
 
   GlobalMethodHandler(@NonNull FlutterPlugin.FlutterPluginBinding binding) {
     this.context = binding.getApplicationContext();
@@ -152,9 +146,7 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
       return new FileInputStream(new File(tilesDb));
     } else {
       String assetKey;
-      if (registrar != null) {
-        assetKey = registrar.lookupKeyForAsset(tilesDb);
-      } else if (flutterAssets != null) {
+      if (flutterAssets != null) {
         assetKey = flutterAssets.getAssetFilePathByName(tilesDb);
       } else {
         throw new IllegalStateException();

--- a/maplibre_gl/lib/src/color_tools.dart
+++ b/maplibre_gl/lib/src/color_tools.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 part of '../maplibre_gl.dart';
 
 extension MapLibreColorConversion on Color {

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   flutter:

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   flutter:

--- a/maplibre_gl_web/analysis_options.yaml
+++ b/maplibre_gl_web/analysis_options.yaml
@@ -1,1 +1,6 @@
 include: ../analysis_options.yaml
+
+analyzer:
+  errors:
+    deprecated_member_use: ignore
+    deprecated_member_use_from_same_package: ignore

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 flutter:
   plugin:

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 flutter:
   plugin:


### PR DESCRIPTION
This pull request includes several changes to the Android project setup and dependencies, as well as some code refactoring in the `GlobalMethodHandler` class. The most important changes are grouped by theme and summarized below:

### Android Project Setup:
Upgrade to latest Flutter Gradle plugins configuration:
https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
### Dependency Updates:

* [`example/pubspec.yaml`](diffhunk://#diff-565b0869896732da3b937c64bc8fd5f0ca37ea1f629d579c29fc70e0f1e3e48eL20-R20): Updated the `path_provider` dependency version from `2.0.15` to `2.1.5`.
* Set minimum supported Flutter version to 3.22.0

### Code Refactoring:

* [`maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java`](diffhunk://#diff-9c836abc6c8048cf093a291198c86b17f16530e99328202318c54f9fe1c65c40L29-L37): Removed the `registrar` field and related code, updating the constructor and `openTilesDbFile` method to use `flutterAssets` instead. [[1]](diffhunk://#diff-9c836abc6c8048cf093a291198c86b17f16530e99328202318c54f9fe1c65c40L29-L37) [[2]](diffhunk://#diff-9c836abc6c8048cf093a291198c86b17f16530e99328202318c54f9fe1c65c40L155-R149)