### PR TITLE
fix: make texture view transparent to match behaviour in web and iOS

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
@@ -16,7 +16,7 @@ import io.flutter.plugin.common.BinaryMessenger;
 class MapLibreMapBuilder implements MapLibreMapOptionsSink {
   public final String TAG = getClass().getSimpleName();
   private final MapLibreMapOptions options =
-      new MapLibreMapOptions().attributionEnabled(true).logoEnabled(false).textureMode(true);
+      new MapLibreMapOptions().attributionEnabled(true).logoEnabled(false).textureMode(true).translucentTextureSurface(true);
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;
   private boolean dragEnabled = true;


### PR DESCRIPTION
My usecase involves displaying multiple maplibre widgets in a stack. Therfore the overlaying maplibre widgets must be transparent in order to see the other maps.

While using iOS or Web, the background is transparent by default (if you add the matching background layer). But under Android, the transparent layer always results in a black background.

To match the behaviour this PR enables texture view transparency by default for Android.