### PR TITLE
chore(example): hold permission_handler at 12.x

### DIFF
--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -25,7 +25,12 @@ dependencies:
   maplibre_gl:
     path: ../maplibre_gl
   path_provider: ^2.1.5
-  permission_handler: ^13.0.0
+  # Held at 12.x: permission_handler_android 14 migrated to Flutter's built-in
+  # Kotlin unconditionally and compiles against SDK 37, so it needs Flutter 3.44
+  # and an installed Android SDK 37 to build, while its pubspec still declares
+  # flutter >=3.24.0. On anything older the Gradle build fails on an unresolved
+  # `compilerOptions`. Lift this once the example itself targets that baseline.
+  permission_handler: ^12.0.0
   share_plus: ^12.0.1
 
 dev_dependencies:


### PR DESCRIPTION
`permission_handler_android` 14 migrated to Flutter's built-in Kotlin **unconditionally** and compiles against SDK 37. Building it therefore needs Flutter 3.44 and an installed Android SDK 37, while its pubspec still declares `flutter: >=3.24.0`.

So pub installs it on older toolchains and the Gradle build then fails on an unresolved `compilerOptions`:

```
Line 69:     compilerOptions {
             ^ Unresolved reference 'compilerOptions'.
Line 70:         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
                 ^ Unresolved reference 'jvmTarget'.
```

and, once past that, on the missing platform:

```
Could not determine the dependencies of task ':permission_handler_android:generateDebugRFile'.
> Failed to find target with hash string 'android-37'
```

Neither is a failure an example app should hand to someone trying the plugin for the first time. The example only asks for location permission, so nothing here needs 14. Holding the constraint keeps the example buildable on the toolchains the plugin itself supports.

Verified locally: with `^12` the debug APK builds on Flutter 3.44 and AGP 8.13.2 (together with #912). Reverts the example side of the bump in #909, which stays in place everywhere else.

This is also a reminder that a dependency's declared Flutter constraint is not enforced by its Gradle config, the same class of mismatch as #823.