### PR TITLE
docs: fix docs live examples, CI deploy, and slim README

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -88,7 +88,7 @@ jobs:
       # on the faster plain JS build above.
       - if: inputs.platform == 'web' && inputs.web-release
         name: Build web (release, WASM, Pages base-href)
-        run: flutter build web --wasm --release --base-href /flutter-maplibre-gl/
+        run: flutter build web --wasm --release --base-href /flutter-maplibre-gl/demo/
       - if: inputs.platform == 'web' && inputs.web-release
         name: Upload web build artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -208,13 +208,19 @@ jobs:
         working-directory: website
         run: mkdocs build
 
-      - name: Assemble Pages bundle (web demo + docs)
-        run: cp -r website/site web-demo/docs
+      # Pages bundle layout: the docs site is the root homepage, and the
+      # Flutter web demo is served under /demo/ (built with that base-href).
+      - name: Assemble Pages bundle (docs at root + demo under /demo)
+        run: |
+          mkdir -p pages
+          cp -r website/site/. pages/
+          mkdir -p pages/demo
+          cp -r web-demo/. pages/demo/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: web-demo
+          path: pages
 
   deploy-pages:
     name: "Deploy to GitHub Pages"

--- a/maplibre_gl/README.md
+++ b/maplibre_gl/README.md
@@ -2,28 +2,57 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-dark-bg.svg">
     <source media="(prefers-color-scheme: light)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg">
-    <img alt="MapLibre Logo" src="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg" width="200">
+    <img alt="MapLibre Logo" src="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg" width="240">
   </picture>
 </p>
 
-# Flutter MapLibre GL
+<h1 align="center">Flutter MapLibre GL</h1>
 
