### PR TITLE
fix(deps): relax meta constraint and correct minimum Flutter to 3.29 (#823)

### DIFF
--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 
 environment:
   sdk: ">=3.7.0 <4.0.0"
-  flutter: '>=3.22.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   flutter:

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -8,7 +8,7 @@ resolution: workspace
 
 environment:
   sdk: ">=3.7.0 <4.0.0"
-  flutter: '>=3.22.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   collection: ^1.19.1

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -7,12 +7,12 @@ resolution: workspace
 
 environment:
   sdk: ">=3.7.0 <4.0.0"
-  flutter: '>=3.22.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.17.0
+  meta: ^1.16.0
 
 dev_dependencies:
   flutter_test:

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 
 environment:
   sdk: ">=3.7.0 <4.0.0"
-  flutter: '>=3.22.0'
+  flutter: '>=3.29.0'
 
 flutter:
   plugin:
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   image: ^4.8.0
   maplibre_gl_platform_interface: ^0.26.1
-  meta: ^1.17.0
+  meta: ^1.16.0
   web: ^1.1.1
 
 dev_dependencies:


### PR DESCRIPTION
## Problem

[Discussion #823](https://github.com/maplibre/flutter-maplibre-gl/discussions/823#discussioncomment-17089240): users on Flutter 3.32.8 / Dart 3.8.1 cannot upgrade to 0.26.1 due to a `meta` version conflict:

```
Because every version of flutter from sdk depends on meta 1.16.0 and
maplibre_gl_web >=0.26.0 depends on meta ^1.17.0, flutter from sdk is
incompatible with maplibre_gl_web >=0.26.0.
... version solving failed.
```

## Root cause

The 0.26.0 release ([a63c5f7](https://github.com/maplibre/flutter-maplibre-gl/commit/a63c5f7)) bumped `meta` from `^1.3.0` to `^1.17.0` in `maplibre_gl_web` and `maplibre_gl_platform_interface`, with no code change requiring it.

The Flutter SDK pins `meta` to an **exact** version (not a range), so `meta: ^1.17.0` effectively requires **Dart 3.9 / Flutter 3.35+**. Any user below that is locked out.

This also contradicted the advertised `flutter: '>=3.22.0'`, which was already false:
- the repo uses **Pub workspaces** (`resolution: workspace`), which require **Dart >= 3.5** (Flutter 3.24); and
- the code uses **Dart 3.7 wildcard parameters** (`_` in `annotation_manager_test.dart`).

So the real, tested baseline was already `sdk: '>=3.7.0'` = **Flutter 3.29**.

## Change

- Relax `meta` to `^1.16.0` (the version pinned by Flutter 3.29 and 3.32).
- Correct the advertised minimum Flutter from `>=3.22.0` to `>=3.29.0` across all packages, so the constraint matches the real baseline.
- The `sdk: '>=3.7.0'` constraint is **unchanged**.

This is the minimal honest correction: it does not raise the effective floor (Dart 3.7 was already required), it just fixes the mislabelled `flutter` minimum and the over-tight `meta` constraint. Users on Flutter 3.29+ (including the #823 reporter on 3.32) can now upgrade.

## Verification

- `melos exec -- flutter analyze` -> no issues across all packages.
- `flutter test test/annotation_manager_test.dart` -> all tests pass.
- `flutter pub get` resolves cleanly.