### PR TITLE
feat(android,ios): Implement SSL Bypass and Unified Header Configuration

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/GlobalMethodHandler.java
@@ -88,6 +88,10 @@ class GlobalMethodHandler implements MethodChannel.MethodCallHandler {
         Map<String, String> headers = (Map<String, String>) methodCall.argument("headers");
         MapLibreHttpRequestUtil.setHttpHeaders(headers, result);
         break;
+      case "setSslCertificateBypass":
+        boolean enabled = methodCall.argument("enabled");
+        MapLibreHttpRequestUtil.setSslCertificateBypass(enabled, result);
+        break;
       case "downloadOfflineRegion#setup":
         String channelName = methodCall.argument("channelName");
         // Prepare args

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreHttpRequestUtil.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreHttpRequestUtil.java
@@ -5,33 +5,92 @@ import io.flutter.plugin.common.MethodChannel;
 import java.util.Map;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.SecureRandom;
+import java.util.HashMap;
 
 abstract class MapLibreHttpRequestUtil {
+  private static boolean sslCertificateBypassEnabled = false;
+  private static Map<String, String> currentHeaders = new HashMap<>();
 
   public static void setHttpHeaders(Map<String, String> headers, MethodChannel.Result result) {
+    currentHeaders.clear();
+    currentHeaders.putAll(headers);
     HttpRequestUtil.setOkHttpClient(getOkHttpClient(headers, result).build());
+    result.success(null);
+  }
+
+  public static void setSslCertificateBypass(boolean enabled, MethodChannel.Result result) {
+    sslCertificateBypassEnabled = enabled;
+    // Apply changes immediately by rebuilding the OkHttpClient with the current headers
+    HttpRequestUtil.setOkHttpClient(getOkHttpClient(currentHeaders, result).build());
     result.success(null);
   }
 
   private static OkHttpClient.Builder getOkHttpClient(
       Map<String, String> headers, MethodChannel.Result result) {
     try {
-      return new OkHttpClient.Builder()
-          .addNetworkInterceptor(
-              chain -> {
-                Request.Builder builder = chain.request().newBuilder();
-                for (Map.Entry<String, String> header : headers.entrySet()) {
-                  if (header.getKey() == null || header.getKey().trim().isEmpty()) {
-                    continue;
-                  }
-                  if (header.getValue() == null || header.getValue().trim().isEmpty()) {
-                    builder.removeHeader(header.getKey());
-                  } else {
-                    builder.header(header.getKey(), header.getValue());
-                  }
-                }
-                return chain.proceed(builder.build());
-              });
+      OkHttpClient.Builder builder = new OkHttpClient.Builder();
+      
+      if (sslCertificateBypassEnabled) {
+        // Create a trust manager that does not validate certificate chains
+        final TrustManager[] trustAllCerts = new TrustManager[] {
+          new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+              return new X509Certificate[]{};
+            }
+          }
+        };
+
+        // Install the all-trusting trust manager
+        final SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(null, trustAllCerts, new SecureRandom());
+        
+        // Create an ssl socket factory with our all-trusting manager
+        final HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+          @Override
+          public boolean verify(String hostname, SSLSession session) {
+            return true;
+          }
+        };
+
+        builder.sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager)trustAllCerts[0])
+              .hostnameVerifier(hostnameVerifier);
+      }
+
+      // Add network interceptor for headers
+      builder.addNetworkInterceptor(
+          chain -> {
+            Request.Builder requestBuilder = chain.request().newBuilder();
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+              if (header.getKey() == null || header.getKey().trim().isEmpty()) {
+                continue;
+              }
+              if (header.getValue() == null || header.getValue().trim().isEmpty()) {
+                requestBuilder.removeHeader(header.getKey());
+              } else {
+                requestBuilder.header(header.getKey(), header.getValue());
+              }
+            }
+            return chain.proceed(requestBuilder.build());
+          });
+          
+      return builder;
     } catch (Exception e) {
       result.error(
           "OK_HTTP_CLIENT_ERROR",

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapsPlugin.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapsPlugin.swift
@@ -29,9 +29,20 @@ public class MapLibreMapsPlugin: NSObject, FlutterPlugin {
                     result(nil)
                     return
                 }
-                let sessionConfig = URLSessionConfiguration.default
-                sessionConfig.httpAdditionalHeaders = headers // your headers here
-                MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
+                NetworkConfiguration.shared.configureHeaders(headers)
+                result(nil)
+            case "setSslCertificateBypass":
+                guard let arguments = methodCall.arguments as? [String: Any],
+                      let enabled = arguments["enabled"] as? Bool
+                else {
+                    result(FlutterError(
+                        code: "setSslCertificateBypassError",
+                        message: "could not decode arguments",
+                        details: nil
+                    ))
+                    return
+                }
+                NetworkConfiguration.shared.configureSSLValidation(enabled: enabled)
                 result(nil)
             case "installOfflineMapTiles":
                 guard let arguments = methodCall.arguments as? [String: String] else { return }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/NetworkConfiguration.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/NetworkConfiguration.swift
@@ -36,7 +36,7 @@ class NetworkConfiguration {
     /// - Parameter headers: Dictionary of HTTP headers to be added to all requests
     func configureHeaders(_ headers: [String: String]) {
         print("🌐 NetworkConfiguration: configureHeaders called with headers=\(headers)")
-        currentHeaders = headers
+        currentHeaders.merge(headers, uniquingKeysWith: { $1 })
         updateNetworkConfiguration()
         print("🌐 NetworkConfiguration: Headers configuration completed")
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/NetworkConfiguration.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/NetworkConfiguration.swift
@@ -6,52 +6,34 @@ class NetworkConfiguration {
     /// Singleton instance
     static let shared = NetworkConfiguration()
     
-    private init() {
-        print("🌐 NetworkConfiguration: Singleton initialized")
-    }
+    private init() {}
     
     // Store current headers
-    private var currentHeaders: [String: String] = [:] {
-        didSet {
-            print("🌐 NetworkConfiguration: Headers updated - \(currentHeaders)")
-        }
-    }
+    private var currentHeaders: [String: String] = [:]
+
     // Store SSL bypass state
-    private var isSSLValidationBypassed = false {
-        didSet {
-            print("🌐 NetworkConfiguration: SSL bypass state changed to \(isSSLValidationBypassed)")
-        }
-    }
+    private var isSSLValidationBypassed = false
     
     /// Configures SSL certificate validation
     /// - Parameter enabled: When true, SSL certificate validation is bypassed
     func configureSSLValidation(enabled: Bool) {
-        print("🌐 NetworkConfiguration: configureSSLValidation called with enabled=\(enabled)")
         isSSLValidationBypassed = enabled
         updateNetworkConfiguration()
-        print("🌐 NetworkConfiguration: SSL validation configuration completed")
     }
     
     /// Configures HTTP headers for all requests
     /// - Parameter headers: Dictionary of HTTP headers to be added to all requests
     func configureHeaders(_ headers: [String: String]) {
-        print("🌐 NetworkConfiguration: configureHeaders called with headers=\(headers)")
         currentHeaders.merge(headers, uniquingKeysWith: { $1 })
         updateNetworkConfiguration()
-        print("🌐 NetworkConfiguration: Headers configuration completed")
     }
     
     /// Updates network configuration while maintaining both SSL bypass state and headers
     private func updateNetworkConfiguration() {
-        print("🌐 NetworkConfiguration: updateNetworkConfiguration started")
-        print("🌐 NetworkConfiguration: Current state - SSL bypass: \(isSSLValidationBypassed), Headers: \(currentHeaders)")
-        
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.httpAdditionalHeaders = currentHeaders
-        print("🌐 NetworkConfiguration: URLSessionConfiguration created with headers")
         
         if isSSLValidationBypassed {
-            print("🌐 NetworkConfiguration: Creating URLSession with SSL bypass delegate")
             // Create a URLSession with SSL bypass delegate
             let session = URLSession(
                 configuration: sessionConfig,
@@ -61,29 +43,16 @@ class NetworkConfiguration {
             
             // Store the session in a static property to prevent it from being deallocated
             NetworkConfiguration.sslBypassSession = session
-            print("🌐 NetworkConfiguration: SSL bypass session created and stored")
         } else {
-            print("🌐 NetworkConfiguration: Resetting to default configuration")
             // Reset to default configuration but keep headers
             NetworkConfiguration.sslBypassSession = nil
-            print("🌐 NetworkConfiguration: SSL bypass session cleared")
         }
         
         MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
-        print("🌐 NetworkConfiguration: MLNNetworkConfiguration.sharedManager updated")
-        print("🌐 NetworkConfiguration: updateNetworkConfiguration completed")
     }
     
     // Keep a strong reference to the SSL bypass session
-    private static var sslBypassSession: URLSession? {
-        didSet {
-            if sslBypassSession != nil {
-                print("🌐 NetworkConfiguration: sslBypassSession assigned")
-            } else {
-                print("🌐 NetworkConfiguration: sslBypassSession cleared")
-            }
-        }
-    }
+    private static var sslBypassSession: URLSession?
 }
 
 /// URLSessionDelegate that handles SSL certificate validation
@@ -92,7 +61,6 @@ private class SSLBypassDelegate: NSObject, URLSessionDelegate {
     
     private override init() {
         super.init()
-        print("🔒 SSLBypassDelegate: Singleton initialized")
     }
     
     func urlSession(
@@ -100,18 +68,11 @@ private class SSLBypassDelegate: NSObject, URLSessionDelegate {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        print("🔒 SSLBypassDelegate: URL session challenge received")
-        print("🔒 SSLBypassDelegate: Challenge protection space: \(challenge.protectionSpace)")
-        print("🔒 SSLBypassDelegate: Authentication method: \(challenge.protectionSpace.authenticationMethod)")
-        
         if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
            let serverTrust = challenge.protectionSpace.serverTrust {
-            print("🔒 SSLBypassDelegate: Server trust challenge detected, bypassing SSL validation")
             let credential = URLCredential(trust: serverTrust)
             completionHandler(.useCredential, credential)
-            print("🔒 SSLBypassDelegate: SSL bypass credential provided")
         } else {
-            print("🔒 SSLBypassDelegate: Non-server trust challenge, using default handling")
             completionHandler(.performDefaultHandling, nil)
         }
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/NetworkConfiguration.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/NetworkConfiguration.swift
@@ -1,0 +1,118 @@
+import Foundation
+import MapLibre
+
+/// Handles network configuration for MapLibre, including SSL certificate validation
+class NetworkConfiguration {
+    /// Singleton instance
+    static let shared = NetworkConfiguration()
+    
+    private init() {
+        print("🌐 NetworkConfiguration: Singleton initialized")
+    }
+    
+    // Store current headers
+    private var currentHeaders: [String: String] = [:] {
+        didSet {
+            print("🌐 NetworkConfiguration: Headers updated - \(currentHeaders)")
+        }
+    }
+    // Store SSL bypass state
+    private var isSSLValidationBypassed = false {
+        didSet {
+            print("🌐 NetworkConfiguration: SSL bypass state changed to \(isSSLValidationBypassed)")
+        }
+    }
+    
+    /// Configures SSL certificate validation
+    /// - Parameter enabled: When true, SSL certificate validation is bypassed
+    func configureSSLValidation(enabled: Bool) {
+        print("🌐 NetworkConfiguration: configureSSLValidation called with enabled=\(enabled)")
+        isSSLValidationBypassed = enabled
+        updateNetworkConfiguration()
+        print("🌐 NetworkConfiguration: SSL validation configuration completed")
+    }
+    
+    /// Configures HTTP headers for all requests
+    /// - Parameter headers: Dictionary of HTTP headers to be added to all requests
+    func configureHeaders(_ headers: [String: String]) {
+        print("🌐 NetworkConfiguration: configureHeaders called with headers=\(headers)")
+        currentHeaders = headers
+        updateNetworkConfiguration()
+        print("🌐 NetworkConfiguration: Headers configuration completed")
+    }
+    
+    /// Updates network configuration while maintaining both SSL bypass state and headers
+    private func updateNetworkConfiguration() {
+        print("🌐 NetworkConfiguration: updateNetworkConfiguration started")
+        print("🌐 NetworkConfiguration: Current state - SSL bypass: \(isSSLValidationBypassed), Headers: \(currentHeaders)")
+        
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.httpAdditionalHeaders = currentHeaders
+        print("🌐 NetworkConfiguration: URLSessionConfiguration created with headers")
+        
+        if isSSLValidationBypassed {
+            print("🌐 NetworkConfiguration: Creating URLSession with SSL bypass delegate")
+            // Create a URLSession with SSL bypass delegate
+            let session = URLSession(
+                configuration: sessionConfig,
+                delegate: SSLBypassDelegate.shared,
+                delegateQueue: nil
+            )
+            
+            // Store the session in a static property to prevent it from being deallocated
+            NetworkConfiguration.sslBypassSession = session
+            print("🌐 NetworkConfiguration: SSL bypass session created and stored")
+        } else {
+            print("🌐 NetworkConfiguration: Resetting to default configuration")
+            // Reset to default configuration but keep headers
+            NetworkConfiguration.sslBypassSession = nil
+            print("🌐 NetworkConfiguration: SSL bypass session cleared")
+        }
+        
+        MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
+        print("🌐 NetworkConfiguration: MLNNetworkConfiguration.sharedManager updated")
+        print("🌐 NetworkConfiguration: updateNetworkConfiguration completed")
+    }
+    
+    // Keep a strong reference to the SSL bypass session
+    private static var sslBypassSession: URLSession? {
+        didSet {
+            if sslBypassSession != nil {
+                print("🌐 NetworkConfiguration: sslBypassSession assigned")
+            } else {
+                print("🌐 NetworkConfiguration: sslBypassSession cleared")
+            }
+        }
+    }
+}
+
+/// URLSessionDelegate that handles SSL certificate validation
+private class SSLBypassDelegate: NSObject, URLSessionDelegate {
+    static let shared = SSLBypassDelegate()
+    
+    private override init() {
+        super.init()
+        print("🔒 SSLBypassDelegate: Singleton initialized")
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        print("🔒 SSLBypassDelegate: URL session challenge received")
+        print("🔒 SSLBypassDelegate: Challenge protection space: \(challenge.protectionSpace)")
+        print("🔒 SSLBypassDelegate: Authentication method: \(challenge.protectionSpace.authenticationMethod)")
+        
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+           let serverTrust = challenge.protectionSpace.serverTrust {
+            print("🔒 SSLBypassDelegate: Server trust challenge detected, bypassing SSL validation")
+            let credential = URLCredential(trust: serverTrust)
+            completionHandler(.useCredential, credential)
+            print("🔒 SSLBypassDelegate: SSL bypass credential provided")
+        } else {
+            print("🔒 SSLBypassDelegate: Non-server trust challenge, using default handling")
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+} 

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -35,6 +35,20 @@ Future<void> setHttpHeaders(Map<String, String> headers) {
   );
 }
 
+/// Enable or disable SSL certificate validation
+///
+/// When enabled (true), the app will bypass SSL certificate validation,
+/// which is useful for handling self-signed certificates or certificate issues.
+/// This should only be used in development or with trusted sources.
+Future<void> setSslCertificateBypass(bool enabled) {
+  return _globalChannel.invokeMethod(
+    'setSslCertificateBypass',
+    <String, dynamic>{
+      'enabled': enabled,
+    },
+  );
+}
+
 Future<List<OfflineRegion>> mergeOfflineRegions(String path) async {
   final String regionsJson = await _globalChannel.invokeMethod(
     'mergeOfflineRegions',

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  maplibre_gl_platform_interface: ^0.22.0
-  maplibre_gl_web: ^0.22.0
+  maplibre_gl_platform_interface: ^0.21.0
+  maplibre_gl_web: ^0.21.0
 
 dev_dependencies:
   very_good_analysis: ^5.0.0


### PR DESCRIPTION
This pull request enhances the network configuration capabilities for both Android and iOS platforms by introducing SSL certificate validation bypass and improving how HTTP headers are managed.

### Key Changes:

#### **Cross-Platform:**

*   **SSL Validation Bypass:** Introduced the ability to disable SSL certificate validation. This is particularly useful for development environments that use self-signed certificates. The feature is managed through a native method call and can be enabled or disabled at runtime.

#### **Android Implementation (`MapLibreHttpRequestUtil.java`):**

*   A new `MapLibreHttpRequestUtil` class now handles the creation of a custom `OkHttpClient`.
*   When SSL bypass is enabled, a custom `X509TrustManager` and `HostnameVerifier` are installed to trust all certificates and hosts.
*   The `setHttpHeaders` method has been updated to apply headers to all outgoing requests via a network interceptor. It currently replaces existing headers with the new set provided.

#### **iOS Implementation (`NetworkConfiguration.swift`):**

*   A new `NetworkConfiguration` singleton manages `URLSession` configurations.
*   When SSL bypass is enabled, a custom `URLSessionDelegate` is used to handle and accept server trust authentication challenges.
*   The `configureHeaders(_:)` method has been improved to **merge** new headers with any existing ones, ensuring that previously set headers are preserved.
*   Network settings are updated atomically, applying both SSL and header configurations at the same time.