### PR TITLE
fixed issue with string object ids

### DIFF
--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -311,7 +311,7 @@ class MapLibreMapController extends MapLibrePlatform
         ], options)
         .map((feature) => {
               'type': 'Feature',
-              'id': feature.id as int?,
+              'id': feature.id,
               'geometry': {
                 'type': feature.geometry.type,
                 'coordinates': feature.geometry.coordinates,


### PR DESCRIPTION
queryRenderedFeaturesInRect doesnt support string feature ids on web. This fixes this issue.