### PR TITLE
fix(android): temporary workaround for icon atlas bug (maplibre-native#4326)

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -445,7 +445,10 @@ final class MapLibreMapController
         return;
       }
 
-      GeoJsonOptions options = new GeoJsonOptions().withSynchronousUpdate(dragEnabled);
+      // synchronousUpdate causes a texture atlas slot-reuse bug in MapLibre Native Android SDK
+      // that silently discards icons registered via addImage() in the same render frame.
+      // Disabled unconditionally until upstream maplibre-native#4326 is fixed.
+      GeoJsonOptions options = new GeoJsonOptions().withSynchronousUpdate(false);
       GeoJsonSource geoJsonSource = new GeoJsonSource(sourceName, featureCollection, options);
       addedFeaturesByLayer.put(sourceName, featureCollection);
 
@@ -1643,18 +1646,19 @@ final class MapLibreMapController
                 null);
             break;
           }
-          // Configure bitmap options to prevent density-based scaling
           BitmapFactory.Options options = new BitmapFactory.Options();
-          options.inScaled = false;       // Disable automatic scaling
-          options.inDensity = 0;          // No source density
-          options.inTargetDensity = 0;    // No target density
-          
+          options.inScaled = false;
+          options.inDensity = DisplayMetrics.DENSITY_DEFAULT;
+          options.inTargetDensity = DisplayMetrics.DENSITY_DEFAULT;
           Bitmap bitmap = BitmapFactory.decodeByteArray(
-              call.argument("bytes"), 
-              0, 
+              call.argument("bytes"),
+              0,
               call.argument("length"),
               options);
-          
+          if (bitmap == null) {
+            result.error("INVALID_IMAGE", "Failed to decode image bytes.", null);
+            break;
+          }
           style.addImage(
               call.argument("name"),
               bitmap,
@@ -1672,6 +1676,14 @@ final class MapLibreMapController
             break;
           }
           List<LatLng> coordinates = Convert.toLatLngList(call.argument("coordinates"), false);
+          Bitmap addSourceBitmap = BitmapFactory.decodeByteArray(
+              call.argument("bytes"),
+              0,
+              call.argument("length"));
+          if (addSourceBitmap == null) {
+            result.error("INVALID_IMAGE", "Failed to decode image bytes.", null);
+            break;
+          }
           style.addSource(
               new ImageSource(
                   call.argument("imageSourceId"),
@@ -1680,8 +1692,7 @@ final class MapLibreMapController
                       coordinates.get(1),
                       coordinates.get(2),
                       coordinates.get(3)),
-                  BitmapFactory.decodeByteArray(
-                      call.argument("bytes"), 0, call.argument("length"))));
+                  addSourceBitmap));
           result.success(null);
           break;
         }
@@ -1706,7 +1717,12 @@ final class MapLibreMapController
           }
           byte[] bytes = call.argument("bytes");
           if (bytes != null) {
-            imageSource.setImage(BitmapFactory.decodeByteArray(bytes, 0, call.argument("length")));
+            Bitmap updateBitmap = BitmapFactory.decodeByteArray(bytes, 0, call.argument("length"));
+            if (updateBitmap == null) {
+              result.error("INVALID_IMAGE", "Failed to decode image bytes.", null);
+              break;
+            }
+            imageSource.setImage(updateBitmap);
           }
           result.success(null);
           break;

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/SourcePropertyConverter.java
@@ -72,7 +72,9 @@ class SourcePropertyConverter {
   }
 
   static GeoJsonOptions buildGeojsonOptions(Map<String, Object> data) {
-    GeoJsonOptions options = new GeoJsonOptions();
+    // Disabled until upstream maplibre-native#4326 is fixed: synchronousUpdate causes a
+    // texture atlas slot-reuse bug that silently discards icons added via addImage().
+    GeoJsonOptions options = new GeoJsonOptions().withSynchronousUpdate(false);
 
     final Object buffer = data.get("buffer");
     if (buffer != null) {


### PR DESCRIPTION
## Summary

Temporary workaround for #825 while the root cause remains unresolved upstream ([maplibre-native#4326](https://github.com/maplibre/maplibre-native/issues/4326)).

### Root cause

Since 0.26.0, Android `GeoJsonSource` objects are created with `withSynchronousUpdate(true)` when drag is enabled (the default). This triggers an upstream bug in the MapLibre Native Android SDK's dynamic texture atlas: when a tile re-layout fires in the same render frame as an `addImage()` call, the atlas reuses the existing slot without re-uploading the GPU pixels. The result is that icons registered via `addImage()` are silently discarded — they appear in the style registry but never reach the GPU.

The upstream fix was proposed in [maplibre-native#4193](https://github.com/maplibre/maplibre-native/pull/4193) but closed unmerged. The issue ([maplibre-native#4326](https://github.com/maplibre/maplibre-native/issues/4326)) remains open and is not fixed in `android-v13.3.0`.

### Changes

**`MapLibreMapController.java`**
- `addGeoJsonSource`: pass `withSynchronousUpdate(false)` unconditionally (was `withSynchronousUpdate(dragEnabled)`)
- `style#addImage`: fix `inDensity=0` → `DENSITY_DEFAULT` so `Style.toImage()` computes `pixelRatio = 1.0` on all devices instead of `screenDensity / 160` (e.g. 3.0 on xxxhdpi); add null check on `decodeByteArray` result
- `style#addImageSource`, `style#updateImageSource`: add null check on `decodeByteArray` result to surface decode failures as clean channel errors instead of NPE

**`SourcePropertyConverter.java`**
- `buildGeojsonOptions`: add `withSynchronousUpdate(false)` — this covers `GeoJsonSource` objects created via the `style#addSource` channel, which previously bypassed the fix in `addGeoJsonSource`

### Revert plan

Remove the `withSynchronousUpdate(false)` calls once maplibre-native#4326 is fixed and the Android SDK dependency is bumped past the fix.

### Test plan

- [ ] Add a symbol via `addImage()` + `addSymbolLayer` on Android — icon should render correctly
- [ ] Drag a symbol annotation — drag should remain smooth (synchronousUpdate is not required for the async Flutter channel drag path)
- [ ] Verify on a high-density device (xxxhdpi) that icon size is correct (pixelRatio fix)
- [ ] Pass corrupted image bytes to `addImage` — should return a `PlatformException` instead of crashing

Refs #825