### PR TITLE
Expose annotation drag

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -8,6 +8,9 @@ abstract class AnnotationManager<T extends Annotation> {
   /// Called if a annotation is tapped
   final void Function(T)? onTap;
 
+  /// Called if a annotation is dragged
+  final void Function(T)? onDrag;
+
   /// base id of the manager. User [layerdIds] to get the actual ids.
   final String id;
 
@@ -29,9 +32,13 @@ abstract class AnnotationManager<T extends Annotation> {
 
   Set<T> get annotations => _idToAnnotation.values.toSet();
 
-  AnnotationManager(this.controller,
-      {this.onTap, this.selectLayer, required this.enableInteraction})
-      : id = getRandomString() {
+  AnnotationManager(
+    this.controller, {
+    this.onTap,
+    this.onDrag,
+    this.selectLayer,
+    required this.enableInteraction,
+  }) : id = getRandomString() {
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
       controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
@@ -144,6 +151,7 @@ abstract class AnnotationManager<T extends Annotation> {
       required DragEventType eventType}) {
     final annotation = byId(id);
     if (annotation != null) {
+      onDrag?.call(annotation);
       annotation.translate(delta);
       set(annotation);
     }
@@ -169,8 +177,12 @@ abstract class AnnotationManager<T extends Annotation> {
 }
 
 class LineManager extends AnnotationManager<Line> {
-  LineManager(super.controller, {super.onTap, super.enableInteraction = true})
-      : super(
+  LineManager(
+    super.controller, {
+    super.onTap,
+    super.onDrag,
+    super.enableInteraction = true,
+  }) : super(
           selectLayer: (Line line) => line.options.linePattern == null ? 0 : 1,
         );
 
@@ -196,6 +208,7 @@ class FillManager extends AnnotationManager<Fill> {
   FillManager(
     super.controller, {
     super.onTap,
+    super.onDrag,
     super.enableInteraction = true,
   }) : super(
           selectLayer: (Fill fill) => fill.options.fillPattern == null ? 0 : 1,
@@ -221,6 +234,7 @@ class CircleManager extends AnnotationManager<Circle> {
   CircleManager(
     super.controller, {
     super.onTap,
+    super.onDrag,
     super.enableInteraction = true,
   });
 
@@ -242,6 +256,7 @@ class SymbolManager extends AnnotationManager<Symbol> {
   SymbolManager(
     super.controller, {
     super.onTap,
+    super.onDrag,
     bool iconAllowOverlap = false,
     bool textAllowOverlap = false,
     bool iconIgnorePlacement = false,

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -136,19 +136,33 @@ class MapLibreMapController extends ChangeNotifier {
         final enableInteraction = interactionEnabled.contains(type);
         switch (type) {
           case AnnotationType.fill:
-            fillManager = FillManager(this,
-                onTap: onFillTapped.call, enableInteraction: enableInteraction);
+            fillManager = FillManager(
+              this,
+              onTap: onFillTapped.call,
+              onDrag: onFillDrag.call,
+              enableInteraction: enableInteraction,
+            );
           case AnnotationType.line:
-            lineManager = LineManager(this,
-                onTap: onLineTapped.call, enableInteraction: enableInteraction);
+            lineManager = LineManager(
+              this,
+              onTap: onLineTapped.call,
+              onDrag: onLineDrag.call,
+              enableInteraction: enableInteraction,
+            );
           case AnnotationType.circle:
-            circleManager = CircleManager(this,
-                onTap: onCircleTapped.call,
-                enableInteraction: enableInteraction);
+            circleManager = CircleManager(
+              this,
+              onTap: onCircleTapped.call,
+              onDrag: onCircleDrag.call,
+              enableInteraction: enableInteraction,
+            );
           case AnnotationType.symbol:
-            symbolManager = SymbolManager(this,
-                onTap: onSymbolTapped.call,
-                enableInteraction: enableInteraction);
+            symbolManager = SymbolManager(
+              this,
+              onTap: onSymbolTapped.call,
+              onDrag: onSymbolDrag.call,
+              enableInteraction: enableInteraction,
+            );
         }
       }
       onStyleLoadedCallback?.call();
@@ -199,11 +213,26 @@ class MapLibreMapController extends ChangeNotifier {
   /// Callbacks to receive tap events for symbols placed on this map.
   final ArgumentCallbacks<Symbol> onSymbolTapped = ArgumentCallbacks<Symbol>();
 
-  /// Callbacks to receive tap events for symbols placed on this map.
+  /// Callbacks to receive drag events for symbols placed on this map.
+  final ArgumentCallbacks<Symbol> onSymbolDrag = ArgumentCallbacks<Symbol>();
+
+  /// Callbacks to receive tap events for circles placed on this map.
   final ArgumentCallbacks<Circle> onCircleTapped = ArgumentCallbacks<Circle>();
+
+  /// Callbacks to receive drag events for circles placed on this map.
+  final ArgumentCallbacks<Circle> onCircleDrag = ArgumentCallbacks<Circle>();
 
   /// Callbacks to receive tap events for fills placed on this map.
   final ArgumentCallbacks<Fill> onFillTapped = ArgumentCallbacks<Fill>();
+
+  /// Callbacks to receive drag events for fills placed on this map.
+  final ArgumentCallbacks<Fill> onFillDrag = ArgumentCallbacks<Fill>();
+
+  /// Callbacks to receive tap events for lines placed on this map.
+  final ArgumentCallbacks<Line> onLineTapped = ArgumentCallbacks<Line>();
+
+  /// Callbacks to receive drag events for lines placed on this map.
+  final ArgumentCallbacks<Line> onLineDrag = ArgumentCallbacks<Line>();
 
   /// Callbacks to receive tap events for features (geojson layer) placed on this map.
   final onFeatureTapped = <OnFeatureInteractionCallback>[];
@@ -219,9 +248,6 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// The returned set will be a detached snapshot of the symbols collection.
   Set<Symbol> get symbols => symbolManager!.annotations;
-
-  /// Callbacks to receive tap events for lines placed on this map.
-  final ArgumentCallbacks<Line> onLineTapped = ArgumentCallbacks<Line>();
 
   /// The current set of lines on this map added with the [addLine] or [addLines] methods.
   ///


### PR DESCRIPTION
### Summary

This PR expose drag events on annotations (such as symbols, circles, lines and fills) by registering a listener.
Developers can now receive positional updates when an annotation is dragged.

### New Parameters Added
`onSymbolDrag`, `onCircleDrag` , `onFillDrag` and `onLineDrag` were introduced to the MapLibreMapController.

### Usage Example

```
void _onMapCreated(MapLibreMapController controller) {
    this.controller = controller;
    controller.onCircleDrag.add(_onCircleDrag);
  }

  void _onCircleDrag(Circle circle){
    print('Circle ${circle.id} was dragged: ${circle.options.geometry}');
  }

  void _addCircle() {
    controller!.addCircle(CircleOptions(geometry: latlng, draggable: true));
  }
  
  @override
  void dispose() {
    controller?.onCircleDrag.remove(_onCircleDrag);
    super.dispose();
  }
