### PR TITLE
fix(web): load asset styles via rootBundle and fix PMTiles protocol race

### DIFF
--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -34,21 +34,22 @@
   <link href='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.css' rel='stylesheet'/>
   <script src="https://unpkg.com/pmtiles@4.4.0/dist/pmtiles.js"></script>
 
-  <title>MapLibre Example</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-
+  <!-- PMTiles protocol must be registered before Flutter boots, so it is placed
+       here (synchronous, after the pmtiles script above) rather than after the
+       async flutter_bootstrap.js which could execute before an inline script
+       that follows it. -->
   <script>
-    // This is just a rough sketch of how to set up a maplibre-gl JS map with pmtiles.
-    // The URL used is the same as in assets/pmtiles_style.json.
-    // In development this only works when passing `--web-browser-flag "--disable-web-security"` to flutter run.
     const protocol = new pmtiles.Protocol();
     maplibregl.addProtocol("pmtiles", protocol.tile);
     const PMTILES_URL = "https://demo-bucket.protomaps.com/v4.pmtiles";
     const source = new pmtiles.FetchSource(PMTILES_URL);
     protocol.add(new pmtiles.PMTiles(source));
   </script>
+
+  <title>MapLibre Example</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -77,7 +77,9 @@ class MapLibreMapController extends MapLibrePlatform
   Future<void> initPlatform(int id) async {
     final camera =
         _creationParams['initialCameraPosition'] as Map<String, dynamic>?;
-    final styleString = _sanitizeStyleObject(_creationParams['styleString']);
+    final styleString = await _sanitizeStyleObject(
+      _creationParams['styleString'],
+    );
     _dragEnabled = _creationParams['dragEnabled'] ?? true;
 
     _map = MapLibreMap(
@@ -1110,21 +1112,29 @@ class MapLibreMapController extends MapLibrePlatform
     }
     _interactiveFeatureLayerIds.clear();
 
-    final sanitizedStyle = _sanitizeStyleObject(styleObject);
+    final sanitizedStyle = await _sanitizeStyleObject(styleObject);
     _map.setStyle(sanitizedStyle, {'diff': false});
   }
 
   /// Sanitizes the style object to ensure it is in the correct format.
-  /// If the style object is a JSON string, use JavaScript's native JSON.parse
-  /// to avoid Dart object metadata leaking into web workers.
-  dynamic _sanitizeStyleObject(dynamic styleObject) {
-    if (styleObject is String &&
-        (styleObject.startsWith('{') || styleObject.startsWith('['))) {
-      // Use JavaScript's native JSON.parse to create pure JS objects
-      return jsonParse(styleObject);
-    } else {
-      return styleObject;
+  ///
+  /// - JSON strings are parsed via native JSON.parse to avoid Dart metadata
+  ///   leaking into web workers.
+  /// - Asset paths (starting with `assets/`) are loaded via [rootBundle] and
+  ///   returned as parsed JS objects, because static asset files are not
+  ///   directly addressable as HTTP resources in all Flutter web deployment
+  ///   configurations (e.g. GitHub Pages with a non-root base href).
+  Future<dynamic> _sanitizeStyleObject(dynamic styleObject) async {
+    if (styleObject is String) {
+      if (styleObject.startsWith('{') || styleObject.startsWith('[')) {
+        return jsonParse(styleObject);
+      }
+      if (styleObject.startsWith('assets/')) {
+        final jsonString = await rootBundle.loadString(styleObject);
+        return jsonParse(jsonString);
+      }
     }
+    return styleObject;
   }
 
   @override


### PR DESCRIPTION
## Summary

- **Asset styles return 404 on GitHub Pages**: `assets/style.json` and similar paths were passed as URL strings to MapLibre GL JS, which then fetched them via HTTP. On GitHub Pages (with `--base-href`), the path resolves to a 404 because Flutter web assets are not directly addressable as static HTTP resources. Fix: `_sanitizeStyleObject` in `maplibre_web_gl_platform.dart` now detects `assets/` prefixes and loads the file via `rootBundle.loadString()`, passing the parsed JS object instead.
- **PMTiles protocol race condition**: The `addProtocol("pmtiles", ...)` inline script in `index.html` was placed after `<script src="flutter_bootstrap.js" async>`. A cached async script can execute before subsequent inline scripts, so Flutter could boot and create the map before the protocol was registered. Fix: moved the PMTiles setup into `<head>` as a synchronous script, guaranteed to run before Flutter boots.

Fixes the **PMTiles example** and **Multi style switch** (asset styles) in the live demo at https://maplibre.org/flutter-maplibre-gl/.

## Test plan

- [ ] Open https://maplibre.org/flutter-maplibre-gl/ after merging and triggering a deploy
- [ ] PMTiles example renders the map correctly
- [ ] Multi style switch: switching to `assets/style.json` and `assets/osm_style.json` works without errors
- [ ] No regressions in other examples that use remote style URLs