### PR TITLE
feat(ios): add intervalMs to LocationEnginePlatforms.iOS for GPS pulsing

### DIFF
--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
@@ -93,7 +93,7 @@ class Convert {
         if let featureTapsTriggersMapClick = options["featureTapsTriggersMapClick"] as? Bool {
             delegate.setFeatureTapsTriggersMapClick(triggers: featureTapsTriggersMapClick)
         }
-        // iOS serializes as [enableHighAccuracy (0/1), distanceFilter, intervalMs]
+        // iOS serializes as [enableHighAccuracy (0/1), distanceFilter, intervalMs, pulseWindowMs]
         if let locationEngineProperties = options["locationEngineProperties"] as? [Int],
            locationEngineProperties.count >= 2
         {
@@ -102,10 +102,14 @@ class Convert {
             let intervalMs = locationEngineProperties.count >= 3
                 ? locationEngineProperties[2]
                 : 0
+            let pulseWindowMs = locationEngineProperties.count >= 4
+                ? locationEngineProperties[3]
+                : MapLibreMapController.defaultPulseWindowMs
             delegate.setLocationEngineProperties(
                 enableHighAccuracy: enableHighAccuracy,
                 distanceFilter: distanceFilter,
-                intervalMs: intervalMs
+                intervalMs: intervalMs,
+                pulseWindowMs: pulseWindowMs
             )
         }
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
@@ -93,15 +93,19 @@ class Convert {
         if let featureTapsTriggersMapClick = options["featureTapsTriggersMapClick"] as? Bool {
             delegate.setFeatureTapsTriggersMapClick(triggers: featureTapsTriggersMapClick)
         }
-        // iOS serializes as [enableHighAccuracy (0/1), distanceFilter]
+        // iOS serializes as [enableHighAccuracy (0/1), distanceFilter, intervalMs]
         if let locationEngineProperties = options["locationEngineProperties"] as? [Int],
            locationEngineProperties.count >= 2
         {
             let enableHighAccuracy = locationEngineProperties[0] == 1
             let distanceFilter = Double(locationEngineProperties[1])
+            let intervalMs = locationEngineProperties.count >= 3
+                ? locationEngineProperties[2]
+                : 0
             delegate.setLocationEngineProperties(
                 enableHighAccuracy: enableHighAccuracy,
-                distanceFilter: distanceFilter
+                distanceFilter: distanceFilter,
+                intervalMs: intervalMs
             )
         }
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -1391,9 +1391,9 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private func setLocationUpdatesActive(_ active: Bool) {
         guard let locationManager = mapView.locationManager else { return }
         if active {
-            locationManager.startUpdatingLocation?()
+            locationManager.startUpdatingLocation()
         } else {
-            locationManager.stopUpdatingLocation?()
+            locationManager.stopUpdatingLocation()
         }
     }
 

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -28,6 +28,12 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private var interactiveFeatureLayerIds = Set<String>()
     private var addedShapesByLayer = [String: MLNShape]()
 
+    // GPS pulse: start/stop location updates on a timer to save battery.
+    private var locationPulseTimer: Timer?
+    private var locationPulseWindowTimer: Timer?
+    private var locationUpdateIntervalMs: Int = 0
+    private static let pulseWindowMs: Int = 5000
+
     private var doubleTapRecognizers: [UITapGestureRecognizer] = []
 
     private var userFps: MLNMapViewPreferredFramesPerSecond = .default
@@ -1369,7 +1375,15 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     }
 
     private func updateMyLocationEnabled() {
-        mapView.showsUserLocation = myLocationEnabled
+        if locationUpdateIntervalMs > 0 && myLocationEnabled {
+            restartLocationPulseIfNeeded()
+        } else {
+            locationPulseTimer?.invalidate()
+            locationPulseTimer = nil
+            locationPulseWindowTimer?.invalidate()
+            locationPulseWindowTimer = nil
+            mapView.showsUserLocation = myLocationEnabled
+        }
     }
 
     private func getCamera() -> MLNMapCamera? {
@@ -2271,7 +2285,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         mapView.userTrackingMode = myLocationTrackingMode
     }
 
-    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double) {
+    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double, intervalMs: Int) {
         guard let locationManager = mapView.locationManager else { return }
         let accuracy = enableHighAccuracy
             ? kCLLocationAccuracyBest
@@ -2281,6 +2295,51 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             : kCLDistanceFilterNone
         locationManager.setDesiredAccuracy?(accuracy)
         locationManager.setDistanceFilter?(filter)
+
+        if locationUpdateIntervalMs != intervalMs {
+            locationUpdateIntervalMs = intervalMs
+            restartLocationPulseIfNeeded()
+        }
+    }
+
+    private func restartLocationPulseIfNeeded() {
+        locationPulseTimer?.invalidate()
+        locationPulseTimer = nil
+        locationPulseWindowTimer?.invalidate()
+        locationPulseWindowTimer = nil
+
+        guard myLocationEnabled, locationUpdateIntervalMs > 0 else {
+            if myLocationEnabled {
+                mapView.showsUserLocation = true
+            }
+            return
+        }
+
+        fireLocationPulse()
+
+        let interval = TimeInterval(locationUpdateIntervalMs) / 1000.0
+        locationPulseTimer = Timer.scheduledTimer(
+            withTimeInterval: interval,
+            repeats: true
+        ) { [weak self] _ in
+            self?.fireLocationPulse()
+        }
+    }
+
+    private func fireLocationPulse() {
+        mapView.showsUserLocation = true
+
+        let windowSec = TimeInterval(Self.pulseWindowMs) / 1000.0
+        locationPulseWindowTimer?.invalidate()
+        locationPulseWindowTimer = Timer.scheduledTimer(
+            withTimeInterval: windowSec,
+            repeats: false
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            if self.locationUpdateIntervalMs > 0 {
+                self.mapView.showsUserLocation = false
+            }
+        }
     }
 
     func setMyLocationRenderMode(myLocationRenderMode: MyLocationRenderMode) {

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -1375,14 +1375,25 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     }
 
     private func updateMyLocationEnabled() {
-        if locationUpdateIntervalMs > 0 && myLocationEnabled {
+        if myLocationEnabled {
             restartLocationPulseIfNeeded()
         } else {
             locationPulseTimer?.invalidate()
             locationPulseTimer = nil
             locationPulseWindowTimer?.invalidate()
             locationPulseWindowTimer = nil
-            mapView.showsUserLocation = myLocationEnabled
+            setLocationUpdatesActive(false)
+            mapView.showsUserLocation = false
+        }
+    }
+
+    /// Start or stop Core Location updates without toggling the user-location annotation.
+    private func setLocationUpdatesActive(_ active: Bool) {
+        guard let locationManager = mapView.locationManager else { return }
+        if active {
+            locationManager.startUpdatingLocation?()
+        } else {
+            locationManager.stopUpdatingLocation?()
         }
     }
 
@@ -2308,10 +2319,17 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         locationPulseWindowTimer?.invalidate()
         locationPulseWindowTimer = nil
 
-        guard myLocationEnabled, locationUpdateIntervalMs > 0 else {
-            if myLocationEnabled {
-                mapView.showsUserLocation = true
-            }
+        guard myLocationEnabled else {
+            setLocationUpdatesActive(false)
+            mapView.showsUserLocation = false
+            return
+        }
+
+        // Keep the blue dot at the last known position between GPS pulses.
+        mapView.showsUserLocation = true
+
+        guard locationUpdateIntervalMs > 0 else {
+            setLocationUpdatesActive(true)
             return
         }
 
@@ -2327,7 +2345,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     }
 
     private func fireLocationPulse() {
-        mapView.showsUserLocation = true
+        setLocationUpdatesActive(true)
 
         let windowSec = TimeInterval(Self.pulseWindowMs) / 1000.0
         locationPulseWindowTimer?.invalidate()
@@ -2337,7 +2355,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         ) { [weak self] _ in
             guard let self = self else { return }
             if self.locationUpdateIntervalMs > 0 {
-                self.mapView.showsUserLocation = false
+                self.setLocationUpdatesActive(false)
             }
         }
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -32,7 +32,8 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private var locationPulseTimer: Timer?
     private var locationPulseWindowTimer: Timer?
     private var locationUpdateIntervalMs: Int = 0
-    private static let pulseWindowMs: Int = 5000
+    private var locationPulseWindowMs: Int = MapLibreMapController.defaultPulseWindowMs
+    static let defaultPulseWindowMs: Int = 5000
 
     private var doubleTapRecognizers: [UITapGestureRecognizer] = []
 
@@ -2296,7 +2297,12 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         mapView.userTrackingMode = myLocationTrackingMode
     }
 
-    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double, intervalMs: Int) {
+    func setLocationEngineProperties(
+        enableHighAccuracy: Bool,
+        distanceFilter: Double,
+        intervalMs: Int,
+        pulseWindowMs: Int
+    ) {
         guard let locationManager = mapView.locationManager else { return }
         let accuracy = enableHighAccuracy
             ? kCLLocationAccuracyBest
@@ -2307,8 +2313,14 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         locationManager.setDesiredAccuracy?(accuracy)
         locationManager.setDistanceFilter?(filter)
 
-        if locationUpdateIntervalMs != intervalMs {
+        let resolvedPulseWindowMs = pulseWindowMs > 0
+            ? pulseWindowMs
+            : Self.defaultPulseWindowMs
+        if locationUpdateIntervalMs != intervalMs
+            || locationPulseWindowMs != resolvedPulseWindowMs
+        {
             locationUpdateIntervalMs = intervalMs
+            locationPulseWindowMs = resolvedPulseWindowMs
             restartLocationPulseIfNeeded()
         }
     }
@@ -2347,7 +2359,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
     private func fireLocationPulse() {
         setLocationUpdatesActive(true)
 
-        let windowSec = TimeInterval(Self.pulseWindowMs) / 1000.0
+        let windowSec = TimeInterval(locationPulseWindowMs) / 1000.0
         locationPulseWindowTimer?.invalidate()
         locationPulseWindowTimer = Timer.scheduledTimer(
             withTimeInterval: windowSec,

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
@@ -22,5 +22,5 @@ protocol MapLibreMapOptionsSink {
     func setAttributionButtonMargins(x: Double, y: Double)
     func setAttributionButtonPosition(position: MLNOrnamentPosition)
     func setFeatureTapsTriggersMapClick(triggers: Bool)
-    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double, intervalMs: Int)
+    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double, intervalMs: Int, pulseWindowMs: Int)
 }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
@@ -22,5 +22,5 @@ protocol MapLibreMapOptionsSink {
     func setAttributionButtonMargins(x: Double, y: Double)
     func setAttributionButtonPosition(position: MLNOrnamentPosition)
     func setFeatureTapsTriggersMapClick(triggers: Bool)
-    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double)
+    func setLocationEngineProperties(enableHighAccuracy: Bool, distanceFilter: Double, intervalMs: Int)
 }

--- a/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
+++ b/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
@@ -4,7 +4,7 @@ part of '../maplibre_gl_platform_interface.dart';
 ///
 /// Use the platform-specific constructors to only set relevant properties:
 /// - [LocationEnginePlatforms.android] — [enableHighAccuracy], [interval], [displacement], [priority]
-/// - [LocationEnginePlatforms.iOS] — [enableHighAccuracy], [displacement]
+/// - [LocationEnginePlatforms.iOS] — [enableHighAccuracy], [displacement], [intervalMs]
 /// - [LocationEnginePlatforms.web] — [enableHighAccuracy], [maximumAge], [timeout]
 @immutable
 class LocationEnginePlatforms {
@@ -50,6 +50,7 @@ class LocationEnginePlatforms {
       interval = null,
       displacement = null,
       priority = null,
+      intervalMs = null,
       maximumAge = null,
       timeout = null;
 
@@ -62,16 +63,26 @@ class LocationEnginePlatforms {
     this.interval = 1000,
     this.displacement = 0,
     this.priority,
-  }) : maximumAge = null,
+  }) : intervalMs = null,
+       maximumAge = null,
        timeout = null;
