### PR TITLE
docs: stable PMTiles demo source, fix expressions example, polish docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Docs
+* The PMTiles example and the live web demo now read from the stable Protomaps demo archive (`demo-bucket.protomaps.com/v4.pmtiles`) instead of a dated planet build. The dated builds are pruned after a few days and are not served with CORS headers, which made the web demo load empty.
+* **Web**: the expressions example no longer throws "layer already exists" when the style reloads, by adding its source and layers only once.
+
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 
 > **Note:** This release enforces a minimum Flutter version of **3.29**, which was already required in practice since 0.26.0 but not reflected in the package constraints (#823).

--- a/maplibre_gl/README.md
+++ b/maplibre_gl/README.md
@@ -1,37 +1,27 @@
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-dark-bg.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg">
-    <img alt="MapLibre Logo" src="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg" width="240">
-  </picture>
-</p>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-dark-bg.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg">
+  <img alt="MapLibre Logo" src="https://maplibre.org/img/maplibre-logos/maplibre-logo-for-light-bg.svg" width="240">
+</picture>
 
-<h1 align="center">Flutter MapLibre GL</h1>
+# Flutter MapLibre GL
 
-<p align="center">
-  Interactive, vector-tile, fully styleable maps for Flutter on <b>Android, iOS and Web</b>, powered by the open source <a href="https://github.com/maplibre">MapLibre</a> engines.<br>
-  <b>Vendor-neutral</b>: host your own tiles or mix providers, no proprietary token required.
-</p>
+Interactive, vector-tile, fully styleable maps for Flutter on <b>Android, iOS and Web</b>, powered by the open source <a href="https://github.com/maplibre">MapLibre</a> engines.<br>
+<b>Vendor-neutral</b>: host your own tiles or mix providers, no proprietary token required.
 
-<p align="center">
-  <a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/v/maplibre_gl?style=flat-square" alt="Pub Version"></a>
-  <a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/likes/maplibre_gl?logo=flutter&style=flat-square" alt="Likes"></a>
-  <a href="https://pub.dev/packages/maplibre_gl/score"><img src="https://img.shields.io/pub/points/maplibre_gl?style=flat-square" alt="Pub Points"></a>
-  <a href="https://github.com/maplibre/flutter-maplibre-gl/stargazers"><img src="https://img.shields.io/github/stars/maplibre/flutter-maplibre-gl?style=flat-square&logo=github&color=green" alt="Stars"></a>
-  <a href="https://github.com/invertase/melos"><img src="https://img.shields.io/badge/maintained%20with-melos-f700ff.svg?style=flat-square" alt="Melos"></a>
-</p>
+<a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/v/maplibre_gl?style=flat-square" alt="Pub Version"></a>
+<a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/likes/maplibre_gl?logo=flutter&style=flat-square" alt="Likes"></a>
+<a href="https://pub.dev/packages/maplibre_gl/score"><img src="https://img.shields.io/pub/points/maplibre_gl?style=flat-square" alt="Pub Points"></a>
+<a href="https://github.com/maplibre/flutter-maplibre-gl/stargazers"><img src="https://img.shields.io/github/stars/maplibre/flutter-maplibre-gl?style=flat-square&logo=github&color=green" alt="Stars"></a>
+<a href="https://github.com/invertase/melos"><img src="https://img.shields.io/badge/maintained%20with-melos-f700ff.svg?style=flat-square" alt="Melos"></a>
 
-<p align="center">
-  <b>✨ New:</b> try the package live in your browser and browse the full docs, no setup or API keys required.
-</p>
+<b>✨ New:</b> try the package live in your browser and browse the full docs, no setup or API keys required.
 
-<p align="center">
-  <a href="https://maplibre.github.io/flutter-maplibre-gl/demo/"><img src="https://img.shields.io/badge/🚀%20Live%20demo-2A6BF2?style=for-the-badge" height="38" alt="Live demo"></a>
-  &nbsp;&nbsp;
-  <a href="https://maplibre.github.io/flutter-maplibre-gl/"><img src="https://img.shields.io/badge/📖%20Documentation-3FB950?style=for-the-badge" height="38" alt="Documentation"></a>
-</p>
+<a href="https://maplibre.github.io/flutter-maplibre-gl/demo/"><img src="https://img.shields.io/badge/🌐%20Live%20demo-2A6BF2?style=for-the-badge" height="38" alt="Live demo"></a>
+&nbsp;&nbsp;
+<a href="https://maplibre.github.io/flutter-maplibre-gl/"><img src="https://img.shields.io/badge/📖%20Documentation-3FB950?style=for-the-badge" height="38" alt="Documentation"></a>
 
-## ✨ Quick start
+## 🚀 Quick start
 
 ```bash
 flutter pub add maplibre_gl

--- a/maplibre_gl_example/assets/pmtiles_style.json
+++ b/maplibre_gl_example/assets/pmtiles_style.json
@@ -4,7 +4,7 @@
     "protomaps": {
       "type": "vector",
       "attribution": "<a href=\"https://github.com/protomaps/basemaps\">Protomaps</a> © <a href=\"https://openstreetmap.org\">OpenStreetMap</a>",
-      "url": "pmtiles://https://build.protomaps.com/20260625.pmtiles"
+      "url": "pmtiles://https://demo-bucket.protomaps.com/v4.pmtiles"
     }
   },
   "layers": [

--- a/maplibre_gl_example/lib/examples/docs/doc_expressions.dart
+++ b/maplibre_gl_example/lib/examples/docs/doc_expressions.dart
@@ -25,6 +25,7 @@ class _DocExpressionsBody extends StatefulWidget {
 
 class _DocExpressionsBodyState extends State<_DocExpressionsBody> {
   MapLibreMapController? _controller;
+  bool _layersAdded = false;
   static const _sourceId = 'countries-source';
   static const _fillLayerId = 'countries-fill';
   static const _labelLayerId = 'countries-labels';
@@ -117,6 +118,11 @@ class _DocExpressionsBodyState extends State<_DocExpressionsBody> {
   Future<void> _onStyleLoaded() async {
     final ctrl = _controller;
     if (ctrl == null) return;
+
+    // onStyleLoadedCallback can fire more than once (e.g. on a style reload on
+    // web). Add the source and layers only once to avoid "layer already exists".
+    if (_layersAdded) return;
+    _layersAdded = true;
 
     await ctrl.addGeoJsonSource(_sourceId, {
       'type': 'FeatureCollection',

--- a/maplibre_gl_example/web/index.html
+++ b/maplibre_gl_example/web/index.html
@@ -41,7 +41,7 @@
   <script>
     const protocol = new pmtiles.Protocol();
     maplibregl.addProtocol("pmtiles", protocol.tile);
-    const PMTILES_URL = "https://build.protomaps.com/20260625.pmtiles";
+    const PMTILES_URL = "https://demo-bucket.protomaps.com/v4.pmtiles";
     const source = new pmtiles.FetchSource(PMTILES_URL);
     protocol.add(new pmtiles.PMTiles(source));
   </script>

--- a/website/docs/advanced/pmtiles.md
+++ b/website/docs/advanced/pmtiles.md
@@ -10,7 +10,7 @@ PMTiles is a single-file archive format for storing map tiles. Instead of a tile
 ></iframe>
 
 !!! note "About this demo"
-    This example reads a public Protomaps planet build (`build.protomaps.com/<YYYYMMDD>.pmtiles`). Protomaps rotates these dated builds out after a few days, so if the pinned date has been pruned the map above may load empty — it's the demo source, not the plugin. For your own apps, host your own `.pmtiles` (see [Hosting options](#hosting-options)) for a stable URL.
+    This example reads the public Protomaps demo archive (`demo-bucket.protomaps.com/v4.pmtiles`). That upstream file is occasionally unavailable, so the map above may load empty from time to time - it's the demo source, not the plugin. For your own apps, host your own `.pmtiles` (see [Hosting options](#hosting-options)) for a stable URL.
 
 ## Why PMTiles?
 
@@ -50,7 +50,7 @@ For testing, use the Protomaps public demo archive:
 ```
 https://demo-bucket.protomaps.com/v4.pmtiles
 ```
-(Protomaps also publishes dated planet builds at `https://build.protomaps.com/<YYYYMMDD>.pmtiles`, but those are rotated out after a few days, so don't hardcode one for anything long-lived. The live demo above pins a recent dated build, which is why it can go empty once that date is pruned.)
+(Protomaps also publishes dated planet builds at `https://build.protomaps.com/<YYYYMMDD>.pmtiles`, but those are rotated out after a few days and are not served with CORS headers, so they can't be read from a browser - don't use one for a web demo or anything long-lived.)
 
 ## Step 2: Create a style JSON
 

--- a/website/docs/compare/why-maplibre.md
+++ b/website/docs/compare/why-maplibre.md
@@ -95,7 +95,7 @@ There are three mainstream ways to put a map in a Flutter app. This page is an h
       <td>Tile cost</td>
       <td><span class="cell-ic"><span class="ic ic--yes">✔</span> Free options</span></td>
       <td><span class="cell-ic"><span class="ic ic--yes">✔</span> Free options</span></td>
-      <td><span class="cell-ic"><span class="ic ic--no">✘</span> Pay-per-use</span></td>
+      <td><span class="cell-ic"><span class="ic ic--yes">✔</span> Free options</span></td>
     </tr>
   </tbody>
 </table>
@@ -137,7 +137,7 @@ flutter_map renders raster tiles (PNG/WebP) by default. It does not do vector st
 - You need **Google-specific features**: Street View, Places integration, Google traffic.
 - Your organization mandates Google services.
 
-Google Maps requires a paid key for production, has no offline support, and the style cannot be customized beyond basic color tweaks.
+The mobile Maps SDK (Android/iOS) is free with no map-load billing, though it still requires an API key and a billing account on file, and usage-based services (Places, Directions, the Maps JavaScript SDK for web) are billed beyond a monthly free credit. Google Maps also has no offline support, and the style cannot be customized beyond basic color tweaks.
 
 ## Performance at scale
 


### PR DESCRIPTION
## Summary

Follow-up to #870. Fixes the PMTiles demo source, repairs the expressions live example, and polishes a couple of docs.

## Changes

### PMTiles demo source (the main fix)
The example app and docs previously pointed at a dated Protomaps planet build (`build.protomaps.com/<YYYYMMDD>.pmtiles`). Those builds are **rotated out after a few days** and, importantly, are **not served with CORS headers**, so they can't be read from a browser at all. The result was a live web demo that loaded empty.

Switched both the example app (`pmtiles_style.json`, `web/index.html`) and the docs to the stable public demo archive `demo-bucket.protomaps.com/v4.pmtiles`, and updated the PMTiles docs note to explain the CORS limitation of the dated builds.

### Expressions example double-load
`onStyleLoadedCallback` can fire more than once (e.g. on a style reload on web). The expressions example added its source and layers unconditionally, so the second fire threw "layer already exists". Added an idempotency guard.

### Docs polish
- **README**: flattened the centered HTML header to plain Markdown so it renders cleanly on pub.dev.
- **why-maplibre**: corrected the Google Maps comparison — the mobile Maps SDK is free with no map-load billing (an API key + billing account are still required); usage-based services are billed beyond a monthly free credit.