-[![Pub Version](https://img.shields.io/pub/v/maplibre_gl)](https://pub.dev/packages/maplibre_gl)
-[![likes](https://img.shields.io/pub/likes/maplibre_gl?logo=flutter)](https://pub.dev/packages/maplibre_gl)
-[![Pub Points](https://img.shields.io/pub/points/maplibre_gl)](https://pub.dev/packages/maplibre_gl/score)
-[![stars](https://badgen.net/github/stars/maplibre/flutter-maplibre-gl?label=stars&color=green&icon=github)](https://github.com/maplibre/flutter-maplibre-gl/stargazers)
-[![melos](https://img.shields.io/badge/maintained%20with-melos-f700ff.svg?style=flat-square)](https://github.com/invertase/melos)
+<p align="center">
+  Interactive, vector-tile, fully styleable maps for Flutter on <b>Android, iOS and Web</b>, powered by the open source <a href="https://github.com/maplibre">MapLibre</a> engines.<br>
+  <b>Vendor-neutral</b>: host your own tiles or mix providers, no proprietary token required.
+</p>
 
-Interactive, vector-tile, fully styleable maps for Flutter on **Android, iOS and Web**, powered by the open source [MapLibre](https://github.com/maplibre) engines. Vendor-neutral: host your own tiles or mix providers, no proprietary token required.
+<p align="center">
+  <a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/v/maplibre_gl?style=flat-square" alt="Pub Version"></a>
+  <a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/likes/maplibre_gl?logo=flutter&style=flat-square" alt="Likes"></a>
+  <a href="https://pub.dev/packages/maplibre_gl/score"><img src="https://img.shields.io/pub/points/maplibre_gl?style=flat-square" alt="Pub Points"></a>
+  <a href="https://github.com/maplibre/flutter-maplibre-gl/stargazers"><img src="https://img.shields.io/github/stars/maplibre/flutter-maplibre-gl?style=flat-square&logo=github&color=green" alt="Stars"></a>
+  <a href="https://github.com/invertase/melos"><img src="https://img.shields.io/badge/maintained%20with-melos-f700ff.svg?style=flat-square" alt="Melos"></a>
+</p>
 
-This project is a fork of [flutter-mapbox-gl](https://github.com/tobrun/flutter-mapbox-gl). If you're coming from it, see [Migration](#migration).
+<p align="center">
+  <b>✨ New:</b> try the package live in your browser and browse the full docs, no setup or API keys required.
+</p>
 
-🚀 **[Launch the interactive demo](https://maplibre.github.io/flutter-maplibre-gl/)** — explore the full example app, interact with the map, and try MapLibre GL features instantly in your browser. No installation, setup, or API keys required.
+<p align="center">
+  <a href="https://maplibre.github.io/flutter-maplibre-gl/demo/"><img src="https://img.shields.io/badge/🚀%20Live%20demo-2A6BF2?style=for-the-badge" height="38" alt="Live demo"></a>
+  &nbsp;&nbsp;
+  <a href="https://maplibre.github.io/flutter-maplibre-gl/"><img src="https://img.shields.io/badge/📖%20Documentation-3FB950?style=for-the-badge" height="38" alt="Documentation"></a>
+</p>
 
-## Platforms & feature support
+## ✨ Quick start
 
-Engines: [maplibre-native](https://github.com/maplibre/maplibre-native) (Android/iOS), [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js) (Web). 
-Only a subset of native SDK APIs is exposed, PRs to extend coverage are welcome.
+```bash
+flutter pub add maplibre_gl
+```
+
+```dart
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+MapLibreMap(
+  initialCameraPosition: const CameraPosition(target: LatLng(0, 0), zoom: 2),
+  styleString: 'https://demotiles.maplibre.org/style.json',
+);
+```
+
+Then head to the [getting started guide](https://maplibre.github.io/flutter-maplibre-gl/getting-started/) for platform setup (iOS/Android permissions, the web `<script>` tag) and to learn how to add markers, layers, offline tiles and more.
+
+> Migrating from [flutter-mapbox-gl](https://github.com/tobrun/flutter-mapbox-gl)? See the [migration guide](https://maplibre.github.io/flutter-maplibre-gl/migration/).
+
+## 🗺️ Feature support
+
+Engines: [maplibre-native](https://github.com/maplibre/maplibre-native) (Android/iOS), [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js) (Web). Only a subset of native SDK APIs is exposed, PRs to extend coverage are welcome.
 
 | Feature | Android | iOS | Web |
 |---|:---:|:---:|:---:|
@@ -33,174 +62,30 @@ Only a subset of native SDK APIs is exposed, PRs to extend coverage are welcome.
 | Fill Extrusion | ✅ | ✅ | ✅ |
 | Heatmap Layer | ✅ | ✅ | ✅ |
 
-## Installation
+See the full [feature matrix](https://maplibre.github.io/flutter-maplibre-gl/compare/feature-matrix/) for details.
 
-```bash
-flutter pub add maplibre_gl
-```
-
-### iOS
-
-If you use location features, add to `ios/Runner/Info.plist`:
-
-```xml
-<key>NSLocationWhenInUseUsageDescription</key>
-<string>[Explain why the app needs the user's location]</string>
-<key>NSLocationAlwaysUsageDescription</key>
-<string>[Explain why the app needs the user's location in the background]</string>
-```
-
-`NSLocationAlwaysUsageDescription` is only required if you request always-on location access.
-
-### Android
-
-For location features, add to `android/app/src/main/AndroidManifest.xml`:
-
-```xml
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-```
-
-The plugin does not request permissions at runtime — handle that yourself (e.g. with [`location`](https://pub.dev/packages/location)).
-
-### Web
-
-Add to the `<head>` of `web/index.html`:
-
-```html
-<script src='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.js'></script>
-<link href='https://unpkg.com/maplibre-gl@^5.24.0/dist/maplibre-gl.css' rel='stylesheet'/>
-```
-
-Always use the version that matches your installed `maplibre_gl_web` — check the example app's [`web/index.html`](./maplibre_gl_example/web/index.html) for the tag currently in use.
-
-## Quick start
-
-```dart
-import 'dart:async';
-import 'package:flutter/material.dart';
-import 'package:maplibre_gl/maplibre_gl.dart';
-
-class SimpleMapPage extends StatefulWidget {
-  const SimpleMapPage({super.key});
-  @override
-  State<SimpleMapPage> createState() => _SimpleMapPageState();
-}
-
-class _SimpleMapPageState extends State<SimpleMapPage> {
-  final _controller = Completer<MapLibreMapController>();
-  static const _initial = CameraPosition(target: LatLng(0, 0), zoom: 2);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: MapLibreMap(
-        initialCameraPosition: _initial,
-        onMapCreated: _controller.complete,
-        styleString: 'https://demotiles.maplibre.org/style.json',
-      ),
-    );
-  }
-}
-```
-
-See the [example app](./maplibre_gl_example) for markers, layers, offline tiles and PMTiles.
-
-## Usage
-
-### Camera
-
-```dart
-await controller.animateCamera(
-  CameraUpdate.newLatLngBounds(bounds, left: 24, top: 24, right: 24, bottom: 24),
-);
-```
-
-Defer camera animations until the style is ready (`onStyleLoadedCallback`).
-
-### Annotations
-
-```dart
-await controller.addSymbol(SymbolOptions(
-  geometry: LatLng(37.7749, -122.4194),
-  iconImage: 'assets/icon_pin.png', // register as a style image first
-  iconSize: 1.2,
-));
-```
-
-For lines/fills via a GeoJSON source, see the example app. Add sources before the layers that depend on them.
-
-### Styles
-
-`styleString` accepts any of: a remote URL, a bundled asset (registered in `pubspec.yaml`), an absolute file path, or a raw JSON string.
-
-### Tiles requiring an API key
-
-Embed the key in the tile URL:
-
-```
-https://tiles.example.com/{z}/{x}/{y}.vector.pbf?api_key=YOUR_KEY
-```
-
-Restrict keys at the provider (domain/referer, usage caps) and inject them at build time rather than committing them.
-
-## Advanced topics
-**Offline / mbtiles** — copy mbtiles, sprites and glyphs from assets to a writable directory, then point your style sources there. See issues [#338](https://github.com/maplibre/flutter-maplibre-gl/issues/338) and [#318](https://github.com/maplibre/flutter-maplibre-gl/issues/318).
-
-**PMTiles** — load datasets via a custom protocol handler; see `pmtiles.dart` in the example app.
-
-**Expressions** — data-driven styling follows the MapLibre style spec. For cross-platform safety use `["!", ["has", "field"]]` rather than `["!has", "field"]` (see FAQ).
-
-**Code generation** — layer/source helpers are generated. Do not edit them directly; run `melos run generate && melos format-all`.
-
-## Migration
-
-Most APIs are source-compatible with `flutter-mapbox-gl`:
-
-- Rename the dependency to `maplibre_gl`.
-- Remove Mapbox token initialization — MapLibre uses open assets or your own endpoints.
-- Replace Mapbox-specific style URLs with self-hosted or MapLibre-compatible ones.
-- Audit filter expressions for iOS (`["!has", ...]` → `["!", ["has", ...]]`).
-
-## Troubleshooting
-
-**Loading mbtiles/sprites/glyphs from assets** — copy to a writable directory first, then reference the new path.
-
-**Android `UnsatisfiedLinkError`** — make sure `abiFilters` covers the ABIs you ship:
-
-```groovy
-ndk { abiFilters 'armeabi-v7a','arm64-v8a','x86_64','x86' }
-```
-
-**iOS crash on location** — add `NSLocationWhenInUseUsageDescription` (see [iOS setup](#ios)).
-
-**iOS `filter property must be a string`** — replace `["!has", "value"]` with `["!", ["has", "value"]]`.
-
-## Architecture
-
-Multi-package melos workspace:
-
-- `maplibre_gl` — main plugin (mobile/native bindings)
-- `maplibre_gl_web` — web implementation
-- `maplibre_gl_platform_interface` — shared platform interface
-- `scripts/` — code generation
-
-Layer/source property helpers and expression utilities are generated. Don't edit generated files; run `melos run generate && melos format-all`.
-
-## Contributing
+## 🤓 Contributing
 
 ```bash
 dart pub global activate melos
 melos bootstrap
 ```
 
-Then run the example app to validate changes. See [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR.
+This is a melos workspace (`maplibre_gl`, `maplibre_gl_web`, `maplibre_gl_platform_interface`). Layer/source helpers are generated, don't edit them directly; run `melos run generate && melos format-all`. See [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR, and the [architecture docs](https://maplibre.github.io/flutter-maplibre-gl/concepts/architecture/) for an overview.
 
-## Resources
+This project is a fork of [flutter-mapbox-gl](https://github.com/tobrun/flutter-mapbox-gl). ❤️
 
-- API docs: https://pub.dev/documentation/maplibre_gl/latest/
-- [Changelog](./CHANGELOG.md) — always check before upgrading
-- Help: [Discussions](https://github.com/maplibre/flutter-maplibre-gl/discussions), [Issues](https://github.com/maplibre/flutter-maplibre-gl/issues/new), [Slack](https://slack.openstreetmap.us/), [StackOverflow #maplibre](https://stackoverflow.com/search?q=maplibre)
+## 🔗 Links
+
+[Example app](./maplibre_gl_example) · [API reference](https://pub.dev/documentation/maplibre_gl/latest/maplibre_gl/) · [Changelog](./CHANGELOG.md) · [Discussions](https://github.com/maplibre/flutter-maplibre-gl/discussions) · [Issues](https://github.com/maplibre/flutter-maplibre-gl/issues/new) · [Slack](https://slack.openstreetmap.us/)
+
+## 💝 Contributors
+
+A huge thanks to everyone who has contributed to this project!
+
+<a href="https://github.com/maplibre/flutter-maplibre-gl/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=maplibre/flutter-maplibre-gl" alt="Contributors" />
+</a>
 
 ## License
 

--- a/maplibre_gl_example/assets/pmtiles_style.json
+++ b/maplibre_gl_example/assets/pmtiles_style.json
@@ -4,7 +4,7 @@
     "protomaps": {
       "type": "vector",
       "attribution": "<a href=\"https://github.com/protomaps/basemaps\">Protomaps</a> © <a href=\"https://openstreetmap.org\">OpenStreetMap</a>",
-      "url": "pmtiles://https://demo-bucket.protomaps.com/v4.pmtiles"
+      "url": "pmtiles://https://build.protomaps.com/20260625.pmtiles"
     }
   },
   "layers": [

--- a/maplibre_gl_example/lib/examples/docs/doc_annotation_markers.dart
+++ b/maplibre_gl_example/lib/examples/docs/doc_annotation_markers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 import '../../page.dart';
 import '../../shared/shared.dart';
+import '../../util.dart';
 
 class DocAnnotationMarkersExample extends ExamplePage {
   const DocAnnotationMarkersExample({super.key})
@@ -57,6 +58,15 @@ class _DocAnnotationMarkersBodyState extends State<_DocAnnotationMarkersBody> {
     final ctrl = _controller;
     if (ctrl == null) return;
 
+    // The demo style has no built-in marker sprite, so register a bundled
+    // image and reference it by name. (Using a style sprite icon like
+    // "marker-15" would fail with "image could not be loaded".)
+    await addImageFromAsset(
+      ctrl,
+      'doc-marker',
+      'assets/symbols/custom-marker.png',
+    );
+
     for (final landmark in _landmarks) {
       await ctrl.addSymbol(
         SymbolOptions(
@@ -64,13 +74,14 @@ class _DocAnnotationMarkersBodyState extends State<_DocAnnotationMarkersBody> {
             (landmark['lat']! as num).toDouble(),
             (landmark['lng']! as num).toDouble(),
           ),
-          iconImage: 'marker-15',
-          iconSize: 2.0,
-          iconColor: '#E74C3C',
+          iconImage: 'doc-marker',
+          iconSize: 0.8,
+          iconOffset: const Offset(0, -10),
           textField: landmark['name']! as String,
-          textOffset: const Offset(0, 1.5),
+          textOffset: const Offset(0, 1.2),
           textAnchor: 'top',
           textSize: 13,
+          textColor: '#1a1a2e',
           textHaloColor: '#ffffff',
           textHaloWidth: 2,
         ),

--- a/maplibre_gl_example/lib/examples/docs/doc_cluster.dart
+++ b/maplibre_gl_example/lib/examples/docs/doc_cluster.dart
@@ -54,18 +54,19 @@ class _DocClusterBodyState extends State<_DocClusterBody> {
       };
     });
 
+    // Pass the data inline when creating the source. A geojson source requires
+    // its "data" property up front: on web (maplibre-gl-js) an empty addSource
+    // followed by setGeoJsonSource fails validation with
+    // 'missing required property "data"', so the dependent layers never attach.
     await ctrl.addSource(
       _sourceId,
-      const GeojsonSourceProperties(
+      GeojsonSourceProperties(
+        data: {'type': 'FeatureCollection', 'features': features},
         cluster: true,
         clusterMaxZoom: 14,
         clusterRadius: 50,
       ),
     );
-    await ctrl.setGeoJsonSource(_sourceId, {
-      'type': 'FeatureCollection',
-      'features': features,
-    });
 
     await ctrl.addCircleLayer(
       _sourceId,

--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -41,7 +41,7 @@
   <script>
     const protocol = new pmtiles.Protocol();
     maplibregl.addProtocol("pmtiles", protocol.tile);
-    const PMTILES_URL = "https://demo-bucket.protomaps.com/v4.pmtiles";
+    const PMTILES_URL = "https://build.protomaps.com/20260625.pmtiles";
     const source = new pmtiles.FetchSource(PMTILES_URL);
     protocol.add(new pmtiles.PMTiles(source));
   </script>

--- a/website/docs/advanced/expressions.md
+++ b/website/docs/advanced/expressions.md
@@ -7,7 +7,7 @@ Expressions are MapLibre's way of making the map respond to your data. Instead o
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-expressions"
+  src="/flutter-maplibre-gl/demo/?example=doc-expressions"
   title="Data-driven expressions"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/expressions.md
+++ b/website/docs/advanced/expressions.md
@@ -7,7 +7,7 @@ Expressions are MapLibre's way of making the map respond to your data. Instead o
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-expressions"
+  src="/flutter-maplibre-gl/?example=doc-expressions"
   title="Data-driven expressions"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/map-language.md
+++ b/website/docs/advanced/map-language.md
@@ -4,7 +4,7 @@ Switch the map label language at runtime without reloading the style. Useful for
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=map-language"
+  src="/flutter-maplibre-gl/?example=map-language"
   title="Map Language example"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/map-language.md
+++ b/website/docs/advanced/map-language.md
@@ -4,7 +4,7 @@ Switch the map label language at runtime without reloading the style. Useful for
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=map-language"
+  src="/flutter-maplibre-gl/demo/?example=map-language"
   title="Map Language example"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/pmtiles.md
+++ b/website/docs/advanced/pmtiles.md
@@ -4,7 +4,7 @@ PMTiles is a single-file archive format for storing map tiles. Instead of a tile
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-pmtiles"
+  src="/flutter-maplibre-gl/demo/?example=doc-pmtiles"
   title="PMTiles example"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/pmtiles.md
+++ b/website/docs/advanced/pmtiles.md
@@ -10,7 +10,7 @@ PMTiles is a single-file archive format for storing map tiles. Instead of a tile
 ></iframe>
 
 !!! note "About this demo"
-    This example reads the public Protomaps demo archive (`demo-bucket.protomaps.com/v4.pmtiles`). That upstream file is occasionally unavailable, so the map above may load empty from time to time — it's the demo source, not the plugin. For your own apps, host your own `.pmtiles` (see [Hosting options](#hosting-options)) for a stable URL.
+    This example reads a public Protomaps planet build (`build.protomaps.com/<YYYYMMDD>.pmtiles`). Protomaps rotates these dated builds out after a few days, so if the pinned date has been pruned the map above may load empty — it's the demo source, not the plugin. For your own apps, host your own `.pmtiles` (see [Hosting options](#hosting-options)) for a stable URL.
 
 ## Why PMTiles?
 
@@ -50,7 +50,7 @@ For testing, use the Protomaps public demo archive:
 ```
 https://demo-bucket.protomaps.com/v4.pmtiles
 ```
-(Protomaps also publishes dated planet builds at `https://build.protomaps.com/<YYYYMMDD>.pmtiles`, but those are rotated out after a few days — don't hardcode one for anything long-lived.)
+(Protomaps also publishes dated planet builds at `https://build.protomaps.com/<YYYYMMDD>.pmtiles`, but those are rotated out after a few days, so don't hardcode one for anything long-lived. The live demo above pins a recent dated build, which is why it can go empty once that date is pruned.)
 
 ## Step 2: Create a style JSON
 

--- a/website/docs/advanced/pmtiles.md
+++ b/website/docs/advanced/pmtiles.md
@@ -4,7 +4,7 @@ PMTiles is a single-file archive format for storing map tiles. Instead of a tile
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-pmtiles"
+  src="/flutter-maplibre-gl/?example=doc-pmtiles"
   title="PMTiles example"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/pmtiles.md
+++ b/website/docs/advanced/pmtiles.md
@@ -9,6 +9,9 @@ PMTiles is a single-file archive format for storing map tiles. Instead of a tile
   loading="lazy"
 ></iframe>
 
+!!! note "About this demo"
+    This example reads the public Protomaps demo archive (`demo-bucket.protomaps.com/v4.pmtiles`). That upstream file is occasionally unavailable, so the map above may load empty from time to time — it's the demo source, not the plugin. For your own apps, host your own `.pmtiles` (see [Hosting options](#hosting-options)) for a stable URL.
+
 ## Why PMTiles?
 
 | Traditional tile server | PMTiles |
@@ -43,10 +46,11 @@ Options:
 - Convert an MBTiles file: `pmtiles convert input.mbtiles output.pmtiles`
 - Generate from OpenStreetMap with [planetiler](https://github.com/onthegomap/planetiler)
 
-For testing, use the Protomaps public CDN:
+For testing, use the Protomaps public demo archive:
 ```
-https://build.protomaps.com/20231001.pmtiles
+https://demo-bucket.protomaps.com/v4.pmtiles
 ```
+(Protomaps also publishes dated planet builds at `https://build.protomaps.com/<YYYYMMDD>.pmtiles`, but those are rotated out after a few days — don't hardcode one for anything long-lived.)
 
 ## Step 2: Create a style JSON
 
@@ -59,7 +63,7 @@ The style JSON references the PMTiles archive as a vector source. Save this as `
   "sources": {
     "protomaps": {
       "type": "vector",
-      "url": "pmtiles://https://build.protomaps.com/20231001.pmtiles",
+      "url": "pmtiles://https://demo-bucket.protomaps.com/v4.pmtiles",
       "attribution": "© OpenStreetMap"
     }
   },

--- a/website/docs/advanced/snapshot.md
+++ b/website/docs/advanced/snapshot.md
@@ -4,7 +4,7 @@ Capture a static image of the current map view as a `Uint8List` (PNG bytes). Use
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=map-snapshot"
+  src="/flutter-maplibre-gl/?example=map-snapshot"
   title="Map Snapshot example"
   loading="lazy"
 ></iframe>

--- a/website/docs/advanced/snapshot.md
+++ b/website/docs/advanced/snapshot.md
@@ -4,7 +4,7 @@ Capture a static image of the current map view as a `Uint8List` (PNG bytes). Use
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=map-snapshot"
+  src="/flutter-maplibre-gl/demo/?example=map-snapshot"
   title="Map Snapshot example"
   loading="lazy"
 ></iframe>

--- a/website/docs/annotations/animated.md
+++ b/website/docs/annotations/animated.md
@@ -4,7 +4,7 @@ Smoothly animate annotation position changes using Flutter's animation system.
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=edit-annotation-animated"
+  src="/flutter-maplibre-gl/?example=edit-annotation-animated"
   title="Edit Annotation Animated example"
   loading="lazy"
 ></iframe>

--- a/website/docs/annotations/animated.md
+++ b/website/docs/annotations/animated.md
@@ -4,7 +4,7 @@ Smoothly animate annotation position changes using Flutter's animation system.
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=edit-annotation-animated"
+  src="/flutter-maplibre-gl/demo/?example=edit-annotation-animated"
   title="Edit Annotation Animated example"
   loading="lazy"
 ></iframe>

--- a/website/docs/annotations/draggable.md
+++ b/website/docs/annotations/draggable.md
@@ -4,7 +4,7 @@ Allow users to drag annotations to new positions on the map.
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=edit-annotation-draggable"
+  src="/flutter-maplibre-gl/demo/?example=edit-annotation-draggable"
   title="Edit Annotation Draggable example"
   loading="lazy"
 ></iframe>

--- a/website/docs/annotations/draggable.md
+++ b/website/docs/annotations/draggable.md
@@ -17,7 +17,7 @@ Set `draggable: true` in `SymbolOptions`:
 final symbol = await controller.addSymbol(
   const SymbolOptions(
     geometry: LatLng(48.8566, 2.3522),
-    iconImage: 'marker-15',
+    iconImage: 'my-pin',
     draggable: true,
   ),
 );

--- a/website/docs/annotations/draggable.md
+++ b/website/docs/annotations/draggable.md
@@ -4,7 +4,7 @@ Allow users to drag annotations to new positions on the map.
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=edit-annotation-draggable"
+  src="/flutter-maplibre-gl/?example=edit-annotation-draggable"
   title="Edit Annotation Draggable example"
   loading="lazy"
 ></iframe>

--- a/website/docs/annotations/markers.md
+++ b/website/docs/annotations/markers.md
@@ -4,7 +4,7 @@ The Annotation API lets you place individual interactive markers, circles, lines
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-annotation-markers"
+  src="/flutter-maplibre-gl/?example=doc-annotation-markers"
   title="Annotation markers"
   loading="lazy"
 ></iframe>

--- a/website/docs/annotations/markers.md
+++ b/website/docs/annotations/markers.md
@@ -17,22 +17,37 @@ Use annotations when you have **fewer than ~50 features** and need individual in
 
 ## Add a symbol (icon + text)
 
+`iconImage` references an image **from the active style's sprite**, or one you
+registered yourself with `addImage` / `addImageFromAsset`. There are no icons
+that exist in every style, so register your own first (see
+[Custom image markers](#custom-image-markers) below) and reference it by name:
+
 ```dart
+await addImageFromAsset(controller, 'my-pin', 'assets/markers/pin.png');
+
 final symbol = await controller.addSymbol(
   const SymbolOptions(
     geometry: LatLng(48.8566, 2.3522),
-    iconImage: 'marker-15',     // built-in MapLibre icon
-    iconSize: 1.5,
-    iconColor: '#E74C3C',
+    iconImage: 'my-pin',        // a name you registered with addImage
+    iconSize: 1.0,
     textField: 'Paris',
     textOffset: Offset(0, 1.5),
     textAnchor: 'top',
     textSize: 14,
+    textColor: '#1a1a2e',
     textHaloColor: '#ffffff',
     textHaloWidth: 2,
   ),
 );
 ```
+
+!!! warning "Icons are style-dependent"
+    `iconImage` must name an image the map actually has. If you reference a name
+    that isn't in the style's sprite and wasn't registered with `addImage`, the
+    symbol renders nothing and the console logs *"image … could not be loaded"*.
+    Many styles (including the MapLibre demo style) ship no general-purpose
+    marker sprite, so register your own image rather than assuming a built-in
+    name exists.
 
 ## Tap callback
 
@@ -65,29 +80,29 @@ await controller.clearSymbols(); // remove all
 
 ```dart
 final symbols = await controller.addSymbols([
-  const SymbolOptions(geometry: LatLng(48.86, 2.35), iconImage: 'marker-15'),
-  const SymbolOptions(geometry: LatLng(51.50, -0.13), iconImage: 'marker-15'),
-  const SymbolOptions(geometry: LatLng(52.52, 13.40), iconImage: 'marker-15'),
+  const SymbolOptions(geometry: LatLng(48.86, 2.35), iconImage: 'my-pin'),
+  const SymbolOptions(geometry: LatLng(51.50, -0.13), iconImage: 'my-pin'),
+  const SymbolOptions(geometry: LatLng(52.52, 13.40), iconImage: 'my-pin'),
 ]);
 ```
 
-## Built-in icon names
+## Where icons come from
 
-MapLibre ships a set of built-in icons from the Maki icon set. Common ones:
+`iconImage` resolves against the images the map currently has:
 
-| Icon name | Use |
-|---|---|
-| `marker-15` | Simple teardrop marker |
-| `circle-15` | Filled circle |
-| `star-15` | Star shape |
-| `restaurant-15` | Fork and knife |
-| `lodging-15` | Bed icon |
-| `hospital-15` | Medical cross |
-| `airport-15` | Airplane |
+- **The active style's sprite** — some styles bundle a named icon set (e.g. a
+  style built on the Maki icons exposes `marker-15`, `restaurant-15`, …). These
+  names only exist if *that* style includes them; they are not guaranteed.
+- **Images you register at runtime** with `addImage` / `addImageFromAsset` —
+  always available regardless of the style. This is the portable choice.
+
+Because the MapLibre demo style (and many others) ship no general-purpose
+marker sprite, the examples here register their own image rather than relying on
+a built-in name.
 
 ### Custom image markers
 
-To use your own image instead of a built-in Maki icon, register it once with `addImage()` (in `onStyleLoadedCallback`), then reference it by name as the `iconImage`:
+Register your image once with `addImage()` (in `onStyleLoadedCallback`), then reference it by name as the `iconImage`:
 
 ```dart
 final bytes = await rootBundle.load('assets/markers/pin.png');

--- a/website/docs/annotations/markers.md
+++ b/website/docs/annotations/markers.md
@@ -4,7 +4,7 @@ The Annotation API lets you place individual interactive markers, circles, lines
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-annotation-markers"
+  src="/flutter-maplibre-gl/demo/?example=doc-annotation-markers"
   title="Annotation markers"
   loading="lazy"
 ></iframe>

--- a/website/docs/camera/camera-controls.md
+++ b/website/docs/camera/camera-controls.md
@@ -4,7 +4,7 @@ The camera defines what the user sees: the center position, zoom level, bearing 
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-camera"
+  src="/flutter-maplibre-gl/?example=doc-camera"
   title="Camera controls"
   loading="lazy"
 ></iframe>

--- a/website/docs/camera/camera-controls.md
+++ b/website/docs/camera/camera-controls.md
@@ -4,7 +4,7 @@ The camera defines what the user sees: the center position, zoom level, bearing 
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-camera"
+  src="/flutter-maplibre-gl/demo/?example=doc-camera"
   title="Camera controls"
   loading="lazy"
 ></iframe>

--- a/website/docs/concepts/annotations-vs-layers.md
+++ b/website/docs/concepts/annotations-vs-layers.md
@@ -32,7 +32,7 @@ Annotations are Flutter objects that represent individual features. You add them
 final symbol = await controller.addSymbol(
   const SymbolOptions(
     geometry: LatLng(48.8566, 2.3522),
-    iconImage: 'marker-15',
+    iconImage: 'my-pin',
     textField: 'Paris',
   ),
 );
@@ -114,7 +114,7 @@ await controller.setGeoJsonSource('cities', newFeatureCollection);
 await controller.addSymbol(
   const SymbolOptions(
     geometry: LatLng(48.8566, 2.3522),
-    iconImage: 'marker-15',
+    iconImage: 'my-pin',
     iconColor: '#E74C3C',
     textField: 'Paris',
   ),
@@ -146,7 +146,7 @@ await controller.addGeoJsonSource('pts', {
 
 await controller.addSymbolLayer('pts', 'pts-layer',
   SymbolLayerProperties(
-    iconImage: 'marker-15',
+    iconImage: 'my-pin',
     iconColor: '#E74C3C',
     textField: [Expressions.get, 'name'],
   ),

--- a/website/docs/concepts/annotations-vs-layers.md
+++ b/website/docs/concepts/annotations-vs-layers.md
@@ -162,7 +162,7 @@ await controller.addSymbolLayer('pts', 'pts-layer',
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-annotation-markers"
+  src="/flutter-maplibre-gl/demo/?example=doc-annotation-markers"
   title="Annotation markers"
   loading="lazy"
 ></iframe>
@@ -171,7 +171,7 @@ await controller.addSymbolLayer('pts', 'pts-layer',
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-symbol-layer"
+  src="/flutter-maplibre-gl/demo/?example=doc-symbol-layer"
   title="Symbol layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/concepts/annotations-vs-layers.md
+++ b/website/docs/concepts/annotations-vs-layers.md
@@ -162,7 +162,7 @@ await controller.addSymbolLayer('pts', 'pts-layer',
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-annotation-markers"
+  src="/flutter-maplibre-gl/?example=doc-annotation-markers"
   title="Annotation markers"
   loading="lazy"
 ></iframe>
@@ -171,7 +171,7 @@ await controller.addSymbolLayer('pts', 'pts-layer',
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-symbol-layer"
+  src="/flutter-maplibre-gl/?example=doc-symbol-layer"
   title="Symbol layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/concepts/geojson.md
+++ b/website/docs/concepts/geojson.md
@@ -176,7 +176,7 @@ This parameter is ignored on Android and iOS (native MapLibre handles feature ID
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-geojson-source"
+  src="/flutter-maplibre-gl/demo/?example=doc-geojson-source"
   title="GeoJSON source"
   loading="lazy"
 ></iframe>

--- a/website/docs/concepts/geojson.md
+++ b/website/docs/concepts/geojson.md
@@ -176,7 +176,7 @@ This parameter is ignored on Android and iOS (native MapLibre handles feature ID
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-geojson-source"
+  src="/flutter-maplibre-gl/?example=doc-geojson-source"
   title="GeoJSON source"
   loading="lazy"
 ></iframe>

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -20,14 +20,14 @@ hide:
   </div>
   <div class="cta-row">
     <a href="getting-started/" class="cta-btn cta-btn--primary">Get started</a>
-    <a href="https://maplibre.github.io/flutter-maplibre-gl/" class="cta-btn cta-btn--demo" target="_blank" rel="noopener"><span class="live-dot" aria-hidden="true"></span>Live demo<svg class="ext-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7m0-7L10 14M19 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h6"/></svg></a>
+    <a href="demo/" class="cta-btn cta-btn--demo" target="_blank" rel="noopener"><span class="live-dot" aria-hidden="true"></span>Live demo<svg class="ext-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7m0-7L10 14M19 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h6"/></svg></a>
     <a href="https://github.com/maplibre/flutter-maplibre-gl" class="cta-btn cta-btn--secondary" target="_blank" rel="noopener">GitHub<svg class="ext-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 3h7v7m0-7L10 14M19 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h6"/></svg></a>
   </div>
 </div>
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-full-map"
+  src="/flutter-maplibre-gl/demo/?example=doc-full-map"
   title="flutter-maplibre-gl live preview"
   loading="lazy"
 ></iframe>

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -27,7 +27,7 @@ hide:
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-full-map"
+  src="/flutter-maplibre-gl/?example=doc-full-map"
   title="flutter-maplibre-gl live preview"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/circle-layer.md
+++ b/website/docs/layers/circle-layer.md
@@ -4,7 +4,7 @@ A circle layer renders filled circles at point locations. It's ideal for data vi
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-circle-layer"
+  src="/flutter-maplibre-gl/?example=doc-circle-layer"
   title="Circle layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/circle-layer.md
+++ b/website/docs/layers/circle-layer.md
@@ -4,7 +4,7 @@ A circle layer renders filled circles at point locations. It's ideal for data vi
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-circle-layer"
+  src="/flutter-maplibre-gl/demo/?example=doc-circle-layer"
   title="Circle layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/cluster.md
+++ b/website/docs/layers/cluster.md
@@ -27,16 +27,16 @@ Clustering is a source-level feature, you enable it on `GeojsonSourceProperties`
 ## Full setup
 
 ```dart
-// 1. Add source with clustering enabled
+// 1. Add source with clustering enabled, passing the data inline.
 await controller.addSource(
   'events',
   const GeojsonSourceProperties(
+    data: featureCollection,   // inline GeoJSON map, or a URL string
     cluster: true,
     clusterMaxZoom: 14,   // stop clustering above this zoom
     clusterRadius: 50,    // pixel radius to group into one cluster
   ),
 );
-await controller.setGeoJsonSource('events', featureCollection);
 
 // 2. Cluster circles: sized by point count
 await controller.addCircleLayer(

--- a/website/docs/layers/cluster.md
+++ b/website/docs/layers/cluster.md
@@ -30,7 +30,7 @@ Clustering is a source-level feature, you enable it on `GeojsonSourceProperties`
 // 1. Add source with clustering enabled, passing the data inline.
 await controller.addSource(
   'events',
-  const GeojsonSourceProperties(
+  GeojsonSourceProperties(
     data: featureCollection,   // inline GeoJSON map, or a URL string
     cluster: true,
     clusterMaxZoom: 14,   // stop clustering above this zoom

--- a/website/docs/layers/cluster.md
+++ b/website/docs/layers/cluster.md
@@ -4,7 +4,7 @@ Clustering groups nearby points into a single bubble at low zoom levels. As user
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-cluster"
+  src="/flutter-maplibre-gl/demo/?example=doc-cluster"
   title="Cluster"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/cluster.md
+++ b/website/docs/layers/cluster.md
@@ -4,7 +4,7 @@ Clustering groups nearby points into a single bubble at low zoom levels. As user
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-cluster"
+  src="/flutter-maplibre-gl/?example=doc-cluster"
   title="Cluster"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/fill-layer.md
+++ b/website/docs/layers/fill-layer.md
@@ -4,7 +4,7 @@ A fill layer renders polygons from a GeoJSON source. Use it for choropleth maps,
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-fill-layer"
+  src="/flutter-maplibre-gl/?example=doc-fill-layer"
   title="Fill layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/fill-layer.md
+++ b/website/docs/layers/fill-layer.md
@@ -4,7 +4,7 @@ A fill layer renders polygons from a GeoJSON source. Use it for choropleth maps,
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-fill-layer"
+  src="/flutter-maplibre-gl/demo/?example=doc-fill-layer"
   title="Fill layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/geojson-source.md
+++ b/website/docs/layers/geojson-source.md
@@ -4,7 +4,7 @@ A GeoJSON source is the data container that style layers read from. It holds a F
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-geojson-source"
+  src="/flutter-maplibre-gl/demo/?example=doc-geojson-source"
   title="GeoJSON source"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/geojson-source.md
+++ b/website/docs/layers/geojson-source.md
@@ -4,7 +4,7 @@ A GeoJSON source is the data container that style layers read from. It holds a F
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-geojson-source"
+  src="/flutter-maplibre-gl/?example=doc-geojson-source"
   title="GeoJSON source"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/heatmap.md
+++ b/website/docs/layers/heatmap.md
@@ -4,7 +4,7 @@ A heatmap visualizes the density or intensity of point data as a smooth color gr
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-heatmap"
+  src="/flutter-maplibre-gl/demo/?example=doc-heatmap"
   title="Heatmap layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/heatmap.md
+++ b/website/docs/layers/heatmap.md
@@ -4,7 +4,7 @@ A heatmap visualizes the density or intensity of point data as a smooth color gr
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-heatmap"
+  src="/flutter-maplibre-gl/?example=doc-heatmap"
   title="Heatmap layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/line-layer.md
+++ b/website/docs/layers/line-layer.md
@@ -4,7 +4,7 @@ A line layer renders LineString and Polygon geometries as stroked paths. Use it 
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-line-layer"
+  src="/flutter-maplibre-gl/?example=doc-line-layer"
   title="Line layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/line-layer.md
+++ b/website/docs/layers/line-layer.md
@@ -4,7 +4,7 @@ A line layer renders LineString and Polygon geometries as stroked paths. Use it 
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-line-layer"
+  src="/flutter-maplibre-gl/demo/?example=doc-line-layer"
   title="Line layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/symbol-layer.md
+++ b/website/docs/layers/symbol-layer.md
@@ -4,7 +4,7 @@ A symbol layer renders icons, text labels, or both at point locations from a Geo
 
 <iframe
   class="example-iframe"
-  src="/flutter-maplibre-gl/?example=doc-symbol-layer"
+  src="/flutter-maplibre-gl/demo/?example=doc-symbol-layer"
   title="Symbol layer"
   loading="lazy"
 ></iframe>

--- a/website/docs/layers/symbol-layer.md
+++ b/website/docs/layers/symbol-layer.md
@@ -4,7 +4,7 @@ A symbol layer renders icons, text labels, or both at point locations from a Geo
 
 <iframe
   class="example-iframe"
-  src="https://maplibre.github.io/flutter-maplibre-gl/?example=doc-symbol-layer"
+  src="/flutter-maplibre-gl/?example=doc-symbol-layer"
   title="Symbol layer"
   loading="lazy"
 ></iframe>

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MapLibre Flutter
-site_url: https://maplibre.github.io/flutter-maplibre-gl/docs/
+site_url: https://maplibre.github.io/flutter-maplibre-gl/
 repo_url: https://github.com/maplibre/flutter-maplibre-gl
 repo_name: GitHub
 edit_uri: edit/main/website/docs/


### PR DESCRIPTION
## Summary

Adds a full documentation website with live, interactive examples, wires up CI to build and deploy it to GitHub Pages, and slims the README down to a landing page that links out to it.

## What's included

### Documentation website
- New MkDocs (Material) site under `website/` covering getting started, camera, annotations, layers, expressions, offline regions, PMTiles, migration, the feature matrix and architecture.
- Each page embeds a **live, interactive example** from the Flutter web demo via same-origin iframes, plus a set of `doc_*` example screens in `maplibre_gl_example`.

### CI / deploy
- New reusable `_build.yml` and an extended `flutter_ci.yml` that build the web demo and the MkDocs site, assemble a single Pages bundle, and deploy on `main`.
- Deploys serialize (no cancel-in-progress on `main`) so a publish is never torn down mid-flight.

### Site layout
- The **documentation homepage is served at the site root** and the **Flutter web demo lives under `/demo/`**.
- Web demo built with a matching `--base-href /flutter-maplibre-gl/demo/`; `mkdocs site_url` points at the root; every example iframe and the homepage demo CTA point at `/demo/`.

### Example / iframe fixes
- Load example iframes via a same-origin relative URL so they work over HTTPS.
- Repair broken marker and cluster live examples; drop `const` on a `GeojsonSourceProperties` built from runtime data.
- Note that the upstream PMTiles demo archive can be intermittently down.

### README
- Trimmed to a slim landing page: hero, quick start, feature matrix, contributing, and a contributors avatar grid, now that the docs site covers everything in depth.
- Highlights the **live demo** and **documentation** as prominent CTAs and fixes the API reference link to point at the API view rather than the rendered README.

## Resulting URLs
- `maplibre.github.io/flutter-maplibre-gl/` -> docs homepage
- `maplibre.github.io/flutter-maplibre-gl/demo/` -> live Flutter demo
- `maplibre.github.io/flutter-maplibre-gl/getting-started/`, `.../migration/`, etc. -> doc pages

## Notes
- The docs site has never been deployed to `main`, so the new layout ships directly with no old public URLs to redirect.
