### PR TITLE
fix(ios): defer camera ops on zero-sized frame to avoid std::domain_error SIGABRT on cold launch

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -109,21 +109,39 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         )
         var longPressRecognizerAdded = false
 
-        if let args = args as? [String: Any] {
+        // Flutter PlatformView hands us a zero-sized frame on cold launch.
+        // Any setter that touches the C++ map's camera/bounds (setCenter,
+        // maximumScreenBounds, min/max zoom, showsUserLocation → flyTo on
+        // cached CL fix) cascades into `constrainCameraAndZoomToBounds` →
+        // `Projection::unproject` on a 0×0 viewport → NaN → the `mbgl::LatLng`
+        // ctor throws `std::domain_error`, which libc++abi cannot unwind
+        // through Swift → SIGABRT (~150 ms after cold launch via force-quit
+        // + relaunch). Defer the options-apply block to the next runloop turn;
+        // Flutter calls `setFrame` with the real size by then. (issue #819)
+        let applyArgs: () -> Void = { [weak self] in
+            guard let self = self, let args = args as? [String: Any] else { return }
 
             Convert.interpretMapLibreMapOptions(options: args["options"], delegate: self)
             if let initialCameraPosition = args["initialCameraPosition"] as? [String: Any],
-               let camera = MLNMapCamera.fromDict(initialCameraPosition, mapView: mapView),
+               let camera = MLNMapCamera.fromDict(initialCameraPosition, mapView: self.mapView),
                let zoom = initialCameraPosition["zoom"] as? Double
             {
-                mapView.setCenter(
+                self.mapView.setCenter(
                     camera.centerCoordinate,
                     zoomLevel: zoom,
                     direction: camera.heading,
                     animated: false
                 )
-                initialTilt = camera.pitch
+                self.initialTilt = camera.pitch
             }
+        }
+        if mapView.frame.size.equalTo(.zero) {
+            DispatchQueue.main.async(execute: applyArgs)
+        } else {
+            applyArgs()
+        }
+
+        if let args = args as? [String: Any] {
             // if let onAttributionClickOverride = args["onAttributionClickOverride"] as? Bool {
             //     if onAttributionClickOverride {
             //         setupAttribution(mapView)
@@ -163,6 +181,17 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     }
 
     func onMethodCall(methodCall: FlutterMethodCall, result: @escaping FlutterResult) {
+        // Camera ops touch the C++ map's projection; on a zero-sized PlatformView
+        // frame (e.g. moveCamera fired from Dart onMapCreated before layout) the
+        // unproject runs on a 0×0 viewport → NaN → mbgl::LatLng throws
+        // std::domain_error → SIGABRT. Defer the whole call until the frame is
+        // real. (issue #819, onMethodCall path — not covered by the init-only fix)
+        if mapView.frame.size.equalTo(.zero), methodCall.method.hasPrefix("camera#") {
+            DispatchQueue.main.async { [weak self] in
+                self?.onMethodCall(methodCall: methodCall, result: result)
+            }
+            return
+        }
         switch methodCall.method {
         case "map#waitForMap":
             if isMapReady {


### PR DESCRIPTION
## Problem

On iOS, apps crash on cold launch (reliably after force-quit + relaunch) with:

```
libc++abi: terminating due to uncaught exception of type std::domain_error
```

Symbolicated, the throw is in MapLibre C++, called from the plugin:

```
__cxa_throw
MapLibre  (mbgl::LatLng ctor)
MapLibre  ...
MapLibreMapController.onMethodCall
closure #1 in MapLibreMapController.init   (method-channel handler)
libdispatch _dispatch_main_queue_callback_4CF
```

## Root cause

Flutter's PlatformView container hands `MapLibreMapController` a **zero-sized frame** on cold launch. Any camera op then runs `setCamera` → `constrainCameraAndZoomToBounds` → `Projection::unproject` on a `0×0` viewport → `NaN` → the `mbgl::LatLng` constructor throws `std::domain_error("latitude must not be NaN")`. libc++abi can't unwind a C++ exception through the Swift frame → `SIGABRT`.

Two entry points hit this with `frame.size == .zero`:
1. `init()` applying `initialCameraPosition` via `setCenter` (this is what #820 addressed), and
2. **any runtime `camera#*` method-channel call** — e.g. `moveCamera` fired from Dart `onMapCreated`, which runs before the view is laid out. This path is **not** covered by #820 and is the one that still crashes in practice.

## Fix

Defer to the next runloop turn when `frame.size == .zero` (Flutter calls `setFrame` with the real size by then):
- the `init` options-apply block, and
- `camera#*` calls in `onMethodCall` (re-dispatch the call; it runs once the frame is real).

No behavior change when the frame is already non-zero (applied synchronously as before).

## Verification

- 10/10 force-quit + relaunch cycles with no `SIGABRT` (previously ~7/8 crashed).
- Tested on a physical iPhone with a Flutter app that calls `moveCamera` from `onMapCreated` plus `minMaxZoomPreference` / `initialCameraPosition`.

Fixes #819. Supersedes #820 (init-only; missed the runtime `camera#*` path).