+
+  // -- iOS --
+
+  /// Interval in milliseconds for pulsed location updates on iOS.
+  /// When > 0, the native side starts GPS for a short window (~5 s) then
+  /// stops, repeating every [intervalMs]. 0 = continuous (default).
+  final int? intervalMs;
 
   /// iOS-specific constructor.
   ///
   /// Exposes only properties relevant to the iOS CLLocationManager:
-  /// [enableHighAccuracy] and [displacement] (mapped to distanceFilter).
+  /// [enableHighAccuracy], [displacement] (mapped to distanceFilter),
+  /// and [intervalMs] (GPS pulse interval, 0 = continuous).
   const LocationEnginePlatforms.iOS({
     this.enableHighAccuracy = false,
     this.displacement = 0,
+    this.intervalMs = 0,
   }) : interval = null,
        priority = null,
        maximumAge = null,
@@ -87,7 +98,8 @@ class LocationEnginePlatforms {
     this.timeout = 0,
   }) : interval = null,
        displacement = null,
-       priority = null;
+       priority = null,
+       intervalMs = null;
 
   static const LocationEnginePlatforms defaultPlatform =
       LocationEnginePlatforms._();
@@ -122,6 +134,7 @@ class LocationEnginePlatforms {
       return [
         if (enableHighAccuracy) 1 else 0,
         displacement ?? 0,
+        intervalMs ?? 0,
       ];
     }
 
