### PR TITLE
Expose annotation drag

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -148,12 +148,12 @@ abstract class AnnotationManager<T extends Annotation> {
       required LatLng origin,
       required LatLng current,
       required LatLng delta,
-      required DragEventType eventType}) {
+      required DragEventType eventType}) async {
     final annotation = byId(id);
     if (annotation != null) {
-      onDrag?.call(annotation, eventType);
       annotation.translate(delta);
-      set(annotation);
+      await set(annotation);
+      onDrag?.call(annotation, eventType);
     }
   }
 

--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -6,7 +6,10 @@ abstract class AnnotationManager<T extends Annotation> {
   final _idToLayerIndex = <String, int>{};
 
   /// Called if a annotation is tapped
-  final void Function(T)? onTap;
+  final ArgumentCallback<T>? onTap;
+
+  /// Called if a annotation is dragged
+  final ArgumentCallback2<T, DragEventType>? onDrag;
 
   /// base id of the manager. User [layerdIds] to get the actual ids.
   final String id;
@@ -29,9 +32,13 @@ abstract class AnnotationManager<T extends Annotation> {
 
   Set<T> get annotations => _idToAnnotation.values.toSet();
 
-  AnnotationManager(this.controller,
-      {this.onTap, this.selectLayer, required this.enableInteraction})
-      : id = getRandomString() {
+  AnnotationManager(
+    this.controller, {
+    this.onTap,
+    this.onDrag,
+    this.selectLayer,
+    required this.enableInteraction,
+  }) : id = getRandomString() {
     for (var i = 0; i < allLayerProperties.length; i++) {
       final layerId = _makeLayerId(i);
       controller.addGeoJsonSource(layerId, buildFeatureCollection([]),
@@ -144,6 +151,7 @@ abstract class AnnotationManager<T extends Annotation> {
       required DragEventType eventType}) {
     final annotation = byId(id);
     if (annotation != null) {
+      onDrag?.call(annotation, eventType);
       annotation.translate(delta);
       set(annotation);
     }
@@ -169,8 +177,12 @@ abstract class AnnotationManager<T extends Annotation> {
 }
 
 class LineManager extends AnnotationManager<Line> {
-  LineManager(super.controller, {super.onTap, super.enableInteraction = true})
-      : super(
+  LineManager(
+    super.controller, {
+    super.onTap,
+    super.onDrag,
+    super.enableInteraction = true,
+  }) : super(
           selectLayer: (Line line) => line.options.linePattern == null ? 0 : 1,
         );
 
@@ -196,6 +208,7 @@ class FillManager extends AnnotationManager<Fill> {
   FillManager(
     super.controller, {
     super.onTap,
+    super.onDrag,
     super.enableInteraction = true,
   }) : super(
           selectLayer: (Fill fill) => fill.options.fillPattern == null ? 0 : 1,
@@ -221,6 +234,7 @@ class CircleManager extends AnnotationManager<Circle> {
   CircleManager(
     super.controller, {
     super.onTap,
+    super.onDrag,
     super.enableInteraction = true,
   });
 
@@ -242,6 +256,7 @@ class SymbolManager extends AnnotationManager<Symbol> {
   SymbolManager(
     super.controller, {
     super.onTap,
+    super.onDrag,
     bool iconAllowOverlap = false,
     bool textAllowOverlap = false,
     bool iconIgnorePlacement = false,

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -136,19 +136,33 @@ class MapLibreMapController extends ChangeNotifier {
         final enableInteraction = interactionEnabled.contains(type);
         switch (type) {
           case AnnotationType.fill:
-            fillManager = FillManager(this,
-                onTap: onFillTapped.call, enableInteraction: enableInteraction);
+            fillManager = FillManager(
+              this,
+              onTap: onFillTapped.call,
+              onDrag: onFillDrag.call,
+              enableInteraction: enableInteraction,
+            );
           case AnnotationType.line:
-            lineManager = LineManager(this,
-                onTap: onLineTapped.call, enableInteraction: enableInteraction);
+            lineManager = LineManager(
+              this,
+              onTap: onLineTapped.call,
+              onDrag: onLineDrag.call,
+              enableInteraction: enableInteraction,
+            );
           case AnnotationType.circle:
-            circleManager = CircleManager(this,
-                onTap: onCircleTapped.call,
-                enableInteraction: enableInteraction);
+            circleManager = CircleManager(
+              this,
+              onTap: onCircleTapped.call,
+              onDrag: onCircleDrag.call,
+              enableInteraction: enableInteraction,
+            );
           case AnnotationType.symbol:
-            symbolManager = SymbolManager(this,
-                onTap: onSymbolTapped.call,
-                enableInteraction: enableInteraction);
+            symbolManager = SymbolManager(
+              this,
+              onTap: onSymbolTapped.call,
+              onDrag: onSymbolDrag.call,
+              enableInteraction: enableInteraction,
+            );
         }
       }
       onStyleLoadedCallback?.call();
@@ -199,11 +213,26 @@ class MapLibreMapController extends ChangeNotifier {
   /// Callbacks to receive tap events for symbols placed on this map.
   final ArgumentCallbacks<Symbol> onSymbolTapped = ArgumentCallbacks<Symbol>();
 
-  /// Callbacks to receive tap events for symbols placed on this map.
+  /// Callbacks to receive drag events for symbols placed on this map.
+  final onSymbolDrag = ArgumentCallbacks2<Symbol, DragEventType>();
+
+  /// Callbacks to receive tap events for circles placed on this map.
   final ArgumentCallbacks<Circle> onCircleTapped = ArgumentCallbacks<Circle>();
+
+  /// Callbacks to receive drag events for circles placed on this map.
+  final onCircleDrag = ArgumentCallbacks2<Circle, DragEventType>();
 
   /// Callbacks to receive tap events for fills placed on this map.
   final ArgumentCallbacks<Fill> onFillTapped = ArgumentCallbacks<Fill>();
+
+  /// Callbacks to receive drag events for fills placed on this map.
+  final onFillDrag = ArgumentCallbacks2<Fill, DragEventType>();
+
+  /// Callbacks to receive tap events for lines placed on this map.
+  final ArgumentCallbacks<Line> onLineTapped = ArgumentCallbacks<Line>();
+
+  /// Callbacks to receive drag events for lines placed on this map.
+  final onLineDrag = ArgumentCallbacks2<Line, DragEventType>();
 
   /// Callbacks to receive tap events for features (geojson layer) placed on this map.
   final onFeatureTapped = <OnFeatureInteractionCallback>[];
@@ -219,9 +248,6 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// The returned set will be a detached snapshot of the symbols collection.
   Set<Symbol> get symbols => symbolManager!.annotations;
-
-  /// Callbacks to receive tap events for lines placed on this map.
-  final ArgumentCallbacks<Line> onLineTapped = ArgumentCallbacks<Line>();
 
   /// The current set of lines on this map added with the [addLine] or [addLines] methods.
   ///

--- a/maplibre_gl_example/lib/place_symbol.dart
+++ b/maplibre_gl_example/lib/place_symbol.dart
@@ -43,6 +43,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   void _onMapCreated(MapLibreMapController controller) {
     this.controller = controller;
     controller.onSymbolTapped.add(_onSymbolTapped);
+    controller.onSymbolDrag.add(_onSymbolDrag);
   }
 
   void _onStyleLoaded() {
@@ -54,6 +55,7 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
   @override
   void dispose() {
     controller?.onSymbolTapped.remove(_onSymbolTapped);
+    controller?.onSymbolDrag.remove(_onSymbolDrag);
     super.dispose();
   }
 
@@ -82,6 +84,17 @@ class PlaceSymbolBodyState extends State<PlaceSymbolBody> {
     _updateSelectedSymbol(
       const SymbolOptions(iconSize: 1.4),
     );
+  }
+
+  void _onSymbolDrag(Symbol symbol, DragEventType eventType) {
+    if (eventType == DragEventType.end) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              'Symbol #${symbol.data?['count'] ?? ''} was dragged to ${symbol.options.geometry}'),
+        ),
+      );
+    }
   }
 
   Future<void> _updateSelectedSymbol(SymbolOptions changes) async {

--- a/maplibre_gl_platform_interface/lib/src/callbacks.dart
+++ b/maplibre_gl_platform_interface/lib/src/callbacks.dart
@@ -56,3 +56,56 @@ class ArgumentCallbacks<T> {
   /// Whether this collection is non-empty.
   bool get isNotEmpty => _callbacks.isNotEmpty;
 }
+
+/// Callback function taking a two arguments.
+typedef ArgumentCallback2<T, U> = void Function(T arg1, U arg2);
+
+/// Mutable collection of [ArgumentCallbacks2] instances, itself an [ArgumentCallbacks2].
+///
+/// Additions and removals happening during a single [call] invocation do not
+/// change who gets a callback until the next such invocation.
+///
+/// Optimized for the singleton case.
+class ArgumentCallbacks2<T, U> {
+  final List<ArgumentCallback2<T, U>> _callbacks = [];
+
+  /// Callback method. Invokes the corresponding method on each callback
+  /// in this collection.
+  ///
+  /// The list of callbacks being invoked is computed at the start of the
+  /// method and is unaffected by any changes subsequently made to this
+  /// collection.
+  void call(T arg1, U arg2) {
+    final length = _callbacks.length;
+    if (length == 1) {
+      _callbacks[0].call(arg1, arg2);
+    } else if (0 < length) {
+      for (final callback in List.from(_callbacks)) {
+        callback(arg1, arg2);
+      }
+    }
+  }
+
+  /// Adds a callback to this collection.
+  void add(ArgumentCallback2<T, U> callback) {
+    _callbacks.add(callback);
+  }
+
+  /// Removes a callback from this collection.
+  ///
+  /// Does nothing, if the callback was not present.
+  void remove(ArgumentCallback2<T, U> callback) {
+    _callbacks.remove(callback);
+  }
+
+  /// Removes all callbacks
+  void clear() {
+    _callbacks.clear();
+  }
+
+  /// Whether this collection is empty.
+  bool get isEmpty => _callbacks.isEmpty;
+
+  /// Whether this collection is non-empty.
+  bool get isNotEmpty => _callbacks.isNotEmpty;
+}


### PR DESCRIPTION
### Summary

This PR expose drag events on annotations (such as symbols, circles, lines and fills) by registering a listener.
Developers can now receive positional updates when an annotation is dragged.

### New Parameters Added
`onSymbolDrag`, `onCircleDrag` , `onFillDrag` and `onLineDrag` were introduced to the MapLibreMapController.

### Usage Example

```
void _onMapCreated(MapLibreMapController controller) {
    this.controller = controller;
    controller.onCircleDrag.add(_onCircleDrag);
  }

  void _onCircleDrag(Circle circle){
    print('Circle ${circle.id} was dragged: ${circle.options.geometry}');
  }

  void _addCircle() {
    controller!.addCircle(CircleOptions(geometry: latlng, draggable: true));
  }
  
  @override
  void dispose() {
    controller?.onCircleDrag.remove(_onCircleDrag);
    super.dispose();
  }
