### PR TITLE
fix(android): restore bitmap decode options of addImage

### DIFF
--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -1643,18 +1643,19 @@ final class MapLibreMapController
                 null);
             break;
           }
-          // Configure bitmap options to prevent density-based scaling
           BitmapFactory.Options options = new BitmapFactory.Options();
-          options.inScaled = false;       // Disable automatic scaling
-          options.inDensity = 0;          // No source density
-          options.inTargetDensity = 0;    // No target density
-          
+          options.inScaled = false;
+          options.inDensity = 0;
+          options.inTargetDensity = 0;
           Bitmap bitmap = BitmapFactory.decodeByteArray(
-              call.argument("bytes"), 
-              0, 
+              call.argument("bytes"),
+              0,
               call.argument("length"),
               options);
-          
+          if (bitmap == null) {
+            result.error("INVALID_IMAGE", "Failed to decode image bytes.", null);
+            break;
+          }
           style.addImage(
               call.argument("name"),
               bitmap,


### PR DESCRIPTION
## Summary

- Remove inline comments and trailing whitespace from the `BitmapFactory.Options` block in `addImage`
- Add a null-check on the decoded bitmap so callers get a proper `INVALID_IMAGE` error instead of a `NullPointerException` when decoding fails

## Test plan

- [ ] Call `addImage` with valid PNG/JPEG bytes and verify the image renders correctly on the map
- [ ] Call `addImage` with invalid/corrupt bytes and verify a proper error is returned (no crash)