### PR TITLE
properly set the locationEngine

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/LocationEngineFactory.kt
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/LocationEngineFactory.kt
@@ -1,0 +1,38 @@
+package org.maplibre.maplibregl
+
+import android.content.Context
+import org.maplibre.android.location.LocationComponent
+import org.maplibre.android.location.engine.LocationEngine
+import org.maplibre.android.location.engine.LocationEngineDefault.getDefaultLocationEngine
+import org.maplibre.android.location.engine.LocationEngineProxy
+import org.maplibre.android.location.engine.LocationEngineRequest
+
+class LocationEngineFactory {
+
+    private var locationEngineRequest: LocationEngineRequest? = null
+
+    fun getLocationEngine(context: Context): LocationEngine {
+        if (locationEngineRequest?.priority == LocationEngineRequest.PRIORITY_HIGH_ACCURACY) {
+            return LocationEngineProxy(
+                MapLibreGPSLocationEngine(context)
+            )
+        }
+        return getDefaultLocationEngine(context)
+    }
+
+    fun initLocationComponent(
+        context: Context,
+        locationComponent: LocationComponent?,
+        locationEngineRequest: LocationEngineRequest?
+    ) {
+        if (locationEngineRequest != null) {
+            this.locationEngineRequest = locationEngineRequest
+        }
+        if (locationComponent != null) {
+            locationComponent.locationEngine = getLocationEngine(context)
+            locationEngineRequest?.let { locationEngineRequest ->
+                locationComponent.locationEngineRequest = locationEngineRequest
+            }
+        }
+    }
+}

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -17,30 +17,24 @@ import android.location.Location;
 import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.Pair;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.TextureView;
 import android.view.View;
 import android.widget.FrameLayout;
-import android.util.Pair;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
-import org.maplibre.android.gestures.AndroidGesturesManager;
-import org.maplibre.android.gestures.MoveGestureDetector;
-import org.maplibre.android.location.engine.LocationEngine;
-import org.maplibre.android.location.engine.LocationEngineDefault;
-import org.maplibre.android.location.engine.LocationEngineProxy;
-import org.maplibre.android.location.engine.LocationEngineRequest;
-import org.maplibre.geojson.Feature;
-import org.maplibre.geojson.FeatureCollection;
+import org.jetbrains.annotations.NotNull;
 import org.maplibre.android.camera.CameraPosition;
 import org.maplibre.android.camera.CameraUpdate;
 import org.maplibre.android.camera.CameraUpdateFactory;
@@ -49,17 +43,20 @@ import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.geometry.LatLngBounds;
 import org.maplibre.android.geometry.LatLngQuad;
 import org.maplibre.android.geometry.VisibleRegion;
+import org.maplibre.android.gestures.AndroidGesturesManager;
+import org.maplibre.android.gestures.MoveGestureDetector;
 import org.maplibre.android.location.LocationComponent;
 import org.maplibre.android.location.LocationComponentActivationOptions;
 import org.maplibre.android.location.LocationComponentOptions;
 import org.maplibre.android.location.OnCameraTrackingChangedListener;
 import org.maplibre.android.location.engine.LocationEngineCallback;
+import org.maplibre.android.location.engine.LocationEngineRequest;
 import org.maplibre.android.location.engine.LocationEngineResult;
 import org.maplibre.android.location.modes.CameraMode;
 import org.maplibre.android.location.modes.RenderMode;
-import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.MapLibreMapOptions;
+import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.OnMapReadyCallback;
 import org.maplibre.android.maps.Style;
 import org.maplibre.android.offline.OfflineManager;
@@ -72,20 +69,18 @@ import org.maplibre.android.style.layers.HillshadeLayer;
 import org.maplibre.android.style.layers.Layer;
 import org.maplibre.android.style.layers.LineLayer;
 import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.layers.PropertyValue;
 import org.maplibre.android.style.layers.RasterLayer;
 import org.maplibre.android.style.layers.SymbolLayer;
-import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.sources.CustomGeometrySource;
 import org.maplibre.android.style.sources.GeoJsonSource;
 import org.maplibre.android.style.sources.ImageSource;
 import org.maplibre.android.style.sources.Source;
 import org.maplibre.android.style.sources.VectorSource;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 
-import io.flutter.plugin.common.BinaryMessenger;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.platform.PlatformView;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -97,6 +92,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.platform.PlatformView;
 
 
 /** Controller of a single MapLibreMaps MapView instance. */
@@ -132,6 +132,7 @@ final class MapLibreMapController
   private boolean myLocationEnabled = false;
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;
+  private LocationEngineFactory myLocationEngineFactory = new LocationEngineFactory();
   private boolean disposed = false;
   private boolean dragEnabled = true;
   private MethodChannel.Result mapReadyResult;
@@ -299,6 +300,7 @@ final class MapLibreMapController
               LocationComponentActivationOptions
                       .builder(context, style)
                       .locationComponentOptions(buildLocationComponentOptions(style))
+                      .locationEngine(myLocationEngineFactory.getLocationEngine(context))
                       .build();
 
       locationComponent.activateLocationComponent(options);
@@ -680,7 +682,6 @@ final class MapLibreMapController
 
   @Override
   public void onMethodCall(MethodCall call, MethodChannel.Result result) {
-
     switch (call.method) {
       case "map#waitForMap":
         if (mapLibreMap != null) {
@@ -1877,17 +1878,8 @@ final class MapLibreMapController
   }
 
   @Override
-  public void setLocationEngineProperties(LocationEngineRequest locationEngineRequest){
-    if(locationComponent != null){
-        if(locationEngineRequest.getPriority() == LocationEngineRequest.PRIORITY_HIGH_ACCURACY){
-            locationComponent.setLocationEngine(new LocationEngineProxy(
-                new MapLibreGPSLocationEngine(context)));
-     } else {
-       locationComponent.setLocationEngine(
-               LocationEngineDefault.INSTANCE.getDefaultLocationEngine(context));
-            }
-      locationComponent.setLocationEngineRequest(locationEngineRequest);
-    }
+  public void setLocationEngineProperties(@NotNull LocationEngineRequest locationEngineRequest) {
+    myLocationEngineFactory.initLocationComponent(context, locationComponent, locationEngineRequest);
   }
 
   @Override


### PR DESCRIPTION
this will fix #571 

this commit will set the locationEngine on enableLocationComponent.

the problem was, that when calling `setLocationEngineProperties`, `locationComponent` is always null. This will properly add the engine whenever the location component is set. 