### PR TITLE
Fixed ios crashes related to source and layers changes

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -537,7 +537,8 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             let belowLayerId = arguments["belowLayerId"] as? String
             let minzoom = arguments["minzoom"] as? Double
             let maxzoom = arguments["maxzoom"] as? Double
-            addHillshadeLayer(
+
+            let addResult = addHillshadeLayer(
                 sourceId: sourceId,
                 layerId: layerId,
                 belowLayerId: belowLayerId,
@@ -545,7 +546,11 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 maximumZoomLevel: maxzoom,
                 properties: properties
             )
-            result(nil)
+          
+            switch addResult {
+            case .success: result(nil)
+            case let .failure(error): result(error.flutterError)
+            }
 
         case "heatmapLayer#add":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -555,7 +560,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             let belowLayerId = arguments["belowLayerId"] as? String
             let minzoom = arguments["minzoom"] as? Double
             let maxzoom = arguments["maxzoom"] as? Double
-            addHeatmapLayer(
+            let addResult = addHeatmapLayer(
                 sourceId: sourceId,
                 layerId: layerId,
                 belowLayerId: belowLayerId,
@@ -563,7 +568,10 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 maximumZoomLevel: maxzoom,
                 properties: properties
             )
-            result(nil)
+            switch addResult {
+            case .success: result(nil)
+            case let .failure(error): result(error.flutterError)
+            }
 
         case "rasterLayer#add":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -573,7 +581,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             let belowLayerId = arguments["belowLayerId"] as? String
             let minzoom = arguments["minzoom"] as? Double
             let maxzoom = arguments["maxzoom"] as? Double
-            addRasterLayer(
+            let addResult = addRasterLayer(
                 sourceId: sourceId,
                 layerId: layerId,
                 belowLayerId: belowLayerId,
@@ -581,7 +589,10 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 maximumZoomLevel: maxzoom,
                 properties: properties
             )
-            result(nil)
+            switch addResult {
+            case .success: result(nil)
+            case let .failure(error): result(error.flutterError)
+            }
 
         case "style#addImage":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
@@ -1493,26 +1504,28 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         minimumZoomLevel: Double?,
         maximumZoomLevel: Double?,
         properties: [String: String]
-    ) {
-        if let style = mapView.style {
-            if let source = style.source(withIdentifier: sourceId) {
-                let layer = MLNHillshadeStyleLayer(identifier: layerId, source: source)
-                LayerPropertyConverter.addHillshadeProperties(
-                    hillshadeLayer: layer,
-                    properties: properties
-                )
-                if let minimumZoomLevel = minimumZoomLevel {
-                    layer.minimumZoomLevel = Float(minimumZoomLevel)
-                }
-                if let maximumZoomLevel = maximumZoomLevel {
-                    layer.maximumZoomLevel = Float(maximumZoomLevel)
-                }
-                if let id = belowLayerId, let belowLayer = style.layer(withIdentifier: id) {
-                    style.insertLayer(layer, below: belowLayer)
-                } else {
-                    style.addLayer(layer)
-                }
+    ) -> Result<Void, MethodCallError> {
+        switch validateBeforeLayerAdd(sourceId: sourceId, layerId: layerId) {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let (style, source)):
+            let layer = MLNHillshadeStyleLayer(identifier: layerId, source: source)
+            LayerPropertyConverter.addHillshadeProperties(
+                hillshadeLayer: layer,
+                properties: properties
+            )
+            if let minimumZoomLevel = minimumZoomLevel {
+                layer.minimumZoomLevel = Float(minimumZoomLevel)
             }
+            if let maximumZoomLevel = maximumZoomLevel {
+                layer.maximumZoomLevel = Float(maximumZoomLevel)
+            }
+            if let id = belowLayerId, let belowLayer = style.layer(withIdentifier: id) {
+                style.insertLayer(layer, below: belowLayer)
+            } else {
+                style.addLayer(layer)
+            }
+            return .success(())
         }
     }
 
@@ -1523,26 +1536,28 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         minimumZoomLevel: Double?,
         maximumZoomLevel: Double?,
         properties: [String: String]
-    ) {
-        if let style = mapView.style {
-            if let source = style.source(withIdentifier: sourceId) {
-                let layer = MLNHeatmapStyleLayer(identifier: layerId, source: source)
-                LayerPropertyConverter.addHeatmapProperties(
-                    heatmapLayer: layer,
-                    properties: properties
-                )
-                if let minimumZoomLevel = minimumZoomLevel {
-                    layer.minimumZoomLevel = Float(minimumZoomLevel)
-                }
-                if let maximumZoomLevel = maximumZoomLevel {
-                    layer.maximumZoomLevel = Float(maximumZoomLevel)
-                }
-                if let id = belowLayerId, let belowLayer = style.layer(withIdentifier: id) {
-                    style.insertLayer(layer, below: belowLayer)
-                } else {
-                    style.addLayer(layer)
-                }
+    ) -> Result<Void, MethodCallError> {
+        switch validateBeforeLayerAdd(sourceId: sourceId, layerId: layerId) {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let (style, source)):
+            let layer = MLNHeatmapStyleLayer(identifier: layerId, source: source)
+            LayerPropertyConverter.addHeatmapProperties(
+                heatmapLayer: layer,
+                properties: properties
+            )
+            if let minimumZoomLevel = minimumZoomLevel {
+                layer.minimumZoomLevel = Float(minimumZoomLevel)
             }
+            if let maximumZoomLevel = maximumZoomLevel {
+                layer.maximumZoomLevel = Float(maximumZoomLevel)
+            }
+            if let id = belowLayerId, let belowLayer = style.layer(withIdentifier: id) {
+                style.insertLayer(layer, below: belowLayer)
+            } else {
+                style.addLayer(layer)
+            }
+            return .success(())
         }
     }
 
@@ -1553,26 +1568,28 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         minimumZoomLevel: Double?,
         maximumZoomLevel: Double?,
         properties: [String: String]
-    ) {
-        if let style = mapView.style {
-            if let source = style.source(withIdentifier: sourceId) {
-                let layer = MLNRasterStyleLayer(identifier: layerId, source: source)
-                LayerPropertyConverter.addRasterProperties(
-                    rasterLayer: layer,
-                    properties: properties
-                )
-                if let minimumZoomLevel = minimumZoomLevel {
-                    layer.minimumZoomLevel = Float(minimumZoomLevel)
-                }
-                if let maximumZoomLevel = maximumZoomLevel {
-                    layer.maximumZoomLevel = Float(maximumZoomLevel)
-                }
-                if let id = belowLayerId, let belowLayer = style.layer(withIdentifier: id) {
-                    style.insertLayer(layer, below: belowLayer)
-                } else {
-                    style.addLayer(layer)
-                }
+    )  -> Result<Void, MethodCallError>  {
+        switch validateBeforeLayerAdd(sourceId: sourceId, layerId: layerId) {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let (style, source)):
+            let layer = MLNRasterStyleLayer(identifier: layerId, source: source)
+            LayerPropertyConverter.addRasterProperties(
+                rasterLayer: layer,
+                properties: properties
+            )
+            if let minimumZoomLevel = minimumZoomLevel {
+                layer.minimumZoomLevel = Float(minimumZoomLevel)
             }
+            if let maximumZoomLevel = maximumZoomLevel {
+                layer.maximumZoomLevel = Float(maximumZoomLevel)
+            }
+            if let id = belowLayerId, let belowLayer = style.layer(withIdentifier: id) {
+                style.insertLayer(layer, below: belowLayer)
+            } else {
+                style.addLayer(layer)
+            }
+            return .success(())
         }
     }
 

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MethodCallError.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MethodCallError.swift
@@ -1,33 +1,90 @@
 import Flutter
 
 enum MethodCallError: Error {
+    case genericError(details: String)
     case invalidLayerType(details: String)
+    case invalidSourceType(details: String)
     case invalidExpression
+    case sourceNotFound(sourceId: String)
+    case layerNotFound(layerId: String)
+    case styleNotFound
+    case sourceAlreadyExists(sourceId: String)
+    case layerAlreadyExists(layerId: String)
+    case geojsonParseError(sourceId: String)
 
     var code: String {
         switch self {
+        case .genericError:
+            return "genericError"
         case .invalidLayerType:
             return "invalidLayerType"
+        case .invalidSourceType:
+            return "invalidSourceType"
         case .invalidExpression:
             return "invalidExpression"
+        case .sourceNotFound:
+            return "sourceNotFound"
+        case .layerNotFound:
+            return "layerNotFound"
+        case .styleNotFound:
+            return "styleNotFound"
+        case .sourceAlreadyExists:
+            return "sourceAlreadyExists"
+        case .layerAlreadyExists:
+            return "layerAlreadyExists"
+        case .geojsonParseError:
+            return "parseError"
+
         }
     }
 
     var message: String {
         switch self {
+        case .genericError:
+            return "Generic error"
         case .invalidLayerType:
             return "Invalid layer type"
+        case .invalidSourceType:
+            return "Invalid source type"
         case .invalidExpression:
             return "Invalid expression"
+        case .sourceNotFound:
+            return "Source not found"
+        case .layerNotFound:
+            return "Layer not found"
+        case .styleNotFound:
+            return "Style not found"
+        case .sourceAlreadyExists:
+            return "Source already exists"
+        case .layerAlreadyExists:
+            return "Layer already exists"
+        case .geojsonParseError:
+            return "Geojson parse error"
         }
     }
 
     var details: String {
         switch self {
+        case let .genericError(details):
+            return details
         case let .invalidLayerType(details):
+            return details
+        case let .invalidSourceType(details):
             return details
         case .invalidExpression:
             return "Could not parse expression."
+        case let .sourceNotFound(sourceId):
+            return "Source with id \(sourceId) not found."
+        case let .layerNotFound(layerId):
+            return "Layer with id \(layerId) not found."
+        case .styleNotFound:
+            return "Style not found."
+        case let .sourceAlreadyExists(sourceId):
+            return "Source with id \(sourceId) already exists."
+        case let .layerAlreadyExists(layerId):
+            return "Layer with id \(layerId) already exists."
+        case let .geojsonParseError(sourceId):
+            return "Geojson parse error for source with id \(sourceId)."
         }
     }
 


### PR DESCRIPTION
This PR addresses several crashes that occurred when attempting to add layers and sources that already exist.


The fix introduces appropriate guard statements and ensures that errors are correctly propagated to the Flutter layer when necessary.

Previously, such issues would result in a crash. With this change, they now raise a platform exception instead.