@@ -138,6 +151,7 @@ class LocationEnginePlatforms {
           interval == other.interval &&
           displacement == other.displacement &&
           priority == other.priority &&
+          intervalMs == other.intervalMs &&
           maximumAge == other.maximumAge &&
           timeout == other.timeout);
 
@@ -147,6 +161,7 @@ class LocationEnginePlatforms {
     interval,
     displacement,
     priority,
+    intervalMs,
     maximumAge,
     timeout,
   );
@@ -157,6 +172,7 @@ class LocationEnginePlatforms {
     if (interval != null) parts.add('interval: $interval');
     if (displacement != null) parts.add('displacement: $displacement');
     if (priority != null) parts.add('priority: $priority');
+    if (intervalMs != null) parts.add('intervalMs: $intervalMs');
     if (maximumAge != null) parts.add('maximumAge: $maximumAge');
     if (timeout != null) parts.add('timeout: $timeout');
     return 'LocationEnginePlatforms{ ${parts.join(', ')} }';

--- a/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
+++ b/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
@@ -70,8 +70,9 @@ class LocationEnginePlatforms {
   // -- iOS --
 
   /// Interval in milliseconds for pulsed location updates on iOS.
-  /// When > 0, the native side starts GPS for a short window (~5 s) then
-  /// stops, repeating every [intervalMs]. 0 = continuous (default).
+  /// When > 0, GPS updates run for a short window (~5 s) then stop, repeating
+  /// every [intervalMs]. The blue dot stays at the last known position between
+  /// pulses. 0 = continuous (default).
   final int? intervalMs;
 
   /// iOS-specific constructor.

--- a/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
+++ b/maplibre_gl_platform_interface/lib/src/location_engine_properties.dart
@@ -4,7 +4,7 @@ part of '../maplibre_gl_platform_interface.dart';
 ///
 /// Use the platform-specific constructors to only set relevant properties:
 /// - [LocationEnginePlatforms.android] — [enableHighAccuracy], [interval], [displacement], [priority]
-/// - [LocationEnginePlatforms.iOS] — [enableHighAccuracy], [displacement], [intervalMs]
+/// - [LocationEnginePlatforms.iOS] — [enableHighAccuracy], [displacement], [intervalMs], [pulseWindowMs]
 /// - [LocationEnginePlatforms.web] — [enableHighAccuracy], [maximumAge], [timeout]
 @immutable
 class LocationEnginePlatforms {
@@ -51,6 +51,7 @@ class LocationEnginePlatforms {
       displacement = null,
       priority = null,
       intervalMs = null,
+      pulseWindowMs = null,
       maximumAge = null,
       timeout = null;
 
@@ -64,6 +65,7 @@ class LocationEnginePlatforms {
     this.displacement = 0,
     this.priority,
   }) : intervalMs = null,
+       pulseWindowMs = null,
        maximumAge = null,
        timeout = null;
 
@@ -75,15 +77,22 @@ class LocationEnginePlatforms {
   /// pulses. 0 = continuous (default).
   final int? intervalMs;
 
+  /// Duration in milliseconds that GPS stays active during each pulse on iOS.
+  ///
+  /// Only used when [intervalMs] > 0. Defaults to 5000 ms when omitted.
+  final int? pulseWindowMs;
+
   /// iOS-specific constructor.
   ///
   /// Exposes only properties relevant to the iOS CLLocationManager:
   /// [enableHighAccuracy], [displacement] (mapped to distanceFilter),
-  /// and [intervalMs] (GPS pulse interval, 0 = continuous).
+  /// [intervalMs] (GPS pulse period, 0 = continuous), and [pulseWindowMs]
+  /// (GPS ON duration per pulse).
   const LocationEnginePlatforms.iOS({
     this.enableHighAccuracy = false,
     this.displacement = 0,
     this.intervalMs = 0,
+    this.pulseWindowMs = 5000,
   }) : interval = null,
        priority = null,
        maximumAge = null,
@@ -100,7 +109,8 @@ class LocationEnginePlatforms {
   }) : interval = null,
        displacement = null,
        priority = null,
-       intervalMs = null;
+       intervalMs = null,
+       pulseWindowMs = null;
 
   static const LocationEnginePlatforms defaultPlatform =
       LocationEnginePlatforms._();
@@ -136,6 +146,7 @@ class LocationEnginePlatforms {
         if (enableHighAccuracy) 1 else 0,
         displacement ?? 0,
         intervalMs ?? 0,
+        pulseWindowMs ?? 5000,
       ];
     }
 
@@ -153,6 +164,7 @@ class LocationEnginePlatforms {
           displacement == other.displacement &&
           priority == other.priority &&
           intervalMs == other.intervalMs &&
+          pulseWindowMs == other.pulseWindowMs &&
           maximumAge == other.maximumAge &&
           timeout == other.timeout);
 
@@ -163,6 +175,7 @@ class LocationEnginePlatforms {
     displacement,
     priority,
     intervalMs,
+    pulseWindowMs,
     maximumAge,
     timeout,
   );
@@ -174,6 +187,7 @@ class LocationEnginePlatforms {
     if (displacement != null) parts.add('displacement: $displacement');
     if (priority != null) parts.add('priority: $priority');
     if (intervalMs != null) parts.add('intervalMs: $intervalMs');
+    if (pulseWindowMs != null) parts.add('pulseWindowMs: $pulseWindowMs');
     if (maximumAge != null) parts.add('maximumAge: $maximumAge');
     if (timeout != null) parts.add('timeout: $timeout');
     return 'LocationEnginePlatforms{ ${parts.join(', ')} }';

--- a/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
@@ -10,6 +10,7 @@ void main() {
       expect(props.interval, isNull);
       expect(props.displacement, isNull);
       expect(props.priority, isNull);
+      expect(props.intervalMs, isNull);
       expect(props.maximumAge, isNull);
       expect(props.timeout, isNull);
     });
@@ -115,9 +116,11 @@ void main() {
       const props = LocationEnginePlatforms.iOS(
         enableHighAccuracy: true,
         displacement: 25,
+        intervalMs: 5000,
       );
       expect(props.enableHighAccuracy, true);
       expect(props.displacement, 25);
+      expect(props.intervalMs, 5000);
       // Android/web fields are null
       expect(props.interval, isNull);
       expect(props.priority, isNull);
@@ -216,19 +219,19 @@ void main() {
   group('iOS serialization', () {
     const platform = TargetPlatform.iOS;
 
-    test('default toList() returns [0, 0]', () {
+    test('default toList() returns [0, 0, 0]', () {
       const props = LocationEnginePlatforms.iOS();
-      expect(props.toList(targetPlatform: platform), [0, 0]);
+      expect(props.toList(targetPlatform: platform), [0, 0, 0]);
     });
 
     test('high accuracy serializes as 1', () {
       const props = LocationEnginePlatforms.iOS(enableHighAccuracy: true);
-      expect(props.toList(targetPlatform: platform), [1, 0]);
+      expect(props.toList(targetPlatform: platform), [1, 0, 0]);
     });
 
     test('displacement maps to distanceFilter', () {
       const props = LocationEnginePlatforms.iOS(displacement: 50);
-      expect(props.toList(targetPlatform: platform), [0, 50]);
+      expect(props.toList(targetPlatform: platform), [0, 50, 0]);
     });
 
     test('combined high accuracy and displacement', () {
@@ -236,7 +239,15 @@ void main() {
         enableHighAccuracy: true,
         displacement: 25,
       );
-      expect(props.toList(targetPlatform: platform), [1, 25]);
+      expect(props.toList(targetPlatform: platform), [1, 25, 0]);
+    });
+
+    test('intervalMs serializes as third element', () {
+      const props = LocationEnginePlatforms.iOS(
+        enableHighAccuracy: true,
+        intervalMs: 30000,
+      );
+      expect(props.toList(targetPlatform: platform), [1, 0, 30000]);
     });
 
     test('android-only and web-only fields are ignored', () {
@@ -244,8 +255,8 @@ void main() {
         interval: 500,
         priority: LocationPriority.noPower,
       );
-      // iOS only serializes enableHighAccuracy and displacement
-      expect(props.toList(targetPlatform: platform), [0, 0]);
+      // iOS only serializes enableHighAccuracy, displacement, and intervalMs
+      expect(props.toList(targetPlatform: platform), [0, 0, 0]);
     });
   });
 

--- a/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
+++ b/maplibre_gl_platform_interface/test/location_engine_properties_test.dart
@@ -219,19 +219,19 @@ void main() {
   group('iOS serialization', () {
     const platform = TargetPlatform.iOS;
 
-    test('default toList() returns [0, 0, 0]', () {
+    test('default toList() returns [0, 0, 0, 5000]', () {
       const props = LocationEnginePlatforms.iOS();
-      expect(props.toList(targetPlatform: platform), [0, 0, 0]);
+      expect(props.toList(targetPlatform: platform), [0, 0, 0, 5000]);
     });
 
     test('high accuracy serializes as 1', () {
       const props = LocationEnginePlatforms.iOS(enableHighAccuracy: true);
-      expect(props.toList(targetPlatform: platform), [1, 0, 0]);
+      expect(props.toList(targetPlatform: platform), [1, 0, 0, 5000]);
     });
 
     test('displacement maps to distanceFilter', () {
       const props = LocationEnginePlatforms.iOS(displacement: 50);
-      expect(props.toList(targetPlatform: platform), [0, 50, 0]);
+      expect(props.toList(targetPlatform: platform), [0, 50, 0, 5000]);
     });
 
     test('combined high accuracy and displacement', () {
@@ -239,7 +239,7 @@ void main() {
         enableHighAccuracy: true,
         displacement: 25,
       );
-      expect(props.toList(targetPlatform: platform), [1, 25, 0]);
+      expect(props.toList(targetPlatform: platform), [1, 25, 0, 5000]);
     });
 
     test('intervalMs serializes as third element', () {
@@ -247,7 +247,16 @@ void main() {
         enableHighAccuracy: true,
         intervalMs: 30000,
       );
-      expect(props.toList(targetPlatform: platform), [1, 0, 30000]);
+      expect(props.toList(targetPlatform: platform), [1, 0, 30000, 5000]);
+    });
+
+    test('pulseWindowMs serializes as fourth element', () {
+      const props = LocationEnginePlatforms.iOS(
+        enableHighAccuracy: true,
+        intervalMs: 30000,
+        pulseWindowMs: 3000,
+      );
+      expect(props.toList(targetPlatform: platform), [1, 0, 30000, 3000]);
     });
 
     test('android-only and web-only fields are ignored', () {
@@ -255,8 +264,8 @@ void main() {
         interval: 500,
         priority: LocationPriority.noPower,
       );
-      // iOS only serializes enableHighAccuracy, displacement, and intervalMs
-      expect(props.toList(targetPlatform: platform), [0, 0, 0]);
+      // iOS only serializes enableHighAccuracy, displacement, intervalMs, pulseWindowMs
+      expect(props.toList(targetPlatform: platform), [0, 0, 0, 5000]);
     });
   });
 


### PR DESCRIPTION
## Summary

Add an optional `intervalMs` parameter to the iOS location engine configuration that enables **GPS pulsing** — a power-saving technique where location updates are enabled for a short window (~5 s) then disabled, repeating every `intervalMs` milliseconds.

This is useful for apps that show a blue dot on the map but don't need continuous 1 Hz GPS when the user is stationary (e.g. browsing a map without active tracking). It dramatically reduces **Location Energy** between pulses while keeping `kCLLocationAccuracyBest`.

### Motivation

Unlike Android's `LocationRequest.setInterval()`, iOS's `CLLocationManager` has no native interval control — once started, it fires continuously. This forces a trade-off between accuracy and battery. GPS pulsing solves this by toggling `startUpdatingLocation` / `stopUpdatingLocation` on a timer, giving the app control over update frequency without sacrificing accuracy.

### Changes

| File | Change |
|---|---|
| `location_engine_properties.dart` | Add `intervalMs` field to `LocationEnginePlatforms.iOS` constructor, serialize as 3rd element |
| `Convert.swift` | Parse optional 3rd element from `locationEngineProperties` (backward compatible — works with 2 or 3 elements) |
| `MapLibreMapController.swift` | Implement pulse timer: `startUpdatingLocation` for 5 s window, then `stopUpdatingLocation`, repeating every `intervalMs` ms. **`showsUserLocation` stays `true`** so the blue dot remains at the last known position between pulses |
| `MapLibreMapOptionsSink.swift` | Extend protocol with `intervalMs` parameter |
| `location_engine_properties_test.dart` | Update iOS serialization expectations, add `intervalMs` test |

### Behavior

| `intervalMs` | Behavior |
|---|---|
| `0` (default) | Continuous location updates — **no change** from current behavior |
| `> 0` (e.g. 30000) | GPS pulses: 5 s ON → OFF → repeat every 30 s. Blue dot **stays visible** at last fix between pulses |

### Backward compatibility

- Default `intervalMs = 0` preserves existing continuous behavior
- Swift parsing is backward compatible (handles both 2-element and 3-element arrays)
- No breaking API changes

## Test plan

- [x] Unit tests updated for iOS serialization (3-element list)
- [x] New test for `intervalMs` serialization
- [ ] Manual test on iOS device: verify blue dot **stays visible** at last position between pulses
- [ ] Manual test on iOS device: verify location updates follow pulse schedule (Instruments)
- [ ] Manual test: verify `intervalMs: 0` behaves identically to current release
- [ ] Verify Xcode Instruments Location Energy Model shows "None" between pulses