### PR TITLE
iOS: tear down MLNMapView in deinit (parity with Android dispose)

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -32,6 +32,27 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         return mapView
     }
 
+    deinit {
+        // The Android controller tears the map down explicitly in `dispose()`
+        // (`mapView.onStop()` / `onDestroy()`), but on iOS a `FlutterPlatformView`
+        // gets no dispose callback, so `MLNMapView` cleanup relies entirely on
+        // ARC reclaiming this controller. `MLNMapView`'s renderer runs off a
+        // `CADisplayLink` that is retained through the run loop until the view
+        // leaves its window, and it keeps tile-fetch connections open. When a
+        // host creates a new map view per screen/route (e.g. a basemap switch),
+        // the old engines can linger and contend for GPU/network resources.
+        // Drive the view out of its window and drop the remaining references so
+        // the engine is reclaimed promptly when the platform view is removed.
+        channel?.setMethodCallHandler(nil)
+        mapView.delegate = nil
+        if let recognizers = mapView.gestureRecognizers {
+            for recognizer in recognizers {
+                mapView.removeGestureRecognizer(recognizer)
+            }
+        }
+        mapView.removeFromSuperview()
+    }
+
     private var styleIsReady: Bool {
         return onStyleLoadedCalled && mapView.style != nil
     }


### PR DESCRIPTION
## Problem

The Android `MapLibreMapController.dispose()` explicitly stops and destroys the map view (`mapView.onStop()` / `onDestroy()`). The **iOS** controller has **no `deinit` and does no teardown** — and a `FlutterPlatformView` gets no dispose callback on iOS, so `MLNMapView` cleanup relies entirely on ARC.

`MLNMapView`'s renderer runs off a `CADisplayLink` that is retained through the run loop until the view leaves its window, and it keeps tile-fetch connections open. When a host creates a new map view per screen/route (for example, switching basemaps), the old engines can linger and contend for GPU/network resources.

## Fix

Add a `deinit` that mirrors Android's teardown:

- `removeFromSuperview()` — drives the view out of its window so MapLibre invalidates the display link and frees the renderer
- `mapView.delegate = nil`
- remove the gesture recognizers
- `channel?.setMethodCallHandler(nil)`

so the engine is reclaimed promptly when the platform view is removed.

## Notes

- iOS-only change; no public API change.
- Verified in a downstream app (release build, iOS 26, iPhone 14 Pro Max) that creates a fresh map view per basemap switch.