### PR TITLE
fix(ios): pause render loop on background to prevent PMTilesFileSource SIGSEGV (#833)

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Package.swift
+++ b/maplibre_gl/ios/maplibre_gl/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // When updating the dependency version,
         // make sure to also update the version in maplibre_gl.podspec.
-        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", exact: "6.25.1"),
+        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", exact: "6.26.0"),
     ],
     targets: [
         .target(

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -28,6 +28,10 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private var interactiveFeatureLayerIds = Set<String>()
     private var addedShapesByLayer = [String: MLNShape]()
 
+    private var userFps: MLNMapViewPreferredFramesPerSecond = .default
+    private var pausedByDart = false
+    private var isBackgroundPaused = false
+
     func view() -> UIView {
         return mapView
     }
@@ -43,6 +47,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         // the old engines can linger and contend for GPU/network resources.
         // Drive the view out of its window and drop the remaining references so
         // the engine is reclaimed promptly when the platform view is removed.
+        NotificationCenter.default.removeObserver(self)
         channel?.setMethodCallHandler(nil)
         mapView.delegate = nil
         if let recognizers = mapView.gestureRecognizers {
@@ -192,6 +197,35 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             mapView.addGestureRecognizer(longPress)
             longPressRecognizerAdded = true
         }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    // Pausing the render loop before the OS suspends the process prevents a
+    // SIGSEGV in PMTilesFileSource, which runs file I/O on a background thread
+    // that can be torn down mid-read during app backgrounding (#833).
+    // didEnterBackground (not willResignActive) is used so transient interruptions
+    // like incoming call banners or Control Center do not freeze the map.
+    @objc private func appDidEnterBackground() {
+        isBackgroundPaused = true
+        mapView.preferredFramesPerSecond = MLNMapViewPreferredFramesPerSecond(rawValue: 0)
+    }
+
+    @objc private func appWillEnterForeground() {
+        isBackgroundPaused = false
+        guard !pausedByDart else { return }
+        mapView.preferredFramesPerSecond = userFps
     }
 
     func gestureRecognizer(
@@ -364,12 +398,25 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         case "map#setMaximumFps":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             if let fps = arguments["fps"] as? Int {
-                mapView.preferredFramesPerSecond = MLNMapViewPreferredFramesPerSecond(rawValue: fps)
+                userFps = MLNMapViewPreferredFramesPerSecond(rawValue: fps)
+                if !pausedByDart && !isBackgroundPaused {
+                    mapView.preferredFramesPerSecond = userFps
+                }
             }
             result(nil)
         case "map#forceOnlineMode":
             // Force online mode by ensuring network requests are enabled
             // In MapLibre GL iOS, this is typically handled by the style and data sources
+            result(nil)
+        case "map#pause":
+            pausedByDart = true
+            mapView.preferredFramesPerSecond = MLNMapViewPreferredFramesPerSecond(rawValue: 0)
+            result(nil)
+        case "map#resume":
+            pausedByDart = false
+            if !isBackgroundPaused {
+                mapView.preferredFramesPerSecond = userFps
+            }
             result(nil)
         case "camera#ease":
             guard let arguments = methodCall.arguments as? [String: Any] else { 


### PR DESCRIPTION
## Problem

On iOS, `PMTilesFileSource` runs file I/O on a C++ background thread inside MapLibre Native. When the user sends the app to background, the OS suspends the process and tears down background threads mid-read, causing a **SIGSEGV** (signal 11 crash).

Closes #833

## Root cause

`MLNMapView`'s render loop is driven by a `CADisplayLink`. As long as it is active, MapLibre Native keeps dispatching tile-fetch requests — including reads into PMTiles archives — onto its internal C++ thread pool. The OS kills those threads during process suspension before any in-flight read can complete.

## Fix

Pause the render loop (`preferredFramesPerSecond = 0`) via `UIApplication.didEnterBackgroundNotification` **before** the OS suspends the process, stopping new tile-fetch dispatch so any in-flight reads have time to drain.

`UIApplication.didEnterBackgroundNotification` is used instead of `willResignActiveNotification` so transient interruptions (incoming call banners, Control Center) do not freeze the map.

### State machine

Three flags keep all interactions correct:

| Flag | Set by | Purpose |
|---|---|---|
| `isBackgroundPaused` | `appDidEnterBackground` / `appWillEnterForeground` | Prevents `map#resume` and `map#setMaximumFps` from re-arming the render loop while backgrounded |
| `pausedByDart` | `map#pause` / `map#resume` | Prevents `appWillEnterForeground` from overriding an explicit Dart-requested pause |
| `userFps` | `map#setMaximumFps` | Stores the user-configured fps so foreground/resume restore the correct rate instead of hardcoding `.default` |

### Changes

- **`MapLibreMapController.swift`**
  - Register `didEnterBackgroundNotification` / `willEnterForegroundNotification` observers at end of `init`
  - `appDidEnterBackground`: set `isBackgroundPaused = true`, fps → 0
  - `appWillEnterForeground`: clear `isBackgroundPaused`, restore `userFps` (guarded by `pausedByDart`)
  - `map#setMaximumFps`: store fps in `userFps`; only apply to `mapView` when not paused or backgrounded
  - `map#pause` / `map#resume`: new handlers with `pausedByDart` tracking; `map#resume` guarded by `isBackgroundPaused`
  - `deinit`: `NotificationCenter.default.removeObserver(self)` before teardown

- **`Package.swift`**: bump MapLibre Native iOS SPM dependency `6.25.1` → `6.26.0` to match `maplibre_gl.podspec`

## Test plan

- [x] Open a map with PMTiles source, send app to background and foreground repeatedly — no SIGSEGV
- [x] Call `map#setMaximumFps` while backgrounded — render loop stays paused until foreground
- [x] Call `map#pause`, background and foreground — map stays paused; `map#resume` restores rendering
- [x] Call `map#pause`, then `map#setMaximumFps` — render loop does not restart until `map#resume`
- [x] Incoming call banner / Control Center while map is visible — map does not freeze