### PR TITLE
remove dart:io import and use UniversalPlatform

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -32,6 +32,28 @@ jobs:
       - name: Lint analysis
         run: melos analyze --fatal-warnings --fatal-infos --concurrency 10
 
+  test:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+      - uses: bluefireteam/melos-action@v3
+      - run: melos test:io
+
+  test-web:
+    name: "Run web tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          cache: true
+      - uses: bluefireteam/melos-action@v3
+      - run: melos test:web
+
   build-android:
     name: "Build Android apk"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .history
 .svn/
 migrate_working_dir/
+build/
 
 # IntelliJ related
 *.iml

--- a/maplibre_gl_platform_interface/lib/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/maplibre_gl_platform_interface.dart
@@ -1,7 +1,6 @@
 library maplibre_gl_platform_interface;
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:convert';
 import 'dart:math';
 import 'package:flutter/foundation.dart';
@@ -9,6 +8,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:universal_platform/universal_platform.dart';
 part 'src/annotation.dart';
 part 'src/callbacks.dart';
 part 'src/camera.dart';

--- a/maplibre_gl_platform_interface/lib/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/maplibre_gl_platform_interface.dart
@@ -2,13 +2,13 @@ library maplibre_gl_platform_interface;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:platform/platform.dart';
 part 'src/annotation.dart';
 part 'src/callbacks.dart';
 part 'src/camera.dart';

--- a/maplibre_gl_platform_interface/lib/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/maplibre_gl_platform_interface.dart
@@ -8,7 +8,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:universal_platform/universal_platform.dart';
+import 'package:platform/platform.dart';
 part 'src/annotation.dart';
 part 'src/callbacks.dart';
 part 'src/camera.dart';

--- a/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
+++ b/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
@@ -15,7 +15,7 @@ class LocationEnginePlatforms {
       LocationEnginePlatforms();
 
   List<int> toList() {
-    if (UniversalPlatform.isAndroid) return androidPlatform.toList();
+    if (const LocalPlatform().isAndroid) return androidPlatform.toList();
     return [];
   }
 }

--- a/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
+++ b/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
@@ -15,7 +15,7 @@ class LocationEnginePlatforms {
       LocationEnginePlatforms();
 
   List<int> toList() {
-    if (Platform.isAndroid) return androidPlatform.toList();
+    if (UniversalPlatform.isAndroid) return androidPlatform.toList();
     return [];
   }
 }

--- a/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
+++ b/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
@@ -15,7 +15,12 @@ class LocationEnginePlatforms {
       LocationEnginePlatforms();
 
   List<int> toList() {
-    if (const LocalPlatform().isAndroid) return androidPlatform.toList();
+    if (kIsWeb) {
+      return [];
+    }
+    if (Platform.isAndroid) {
+      return androidPlatform.toList();
+    }
     return [];
   }
 }

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  universal_platform: ^1.1.0
   flutter:
     sdk: flutter
   meta: ^1.0.5
+  universal_platform: ^1.1.0
 
 dev_dependencies:
   very_good_analysis: ^5.0.0

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  universal_platform: ^1.1.0
+  platform: ^3.1.6
 
 dev_dependencies:
   very_good_analysis: ^5.0.0

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  platform: ^3.1.6
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   very_good_analysis: ^5.0.0

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
+  universal_platform: ^1.1.0
   flutter:
     sdk: flutter
   meta: ^1.0.5

--- a/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_platform_interface/maplibre_gl_platform_interface.dart';
+
+void main() {
+  group(LocationEnginePlatforms, () {
+    test('defaultPlatform.toList() works on all platforms', () {
+      expect(LocationEnginePlatforms.defaultPlatform.toList(), isList);
+    });
+  });
+}

--- a/melos.yaml
+++ b/melos.yaml
@@ -3,3 +3,23 @@ name: maplibre_gl_workspace
 packages:
   - scripts
   - maplibre_gl*
+
+scripts:
+  test:
+    description: Run all tests
+    run: |
+      set -e
+      melos test:io
+      melos test:web
+
+  test:io:
+    description: Run IO tests
+    exec: flutter test
+    packageFilters:
+      scope: maplibre_gl_platform_interface
+
+  test:web:
+    description: Run Web tests
+    exec: flutter test --platform chrome
+    packageFilters:
+      scope: maplibre_gl_platform_interface


### PR DESCRIPTION
Fix #550 

Please add the following to the pubspec.yaml to test it in other projects: 

```
dependencies: 
  # vector map
  maplibre_gl:
    git:
      url: https://github.com/maplibre/flutter-maplibre-gl.git
      ref: 550-bug-unsupported-operation-platform_operatingsystem
      path: maplibre_gl

dependency_overrides:
  maplibre_gl_platform_interface:
    git:
      url: https://github.com/maplibre/flutter-maplibre-gl.git
      ref: 550-bug-unsupported-operation-platform_operatingsystem
      path: maplibre_gl_platform_interface

```