### PR TITLE
Make layerId parameter nullable in onFeatureTapped callbacks

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -56,7 +56,7 @@ abstract class AnnotationManager<T extends Annotation> {
   }
 
   _onFeatureTapped(
-      dynamic id, Point<double> point, LatLng coordinates, String layerId) {
+      dynamic id, Point<double> point, LatLng coordinates, String? layerId) {
     final annotation = _idToAnnotation[id];
     if (annotation != null) {
       onTap!(annotation);

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -8,7 +8,7 @@ typedef OnMapClickCallback = void Function(
     Point<double> point, LatLng coordinates);
 
 typedef OnFeatureInteractionCallback = void Function(
-    dynamic id, Point<double> point, LatLng coordinates, String layerId);
+    dynamic id, Point<double> point, LatLng coordinates, String? layerId);
 
 typedef OnFeatureDragnCallback = void Function(dynamic id,
     {required Point<double> point,


### PR DESCRIPTION
Updated the layerId parameter in feature interaction callbacks to be nullable (String?) in both annotation_manager.dart and controller.dart. This change improves type safety and handles the case where web returns null for this.

v0.21 was throwing the following error on web with the recent change to the onFeatureTapped callback that added the layerId argument:

```
DartError: TypeError: null: type 'Null' is not a subtype of type 'String'
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 288:3       throw_
errors.dart:288
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 110:39                 _failedAsCheck
profile.dart:110
dart-sdk/lib/_internal/js_shared/lib/rti.dart 1383:3                              _generalAsCheckImplementation
rti.dart:1383
packages/maplibre_gl/src/controller.dart 96:54                                    <fn>
controller.dart:96
packages/maplibre_gl_platform_interface/src/callbacks.dart 28:18                  call
callbacks.dart:28
packages/maplibre_gl_web/src/maplibre_web_gl_platform.dart 450:30                 [_onMapClick]
maplibre_web_gl_platform.dart:450
packages/maplibre_gl_web/src/util/evented.dart 69:13                              <fn>
evented.dart:69
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 419:37  _checkAndCall
operations.dart:419
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 110:39                 dcall
profile.dart:110
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 110:39                 ret
profile.dart:110
https://unpkg.com/maplibre-gl@%5E4.3/dist/maplibre-gl.js 42:9476                  fire
https://unpkg.com/maplibre-gl@%5E4.3/dist/maplibre-gl.js 46:298926                click
https://unpkg.com/maplibre-gl@%5E4.3/dist/maplibre-gl.js 46:322320                handleEvent
```