### PR TITLE
fix(ci): silence onReorder deprecation to unblock static analysis

### DIFF
--- a/maplibre_gl_example/lib/examples/annotations/annotation_order_example.dart
+++ b/maplibre_gl_example/lib/examples/annotations/annotation_order_example.dart
@@ -183,6 +183,11 @@ class _AnnotationOrderBodyState extends State<_AnnotationOrderBody> {
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: _annotationOrder.length,
+                  // `onReorder` is deprecated after Flutter 3.41 in favour of
+                  // `onReorderItem`, but the latter is only available from
+                  // Flutter 3.44. Keep `onReorder` to stay compatible with the
+                  // minimum supported Flutter version.
+                  // ignore: deprecated_member_use
                   onReorder: (oldIndex, newIndex) {
                     setState(() {
                       if (newIndex > oldIndex) {


### PR DESCRIPTION
## Problem

The **Static code analysis** check is failing on every open PR (e.g. #836, #842), independently of each PR's changes:

```
maplibre_gl_example/lib/examples/annotations/annotation_order_example.dart:186:19
info - 'onReorder' is deprecated and shouldn't be used. Use the onReorderItem
callback instead. ... This feature was deprecated after v3.41.0-0.0.pre. - deprecated_member_use
##[error]Process completed with exit code 1.
```

## Root cause

CI runs `melos run analyze-all` -> `dart analyze --fatal-warnings --fatal-infos` on the **stable** channel (currently Flutter 3.44). Flutter 3.41+ deprecated `ReorderableListView.onReorder`, so the deprecation **info** became a **fatal** error.

The suggested replacement `onReorderItem` is only available from **Flutter 3.44**, which is below the minimum supported Flutter version, so switching the API would introduce a new incompatibility for users on older (still supported) Flutter releases.

## Change

Suppress the deprecation on the single call site with `// ignore: deprecated_member_use`, plus a comment explaining why `onReorderItem` can't be used yet. `onReorder` is deprecated but still present across the whole supported range, so behaviour is unchanged.

## Verification

`dart analyze --fatal-warnings --fatal-infos` on **Flutter 3.44** (the channel CI uses):

```
[maplibre_gl]: No issues found!
[maplibre_gl_web]: No issues found!
[maplibre_gl_platform_interface]: No issues found!
[maplibre_gl_example]: No issues found!
[maplibre_code_gen]: No issues found!
└> SUCCESS
```