### PR TITLE
fix(ios): accept rgb/rgba/hsl/hsla strings on layer color properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Fixed
+* **iOS**: Accept any color string MapLibre's style-spec parser understands (`rgb()`, `rgba()`, `hsl()`, `hsla()`, named colors, ...) on layer color properties. Previously only `#RRGGBB`/`#AARRGGBB` hex was handled and anything else rendered transparent.
+
 ## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
 
 > **Note:** Several users reported crashes on a range of Android devices after upgrading to 0.26.0, particularly on older / less recent hardware. These issues are addressed in 0.26.1 (see the Android fixes below).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+* **iOS**: Accept any color string MapLibre's style-spec parser understands (`rgb()`, `rgba()`, `hsl()`, `hsla()`, named colors, ...) on layer color properties. Previously only `#RRGGBB`/`#AARRGGBB` hex was handled and anything else rendered transparent.
+
 ## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
 
 > **Note:** Several users reported crashes on a range of Android devices after upgrading to 0.26.0, particularly on older / less recent hardware. These issues are addressed in 0.26.1 (see the Android fixes below).

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/LayerPropertyConverter.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/LayerPropertyConverter.swift
@@ -495,11 +495,15 @@ class LayerPropertyConverter {
             return NSExpression(forConstantValue: fontNames)
         }
 
-        // this is required because NSExpression.init(mglJSONObject: json) fails to create
-        // a proper Expression if the data of is a hexString
         if isColor {
             if let color = json as? String {
-                return NSExpression(forConstantValue: UIColor(hexString: color))
+                if let parsed = UIColor(hexString: color) {
+                    return NSExpression(forConstantValue: parsed)
+                }
+                // Without the fallback argument MLN raises an uncaught
+                // NSInternalInconsistencyException at render time when the
+                // input string can't be cast.
+                return NSExpression(mglJSONObject: ["to-color", color, "#000000"])
             }
         }
 

--- a/scripts/templates/LayerPropertyConverter.swift.template
+++ b/scripts/templates/LayerPropertyConverter.swift.template
@@ -93,11 +93,15 @@ class LayerPropertyConverter {
             return NSExpression(forConstantValue: fontNames)
         }
 
-        // this is required because NSExpression.init(mglJSONObject: json) fails to create
-        // a proper Expression if the data of is a hexString
         if isColor {
             if let color = json as? String {
-                return NSExpression(forConstantValue: UIColor(hexString: color))
+                if let parsed = UIColor(hexString: color) {
+                    return NSExpression(forConstantValue: parsed)
+                }
+                // Without the fallback argument MLN raises an uncaught
+                // NSInternalInconsistencyException at render time when the
+                // input string can't be cast.
+                return NSExpression(mglJSONObject: ["to-color", color, "#000000"])
             }
         }
 


### PR DESCRIPTION
On iOS, only hex worked on layer color properties. `rgba()`, `hsl()`, named colors etc. silently rendered as transparent — the same values render correctly on Android.

```dart
LineLayerProperties(lineColor: 'rgba(229, 57, 53, 1)') // now accepted on iOS
```