### PR TITLE
fix: de-register annotation drag callback on dispose.

### DIFF
--- a/maplibre_gl/lib/src/annotation_manager.dart
+++ b/maplibre_gl/lib/src/annotation_manager.dart
@@ -49,6 +49,15 @@ abstract class AnnotationManager<T extends Annotation> {
   /// Returns the annotation with the given [id], or null if not found.
   T? byId(String id) => _idToAnnotation[id];
 
+  /// Stored drag callback reference so we can reliably de-register it.
+  ///
+  /// This must be the *same* function instance used with
+  /// `controller.onFeatureDrag.add(...)`, otherwise `remove(...)` may fail
+  /// (method tear-offs can create new function objects).
+  ///
+  /// Prevents duplicate/stale drag handlers after style reloads.
+  late final OnFeatureDragCallback _dragCb = _onDrag;
+
   /// Current set of managed annotations.
   Set<T> get annotations => _idToAnnotation.values.toSet();
 
@@ -84,7 +93,8 @@ abstract class AnnotationManager<T extends Annotation> {
         );
       }
 
-      controller.onFeatureDrag.add(_onDrag);
+      controller.onFeatureDrag.remove(_dragCb); // safe even if not present
+      controller.onFeatureDrag.add(_dragCb);
 
       // Mark as initialized
       _isInitialized = true;
