### PR TITLE
fix(android): add androidGeoJsonSynchronousUpdate workaround for disappearing symbols (#825)

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
@@ -20,7 +20,7 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;
   private boolean dragEnabled = true;
-  private boolean geoJsonSynchronousUpdate = true;
+  private boolean geoJsonSynchronousUpdate = false;
   private boolean featureTapsTriggersMapClick = false;
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapBuilder.java
@@ -20,6 +20,7 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
   private boolean trackCameraPosition = false;
   private boolean myLocationEnabled = false;
   private boolean dragEnabled = true;
+  private boolean geoJsonSynchronousUpdate = true;
   private boolean featureTapsTriggersMapClick = false;
   private int myLocationTrackingMode = 0;
   private int myLocationRenderMode = 0;
@@ -42,8 +43,9 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
             messenger, 
             lifecycleProvider, 
             options, 
-            styleString, 
-            dragEnabled, 
+            styleString,
+            dragEnabled,
+            geoJsonSynchronousUpdate,
             featureTapsTriggersMapClick
         );
     controller.init();
@@ -245,6 +247,10 @@ class MapLibreMapBuilder implements MapLibreMapOptionsSink {
 
   public void setDragEnabled(boolean enabled) {
     this.dragEnabled = enabled;
+  }
+
+  public void setGeoJsonSynchronousUpdate(boolean enabled) {
+    this.geoJsonSynchronousUpdate = enabled;
   }
 
   public void setFeatureTapsTriggersMapClick(boolean triggers) {

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -143,6 +143,7 @@ final class MapLibreMapController
   private LocationEngineFactory myLocationEngineFactory = new LocationEngineFactory();
   private boolean disposed = false;
   private boolean dragEnabled = true;
+  private boolean geoJsonSynchronousUpdate = true;
   private boolean featureTapsTriggersMapClick = false;
   private boolean mapViewStarted = false;
   private MethodChannel.Result mapReadyResult;
@@ -193,12 +194,14 @@ final class MapLibreMapController
       MapLibreMapOptions options,
       String styleStringInitial,
       boolean dragEnabled,
+      boolean geoJsonSynchronousUpdate,
       boolean featureTapsTriggersMapClick
   ) {
     MapLibreUtils.getMapLibre(context);
     this.id = id;
     this.context = context;
     this.dragEnabled = dragEnabled;
+    this.geoJsonSynchronousUpdate = geoJsonSynchronousUpdate;
     this.featureTapsTriggersMapClick = featureTapsTriggersMapClick;
     this.styleStringInitial = styleStringInitial;
     this.mapViewContainer = new FrameLayout(context);
@@ -445,7 +448,12 @@ final class MapLibreMapController
         return;
       }
 
-      GeoJsonOptions options = new GeoJsonOptions().withSynchronousUpdate(dragEnabled);
+      // Synchronous updates reduce flicker while dragging, but they trigger an
+      // upstream maplibre-native bug where SymbolLayer icons disappear when the
+      // map is scaled (https://github.com/maplibre/maplibre-native/issues/4035).
+      // Allow disabling it via the androidGeoJsonSynchronousUpdate map option.
+      GeoJsonOptions options =
+          new GeoJsonOptions().withSynchronousUpdate(dragEnabled && geoJsonSynchronousUpdate);
       GeoJsonSource geoJsonSource = new GeoJsonSource(sourceName, featureCollection, options);
       addedFeaturesByLayer.put(sourceName, featureCollection);
 

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -143,7 +143,7 @@ final class MapLibreMapController
   private LocationEngineFactory myLocationEngineFactory = new LocationEngineFactory();
   private boolean disposed = false;
   private boolean dragEnabled = true;
-  private boolean geoJsonSynchronousUpdate = true;
+  private boolean geoJsonSynchronousUpdate = false;
   private boolean featureTapsTriggersMapClick = false;
   private boolean mapViewStarted = false;
   private MethodChannel.Result mapReadyResult;

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapFactory.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapFactory.java
@@ -38,6 +38,11 @@ public class MapLibreMapFactory extends PlatformViewFactory {
       boolean dragEnabled = Convert.toBoolean(params.get("dragEnabled"));
       builder.setDragEnabled(dragEnabled);
     }
+    if (params.containsKey("androidGeoJsonSynchronousUpdate")) {
+      boolean synchronousUpdate =
+          Convert.toBoolean(params.get("androidGeoJsonSynchronousUpdate"));
+      builder.setGeoJsonSynchronousUpdate(synchronousUpdate);
+    }
     if(params.containsKey("styleString")) {
       String styleString = Convert.toString(params.get("styleString"));
       builder.setStyleString(styleString);

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -28,6 +28,7 @@ class MapLibreMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.doubleClickZoomEnabled,
     this.dragEnabled = true,
+    this.androidGeoJsonSynchronousUpdate = true,
     this.featureTapsTriggersMapClick = false,
     this.trackCameraPosition = false,
     this.myLocationEnabled = false,
@@ -140,6 +141,21 @@ class MapLibreMap extends StatefulWidget {
   /// Disable to avoid performance issues that from the drag event listeners.
   /// Biggest impact in android
   final bool dragEnabled;
+
+  /// Whether GeoJSON sources on **Android** are created with synchronous
+  /// updates enabled (`GeoJsonOptions.withSynchronousUpdate`).
+  ///
+  /// Synchronous updates make annotation dragging feel smoother, but they
+  /// trigger an upstream maplibre-native bug where icons in a `SymbolLayer`
+  /// disappear while the map is zoomed/scaled, and the compass may fail to
+  /// render. See https://github.com/maplibre/maplibre-native/issues/4035.
+  ///
+  /// Set this to `false` as a workaround if you see symbols/icons disappearing
+  /// on Android. Has no effect on iOS or web. Only the initial value is used;
+  /// it can not be changed at runtime.
+  ///
+  /// Defaults to `true` to preserve the behavior introduced in 0.26.0.
+  final bool androidGeoJsonSynchronousUpdate;
 
   /// Whether tapping on a feature also triggers the map click event.
   /// Defaults to `false`.
@@ -338,6 +354,7 @@ class _MapLibreMapState extends State<MapLibreMap> {
       'styleString': widget.styleString,
       'options': _MapLibreMapOptions.fromWidget(widget).toMap(),
       'dragEnabled': widget.dragEnabled,
+      'androidGeoJsonSynchronousUpdate': widget.androidGeoJsonSynchronousUpdate,
       if (widget.iosLongClickDuration != null)
         'iosLongClickDurationMilliseconds':
             widget.iosLongClickDuration!.inMilliseconds,

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -28,7 +28,7 @@ class MapLibreMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.doubleClickZoomEnabled,
     this.dragEnabled = true,
-    this.androidGeoJsonSynchronousUpdate = true,
+    this.androidGeoJsonSynchronousUpdate = false,
     this.featureTapsTriggersMapClick = false,
     this.trackCameraPosition = false,
     this.myLocationEnabled = false,
@@ -145,16 +145,19 @@ class MapLibreMap extends StatefulWidget {
   /// Whether GeoJSON sources on **Android** are created with synchronous
   /// updates enabled (`GeoJsonOptions.withSynchronousUpdate`).
   ///
-  /// Synchronous updates make annotation dragging feel smoother, but they
-  /// trigger an upstream maplibre-native bug where icons in a `SymbolLayer`
-  /// disappear while the map is zoomed/scaled, and the compass may fail to
-  /// render. See https://github.com/maplibre/maplibre-native/issues/4035.
+  /// Synchronous updates make annotation dragging feel slightly smoother, but
+  /// they trigger an upstream maplibre-native bug where icons in a
+  /// `SymbolLayer` disappear while the map is zoomed/scaled, and the compass
+  /// may fail to render. See
+  /// https://github.com/maplibre/maplibre-native/issues/4035.
   ///
-  /// Set this to `false` as a workaround if you see symbols/icons disappearing
-  /// on Android. Has no effect on iOS or web. Only the initial value is used;
-  /// it can not be changed at runtime.
+  /// Defaults to `false`, which matches the async behavior used before 0.26.0
+  /// (and the behavior of maplibre-react-native, which never enables this) and
+  /// avoids the upstream bug. Set it to `true` to opt back into synchronous
+  /// updates if you rely on drag smoothness and do not use icon symbols.
   ///
-  /// Defaults to `true` to preserve the behavior introduced in 0.26.0.
+  /// Has no effect on iOS or web. Only the initial value is used; it can not be
+  /// changed at runtime.
   final bool androidGeoJsonSynchronousUpdate;
 
   /// Whether tapping on a feature also triggers the map click event.


### PR DESCRIPTION
## Summary

Fixes #825, where **`SymbolLayer` icons disappear while zooming/scaling and the compass fails to render on Android** (regression since 0.26.0, iOS unaffected).

## Root cause

PR #716 (shipped in 0.26.0) changed Android GeoJSON source creation to:

```java
new GeoJsonOptions().withSynchronousUpdate(dragEnabled)
```

Because `dragEnabled` defaults to `true`, **every** GeoJSON source, including the internal `SymbolManager` source used by `addSymbol`, now runs in synchronous-update mode, which triggers an upstream maplibre-native bug.

## Upstream status (the root cause is upstream)

The real fix belongs in maplibre-native:

- maplibre-native issue **[#4035](https://github.com/maplibre/maplibre-native/issues/4035)** is still **open**, and its title describes this exact bug: *"Using `new GeoJsonOptions().withSynchronousUpdate(true)` with GeoJsonSource will cause icons in SymbolLayer to disappear when scaled."* The maintainer there even asks the reporter *"why do you need `withSynchronousUpdate(true)`?"*.
- The candidate fix, maplibre-native PR **[#4193](https://github.com/maplibre/maplibre-native/pull/4193)**, is **closed and not merged**.
- The latest release **`android-v13.2.0`** (2026-05-25) does **not** include a fix, so bumping the native SDK does not help.

## Why disable it (prior art)

`maplibre-react-native` **never enables `withSynchronousUpdate`** anywhere in its codebase, which is precisely why RN-Android does not suffer this icon-vanishing behavior. Their related PR ([maplibre-react-native#1547](https://github.com/maplibre/maplibre-react-native/pull/1547)) targets a different bug (iOS dynamically-added `<Images/>` not registering after mount) and the maintainer notes it is only ~50% reliable for the disappear-on-scale case and likely upstream too.

The conclusion: the reliable mitigation is to not enable the broken native code path by default.

## Change

Adds a new **`androidGeoJsonSynchronousUpdate`** option to `MapLibreMap` (Android-only), plumbed through the factory, builder and controller. The effective native flag becomes `dragEnabled && androidGeoJsonSynchronousUpdate`.

- **Default `false`**: async GeoJSON updates, as before 0.26.0 and as in maplibre-react-native. Fixes #825 out of the box.
- **Set to `true`**: opts back into synchronous updates for users who rely on drag smoothness and do not use icon symbols.

```dart
MapLibreMap(
  // synchronous updates are now OFF by default; opt back in only if needed:
  // androidGeoJsonSynchronousUpdate: true,
)
```

No effect on iOS or web (those platforms never enabled synchronous GeoJSON updates, matching the report that only Android is affected).

## Notes

- Behavior change vs 0.26.0/0.26.1: annotation dragging on Android reverts to async updates by default.
- Per repo convention, the version bump and `CHANGELOG.md` are handled in the dedicated release PR. This targets the **0.26.2** release.
- This mitigates the symptom; the root cause should remain tracked against upstream maplibre-native #4035.