### PR TITLE
fix(ios): make setCustomHeaders apply to tile requests via URLProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [Unreleased]
 
 ### Fixed
+* **iOS**: `setCustomHeaders` and `setHttpHeaders` now correctly apply to all map network requests (tiles, styles, sprites, glyphs). Both APIs were previously silently ignored on iOS (#831).
 * **iOS**: `setMapLanguage` now passes the `text-field` expression as a native `NSArray` to `LayerPropertyConverter` instead of a JSON-encoded string. The previous code violated the converter's documented contract, so every label on custom (non-Mapbox) styles such as OpenFreeMap Liberty rendered the literal expression text (e.g. `["coalesce",["get","name:zh-Hant"],["get","name:latin"],["get","name"]]`) on the map instead of the localised place name. Same root cause as the unresolved bug in #250 and the still-open report in #336.
 * **iOS**: Accept any color string MapLibre's style-spec parser understands (`rgb()`, `rgba()`, `hsl()`, `hsla()`, named colors, ...) on layer color properties. Previously only `#RRGGBB`/`#AARRGGBB` hex was handled and anything else rendered transparent.
 

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreCustomHeaders.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreCustomHeaders.swift
@@ -2,38 +2,52 @@ import Foundation
 import MapLibre
 
 public class MapLibreCustomHeaders {
-    private static var customHeaders: [String: String] = [:]
-    private static var filterPatterns: [String] = []
+    private static let queue = DispatchQueue(
+        label: "io.flutter.maplibre_gl.customHeaders",
+        attributes: .concurrent
+    )
+    private static var _customHeaders: [String: String] = [:]
+    private static var _filterPatterns: [String] = []
 
+    // Sets both headers and filter atomically.
     public static func setCustomHeaders(_ headers: [String: String], filter: [String]) {
-        customHeaders = headers
-        filterPatterns = filter
+        queue.async(flags: .barrier) {
+            _customHeaders = headers
+            _filterPatterns = filter
+        }
+    }
 
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.httpAdditionalHeaders = headers
-        MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
+    // Updates only headers, leaving the existing filter intact.
+    public static func setHeaders(_ headers: [String: String]) {
+        queue.async(flags: .barrier) {
+            _customHeaders = headers
+        }
     }
 
     public static func getCustomHeaders() -> [String: String] {
-        return customHeaders
+        queue.sync { _customHeaders }
     }
 
     public static func getFilterPatterns() -> [String] {
-        return filterPatterns
+        queue.sync { _filterPatterns }
+    }
+
+    // Returns headers and whether they should be applied, in a single lock acquisition.
+    public static func headersIfApplicable(to url: String) -> (headers: [String: String], apply: Bool) {
+        queue.sync {
+            let apply: Bool
+            if _filterPatterns.isEmpty {
+                apply = true
+            } else {
+                apply = _filterPatterns.contains {
+                    url.range(of: $0, options: .regularExpression) != nil
+                }
+            }
+            return (_customHeaders, apply)
+        }
     }
 
     public static func shouldApplyHeaders(to url: String) -> Bool {
-        if filterPatterns.isEmpty {
-            return true
-        }
-
-        for pattern in filterPatterns {
-            if url.range(of: pattern, options: .regularExpression) != nil {
-                return true
-            }
-        }
-
-        return false
+        headersIfApplicable(to: url).apply
     }
 }
-

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreHeadersProtocol.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreHeadersProtocol.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// URLProtocol that injects custom headers into every tile/resource request that
+// MapLibre-native makes. Registered once at plugin startup; headers are read
+// from MapLibreCustomHeaders at request time, so setCustomHeaders works even
+// after MLNMapView has been created.
+final class MapLibreHeadersProtocol: URLProtocol {
+    private static let handledKey = "MapLibreHeadersProtocolHandled"
+
+    // Stored so stopLoading() can cancel and invalidate them.
+    private var activeTask: URLSessionDataTask?
+    private var activeSession: URLSession?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        guard URLProtocol.property(forKey: handledKey, in: request) == nil else {
+            return false
+        }
+        let scheme = request.url?.scheme?.lowercased() ?? ""
+        return scheme == "http" || scheme == "https"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        let mutable = (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
+        URLProtocol.setProperty(true, forKey: Self.handledKey, in: mutable)
+
+        // Read headers and filter atomically in one lock acquisition.
+        let (headers, shouldApply) = MapLibreCustomHeaders.headersIfApplicable(to: mutable.url?.absoluteString ?? "")
+        if shouldApply {
+            for (key, value) in headers {
+                mutable.setValue(value, forHTTPHeaderField: key)
+            }
+        }
+
+        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        let task = session.dataTask(with: mutable as URLRequest)
+        activeSession = session
+        activeTask = task
+        task.resume()
+    }
+
+    override func stopLoading() {
+        activeTask?.cancel()
+        activeSession?.invalidateAndCancel()
+        activeTask = nil
+        activeSession = nil
+    }
+}
+
+extension MapLibreHeadersProtocol: URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        client?.urlProtocol(self, didLoad: data)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        activeSession?.finishTasksAndInvalidate()
+        activeTask = nil
+        activeSession = nil
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+        client?.urlProtocol(self, wasRedirectedTo: request, redirectResponse: response)
+        // Follow the redirect so the underlying load completes.
+        completionHandler(request)
+    }
+}

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapsPlugin.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapsPlugin.swift
@@ -11,6 +11,16 @@ public class MapLibreMapsPlugin: NSObject, FlutterPlugin {
         let instance = MapLibreMapFactory(withRegistrar: registrar)
         registrar.register(instance, withId: "plugins.flutter.io/maplibre_gl")
 
+        // Register the header-injection protocol before any MLNMapView is created.
+        // MLNNetworkConfiguration docs require sessionConfiguration to be set before
+        // the first map view; we bake the protocol class into the session config here
+        // so that MapLibreHeadersProtocol can intercept requests at call time.
+        let sessionConfig = MLNNetworkConfiguration.sharedManager.sessionConfiguration
+            ?? URLSessionConfiguration.default
+        sessionConfig.protocolClasses = [MapLibreHeadersProtocol.self]
+            + (sessionConfig.protocolClasses ?? [])
+        MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
+
         let channel = FlutterMethodChannel(
             name: "plugins.flutter.io/maplibre_gl",
             binaryMessenger: registrar.messenger()
@@ -30,9 +40,7 @@ public class MapLibreMapsPlugin: NSObject, FlutterPlugin {
                     result(nil)
                     return
                 }
-                let sessionConfig = URLSessionConfiguration.default
-                sessionConfig.httpAdditionalHeaders = headers // your headers here
-                MLNNetworkConfiguration.sharedManager.sessionConfiguration = sessionConfig
+                MapLibreCustomHeaders.setHeaders(headers)
                 result(nil)
             case "installOfflineMapTiles":
                 guard let arguments = methodCall.arguments as? [String: String] else { return }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineManagerUtils.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/OfflineManagerUtils.swift
@@ -233,7 +233,10 @@ class OfflineManagerUtils {
     // MARK: Concurrency Control
 
     static func setMaxConcurrentRequests(result: @escaping FlutterResult, maxRequestsPerHost: Int?) {
-        let sessionConfig = MLNNetworkConfiguration.sharedManager.sessionConfiguration ?? URLSessionConfiguration.default
+        // Read the existing config so protocolClasses (e.g. MapLibreHeadersProtocol)
+        // registered at startup are preserved when we write back.
+        let sessionConfig = MLNNetworkConfiguration.sharedManager.sessionConfiguration
+            ?? URLSessionConfiguration.default
         if let maxPerHost = maxRequestsPerHost {
             sessionConfig.httpMaximumConnectionsPerHost = maxPerHost
         }

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1092,12 +1092,41 @@ class MapLibreMapController extends ChangeNotifier {
     return _maplibrePlatform.getStyle();
   }
 
-  /// Sets custom HTTP headers for map requests.
+  /// Sets custom HTTP headers that are injected into network requests made by
+  /// this map instance.
   ///
-  /// The [headers] map contains the header key-value pairs to set, and [filter]
-  /// contains URL patterns to determine which requests should include these headers.
+  /// [headers] is a map of header name to value. Pass an empty map to clear
+  /// all previously set headers.
   ///
-  /// The returned [Future] completes when the headers are successfully set.
+  /// [filter] is a list of regular-expression strings. When non-empty, headers
+  /// are only injected into requests whose URL matches **at least one** of the
+  /// patterns. When empty, headers are injected into every request.
+  ///
+  /// This is a **per-map** API and takes effect immediately — subsequent tile
+  /// requests will carry the new headers. To apply headers globally to all map
+  /// instances without URL filtering, use the top-level [setHttpHeaders]
+  /// function instead.
+  ///
+  /// Example — restrict an API key to a specific tile host:
+  /// ```dart
+  /// await controller.setCustomHeaders(
+  ///   {'X-Api-Key': 'secret'},
+  ///   [r'https://tiles\.example\.com/.*'],
+  /// );
+  /// ```
+  ///
+  /// Example — apply headers to all requests (no filter):
+  /// ```dart
+  /// await controller.setCustomHeaders(
+  ///   {'Authorization': 'Bearer $token'},
+  ///   [],
+  /// );
+  /// ```
+  ///
+  /// Example — clear all headers:
+  /// ```dart
+  /// await controller.setCustomHeaders({}, []);
+  /// ```
   Future<void> setCustomHeaders(
     Map<String, String> headers,
     List<String> filter,
@@ -1105,9 +1134,10 @@ class MapLibreMapController extends ChangeNotifier {
     return _maplibrePlatform.setCustomHeaders(headers, filter);
   }
 
-  /// Gets the current custom HTTP headers.
+  /// Returns the custom HTTP headers currently set on this map instance.
   ///
-  /// The returned [Future] completes with a map of the current custom headers.
+  /// Returns the headers previously set via [setCustomHeaders]. Does not
+  /// include headers set via the global [setHttpHeaders] function.
   Future<Map<String, String>> getCustomHeaders() async {
     return _maplibrePlatform.getCustomHeaders();
   }

--- a/maplibre_gl/lib/src/global.dart
+++ b/maplibre_gl/lib/src/global.dart
@@ -36,6 +36,34 @@ Future<dynamic> setOffline(bool offline) => _globalChannel.invokeMethod(
   },
 );
 
+/// Sets HTTP headers that are injected into every network request MapLibre
+/// makes (tile fetches, style JSON, sprites, glyphs).
+///
+/// This is a **global** API: the headers apply to all map instances in the
+/// process. To scope headers to specific URLs or to a single map instance,
+/// use [MaplibreMapController.setCustomHeaders] instead.
+///
+/// Headers are applied at request time, so this method can be called before
+/// or after a [MaplibreMap] widget is created. Calling it again replaces the
+/// previously set headers; pass an empty map to clear all headers.
+///
+/// Example — attach a bearer token before showing any map:
+/// ```dart
+/// await setHttpHeaders({'Authorization': 'Bearer $token'});
+/// ```
+///
+/// Example — attach multiple headers:
+/// ```dart
+/// await setHttpHeaders({
+///   'Authorization': 'Bearer $token',
+///   'X-Request-ID': requestId,
+/// });
+/// ```
+///
+/// Example — clear all previously set headers:
+/// ```dart
+/// await setHttpHeaders({});
+/// ```
 Future<void> setHttpHeaders(Map<String, String> headers) {
   return _globalChannel.invokeMethod(
     'setHttpHeaders',

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -156,13 +156,36 @@ abstract class MapLibrePlatform {
   /// Gets the current map style as JSON string.
   Future<String?> getStyle();
 
-  /// Sets custom HTTP headers for map requests.
+  /// Sets custom HTTP headers for requests made by this map instance.
+  ///
+  /// [headers] is a map of header name to value. Pass an empty map to remove
+  /// all previously set headers.
+  ///
+  /// [filter] is a list of regular-expression strings. When non-empty, headers
+  /// are only injected into requests whose URL matches at least one pattern.
+  /// Pass an empty list to apply headers to every request.
+  ///
+  /// Example — send an API key only to your own tile server:
+  /// ```dart
+  /// await controller.setCustomHeaders(
+  ///   {'X-Api-Key': 'secret'},
+  ///   [r'https://tiles\.example\.com/.*'],
+  /// );
+  /// ```
+  ///
+  /// Example — send an Authorization header to all requests (no filter):
+  /// ```dart
+  /// await controller.setCustomHeaders(
+  ///   {'Authorization': 'Bearer $token'},
+  ///   [],
+  /// );
+  /// ```
   Future<void> setCustomHeaders(
     Map<String, String> headers,
     List<String> filter,
   );
 
-  /// Gets the current custom HTTP headers.
+  /// Returns the custom HTTP headers currently set on this map instance.
   Future<Map<String, String>> getCustomHeaders();
 
   Future<List> queryRenderedFeatures(


### PR DESCRIPTION
## Summary

Fixes #831 — `setCustomHeaders` silently does nothing on iOS.

### Root cause

`MLNNetworkConfiguration` documentation explicitly states that `sessionConfiguration` must be set **before** the first `MLNMapView` is instantiated. The previous implementation called `MLNNetworkConfiguration.sharedManager.sessionConfiguration = ...` from `setCustomHeaders` / `setHttpHeaders`, which is after the map view already exists. The already-created internal `URLSession` ignores any subsequent changes to the session config, so headers were never applied.

### Fix

Register a `URLProtocol` subclass (`MapLibreHeadersProtocol`) at plugin startup — inside `register(with:)`, before any `MLNMapView` is created — by prepending it to `MLNNetworkConfiguration.sharedManager.sessionConfiguration.protocolClasses`. The protocol intercepts every HTTP/HTTPS request at call time and injects the current custom headers, so `setCustomHeaders` / `setHttpHeaders` work correctly even after the map view has been created.

This mirrors how Android already works: OkHttp `NetworkInterceptor` added to the client reads headers at request time, not at configuration time.

### Changes

- **`MapLibreHeadersProtocol.swift`** (new) — `URLProtocol` subclass; intercepts HTTP/HTTPS, injects headers from `MapLibreCustomHeaders` atomically, handles `stopLoading` cancellation and session cleanup correctly.
- **`MapLibreCustomHeaders.swift`** — added thread safety (concurrent `DispatchQueue` with barrier writes); added `setHeaders(_:)` to update only headers without clobbering the filter set by the per-map API; added `headersIfApplicable(to:)` to read headers + filter in a single lock acquisition.
- **`MapLibreMapsPlugin.swift`** — register the protocol at startup; change `setHttpHeaders` handler to call `MapLibreCustomHeaders.setHeaders(_:)` instead of directly mutating `MLNNetworkConfiguration`.
- **`OfflineManagerUtils.swift`** — comment explaining the read-back pattern in `setMaxConcurrentRequests` preserves the registered `protocolClasses`.

## Test plan

- [ ] Call `setHttpHeaders({"Authorization": "Bearer token"})` before and after map creation — verify network requests include the header in a proxy/Charles trace
- [ ] Call `map.setCustomHeaders({"X-Key": "val"}, filter: ["tiles.example.com"])` — verify header applied only to matching URLs
- [ ] Verify map loads normally when no custom headers are set (nil / empty headers)
- [ ] Verify offline region download still works after calling `setMaxConcurrentRequests`