@@ -180,6 +190,7 @@ abstract class AnnotationManager<T extends Annotation> {
   Future<void> dispose() async {
     if (controller.isDisposed) return;
     _idToAnnotation.clear();
+    controller.onFeatureDrag.remove(_dragCb);
 
     await _setAll();
     for (var i = 0; i < allLayerProperties.length; i++) {

--- a/maplibre_gl/test/annotation_manager_test.dart
+++ b/maplibre_gl/test/annotation_manager_test.dart
@@ -340,8 +340,7 @@ void main() {
       expect(controller.onFeatureDrag.length, before - 2);
     });
 
-    test('dispose preserves other managers and user-added callbacks',
-        () async {
+    test('dispose preserves other managers and user-added callbacks', () async {
       void userCallback(_, _, _, _, _, _, _) {}
       controller.onFeatureDrag.add(userCallback);
 
@@ -369,43 +368,45 @@ void main() {
       expect(controller.onFeatureDrag.length, initial);
     });
 
-    test('drag event after style reload does not target a disposed manager',
-        () async {
-      final oldSymbol = await controller.addSymbol(
-        const SymbolOptions(geometry: LatLng(0, 0), draggable: true),
-      );
+    test(
+      'drag event after style reload does not target a disposed manager',
+      () async {
+        final oldSymbol = await controller.addSymbol(
+          const SymbolOptions(geometry: LatLng(0, 0), draggable: true),
+        );
 
-      // Trigger the real style-reload code path on the controller.
-      platform.onMapStyleLoadedPlatform.call(null);
-      await pumpEventQueue();
+        // Trigger the real style-reload code path on the controller.
+        platform.onMapStyleLoadedPlatform.call(null);
+        await pumpEventQueue();
 
-      final newSymbol = await controller.addSymbol(
-        const SymbolOptions(geometry: LatLng(10, 20), draggable: true),
-      );
+        final newSymbol = await controller.addSymbol(
+          const SymbolOptions(geometry: LatLng(10, 20), draggable: true),
+        );
 
-      final dragged = <String>[];
-      controller.onFeatureDrag.add(
-        (point, origin, current, delta, id, annotation, eventType) {
-          dragged.add(id);
-        },
-      );
+        final dragged = <String>[];
+        controller.onFeatureDrag.add(
+          (point, origin, current, delta, id, annotation, eventType) {
+            dragged.add(id);
+          },
+        );
 
-      platform.onFeatureDraggedPlatform.call({
-        'id': newSymbol.id,
-        'eventType': DragEventType.drag.name,
-        'point': const Point(0.0, 0.0),
-        'origin': const LatLng(10, 20),
-        'current': const LatLng(10.001, 20.001),
-        'delta': const LatLng(0.001, 0.001),
-      });
+        platform.onFeatureDraggedPlatform.call({
+          'id': newSymbol.id,
+          'eventType': DragEventType.drag.name,
+          'point': const Point(0.0, 0.0),
+          'origin': const LatLng(10, 20),
+          'current': const LatLng(10.001, 20.001),
+          'delta': const LatLng(0.001, 0.001),
+        });
 
-      // Only the new manager (and our observer) should have been notified.
-      // With the bug, the old manager's stale _onDrag would also fire.
-      expect(dragged, [newSymbol.id]);
-      expect(controller.symbolManager!.byId(newSymbol.id), isNotNull);
-      // Old symbol's id is unrelated to anything live now.
-      expect(controller.symbolManager!.byId(oldSymbol.id), isNull);
-    });
+        // Only the new manager (and our observer) should have been notified.
+        // With the bug, the old manager's stale _onDrag would also fire.
+        expect(dragged, [newSymbol.id]);
+        expect(controller.symbolManager!.byId(newSymbol.id), isNotNull);
+        // Old symbol's id is unrelated to anything live now.
+        expect(controller.symbolManager!.byId(oldSymbol.id), isNull);
+      },
+    );
   });
 
   group('AnnotationManager GeoJSON output', () {

--- a/maplibre_gl/test/annotation_manager_test.dart
+++ b/maplibre_gl/test/annotation_manager_test.dart
@@ -318,6 +318,96 @@ void main() {
     });
   });
 
+  group('AnnotationManager drag callback lifecycle', () {
+    test('initialize registers one drag callback per manager', () {
+      // setUp() initializes 4 managers (fill, line, circle, symbol).
+      expect(controller.onFeatureDrag.length, 4);
+    });
+
+    test('repeated initialize is idempotent', () async {
+      final before = controller.onFeatureDrag.length;
+      await controller.symbolManager!.initialize();
+      await controller.symbolManager!.initialize();
+      expect(controller.onFeatureDrag.length, before);
+    });
+
+    test('dispose removes the manager drag callback', () async {
+      final before = controller.onFeatureDrag.length;
+      await controller.symbolManager!.dispose();
+      expect(controller.onFeatureDrag.length, before - 1);
+
+      await controller.lineManager!.dispose();
+      expect(controller.onFeatureDrag.length, before - 2);
+    });
+
+    test('dispose preserves other managers and user-added callbacks',
+        () async {
+      void userCallback(_, _, _, _, _, _, _) {}
+      controller.onFeatureDrag.add(userCallback);
+
+      await controller.symbolManager!.dispose();
+
+      // Symbol manager removed, but the other 3 + user callback remain.
+      expect(controller.onFeatureDrag.length, 4);
+      expect(controller.onFeatureDrag, contains(userCallback));
+    });
+
+    test('style-reload cycle does not leak stale drag callbacks', () async {
+      // Reproduces the scenario from PR #806: on every style reload the
+      // controller disposes existing managers and creates new ones. Without
+      // the fix, each reload would leave the previous _onDrag registered,
+      // accumulating duplicates.
+      final initial = controller.onFeatureDrag.length;
+
+      for (var i = 0; i < 3; i++) {
+        platform.onMapStyleLoadedPlatform.call(null);
+        // The handler is async fire-and-forget through ArgumentCallbacks;
+        // drain the microtask queue until dispose+initialize complete.
+        await pumpEventQueue();
+      }
+
+      expect(controller.onFeatureDrag.length, initial);
+    });
+
+    test('drag event after style reload does not target a disposed manager',
+        () async {
+      final oldSymbol = await controller.addSymbol(
+        const SymbolOptions(geometry: LatLng(0, 0), draggable: true),
+      );
+
+      // Trigger the real style-reload code path on the controller.
+      platform.onMapStyleLoadedPlatform.call(null);
+      await pumpEventQueue();
+
+      final newSymbol = await controller.addSymbol(
+        const SymbolOptions(geometry: LatLng(10, 20), draggable: true),
+      );
+
+      final dragged = <String>[];
+      controller.onFeatureDrag.add(
+        (point, origin, current, delta, id, annotation, eventType) {
+          dragged.add(id);
+        },
+      );
+
+      platform.onFeatureDraggedPlatform.call({
+        'id': newSymbol.id,
+        'eventType': DragEventType.drag.name,
+        'point': const Point(0.0, 0.0),
+        'origin': const LatLng(10, 20),
+        'current': const LatLng(10.001, 20.001),
+        'delta': const LatLng(0.001, 0.001),
+      });
+
+      // Only the new manager (and our observer) should have been notified.
+      // With the bug, the old manager's stale _onDrag would also fire.
+      expect(dragged, [newSymbol.id]);
+      expect(controller.symbolManager!.byId(newSymbol.id), isNotNull);
+      // Old symbol's id is unrelated to anything live now.
+      expect(controller.symbolManager!.byId(oldSymbol.id), isNull);
+    });
+  });
+
   group('AnnotationManager GeoJSON output', () {
     test('setGeoJsonSource is called with FeatureCollection on add', () async {
       platform.reset();


### PR DESCRIPTION
## Problem
Dragging `draggable: true` annotations after a style reload (setStyle / style load) can misbehave (excessive movement) and crash with:

`_idToAnnotation.containsKey(annotation.id): you can only set existing annotations
`

This happens on Android and iOS, and is reproducible in this repo’s `maplibre_gl_example` app.

## Solution implemented
De-register the `onFeatureDrag` callback in `AnnotationManager.dispose()` and ensure the same callback reference is used for add/remove, preventing stale/duplicate drag handlers after style reload.

## Steps to reproduce
1. Create a MapLibreMap with a controller.
2. Call controller.setStyle(...) (one or more times) and wait for onStyleLoadedCallback.
3. Add a draggable annotation (e.g. SymbolOptions(draggable: true)).
4. Drag the annotation.
5. Observe jumpy drag and crash logs.