### PR TITLE
chore(example): drop the obsolete jetifier flag

### DIFF
--- a/maplibre_gl_example/android/gradle.properties
+++ b/maplibre_gl_example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
Jetifier rewrites pre-AndroidX libraries to AndroidX. Every dependency of this example has been AndroidX for years, so the transform has nothing to rewrite, yet it still runs over every artifact including the Flutter engine jar.

It is not free. With the example's 1536 MB Gradle heap, `JetifyTransform` runs out of Java heap space on the engine jar and the Android build fails outright:

```
> Execution failed for JetifyTransform: .../io.flutter/x86_64_debug/.../x86_64_debug-1.0.0-....jar
   > Java heap space
```

Removing the flag builds the debug APK cleanly on the same heap, verified locally with Flutter 3.44 and AGP 8.13.2. No other change was needed.

Found while investigating whether the plugin can support AGP 9 (#905, #904).