### PR TITLE
fixed inconsistencies with style loading on web

### DIFF
--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -73,7 +73,7 @@ class MapLibreMapController extends MapLibrePlatform
           attributionControl: false, //avoid duplicate control
         ),
       );
-      _map.on('load', _onStyleLoaded);
+      _map.on('style.load', _onStyleLoaded);
       _map.on('click', _onMapClick);
       // long click not available in web, so it is mapped to double click
       _map.on('dblclick', _onMapLongClick);
@@ -417,6 +417,13 @@ class MapLibreMapController extends MapLibrePlatform
   }
 
   void _onStyleLoaded(_) {
+    final loaded = _map.isStyleLoaded();
+    if (!loaded) {
+      Future.delayed(const Duration(milliseconds: 100), () {
+        _onStyleLoaded(_);
+      });
+      return;
+    }
     _mapReady = true;
     _onMapResize();
     onMapStyleLoadedPlatform(null);
@@ -702,11 +709,7 @@ class MapLibreMapController extends MapLibrePlatform
     }
     _interactiveFeatureLayerIds.clear();
 
-    _map.setStyle(styleString);
-    // catch style loaded for later style changes
-    if (_mapReady) {
-      _map.once("styledata", _onStyleLoaded);
-    }
+    _map.setStyle(styleString, {'diff': false});
   }
 
   @override

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -6,7 +6,6 @@ class MapLibreMapController extends MapLibrePlatform
 
   late Map<String, dynamic> _creationParams;
   late MapLibreMap _map;
-  bool _mapReady = false;
   dynamic _draggedFeatureId;
   LatLng? _dragOrigin;
   LatLng? _dragPrevious;
@@ -424,7 +423,6 @@ class MapLibreMapController extends MapLibrePlatform
       });
       return;
     }
-    _mapReady = true;
     _onMapResize();
     onMapStyleLoadedPlatform(null);
   }

--- a/maplibre_gl_web/lib/src/ui/map.dart
+++ b/maplibre_gl_web/lib/src/ui/map.dart
@@ -495,7 +495,7 @@ class MapLibreMap extends Camera {
   ///  @returns {MapLibreMap} `this`
   ///  @see [Change a map's style](https://maplibre.org/maplibre-gl-js/docs/examples/setstyle/)
   MapLibreMap setStyle(dynamic style, [dynamic options]) =>
-      MapLibreMap.fromJsObject(jsObject.setStyle(style));
+      MapLibreMap.fromJsObject(jsObject.setStyle(style, jsify(options)));
 
   ///  Returns the map's MapLibre style object, which can be used to recreate the map's style.
   ///


### PR DESCRIPTION
This PR addresses long-standing issues with inconsistent style loading behavior between the native and web platforms, both in this repo and the original library.

On the web, style updates are applied incrementally—only the parts that have changed are updated. In contrast, the native side performs full style replacements. This mismatch has led to divergent runtime behavior and visual inconsistencies between the platforms.

Compounding this, the web implementation inconsistently triggers the onStyleLoaded callback. This can lead to scenarios where outdated style components remain active even after a new style is supposed to be fully loaded.

As a workaround, this PR adds a polling mechanism that verifies the style has actually finished loading before notifying the Flutter side via the callback.