### PR TITLE
build(android): apply the Kotlin Gradle Plugin only below AGP 9

### DIFF
--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -22,7 +22,17 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// Flutter is moving Kotlin compilation into AGP itself. From AGP 9 a plugin that
+// applies the Kotlin Gradle Plugin breaks the host app's build, and Flutter already
+// warns about it today (#905). Applying KGP only below AGP 9 keeps this plugin
+// working on both, without forcing the package minimum to Flutter 3.44, which the
+// unconditional migration would require. Drop the condition, and apply nothing,
+// once that floor is normal for us.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -46,9 +56,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_21
         targetCompatibility JavaVersion.VERSION_21
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-    }
     configurations.all {
         // Exclude the regular (Vulkan) SDK to avoid duplicate classes with the OpenGL variant
         // If we want to use the Vulkan-based renderer in the future, we can remove this exclusion and switch to the regular SDK dependency below.
@@ -63,6 +70,15 @@ android {
         implementation 'com.squareup.okhttp3:okhttp:5.4.0'
         implementation 'com.google.android.gms:play-services-base:18.10.0'
         implementation 'com.google.android.gms:play-services-location:21.4.0'
+    }
+}
+
+// Set through the Kotlin extension rather than android.kotlinOptions, which AGP 9
+// removes. The extension is present whether KGP was applied above or AGP provides
+// Kotlin itself.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
     }
 }
 


### PR DESCRIPTION
Closes #905.

Flutter is moving Kotlin compilation into AGP itself. A plugin that applies the Kotlin Gradle Plugin (KGP) already makes Flutter warn the host app, and from AGP 9 it breaks the build:

```
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): ... maplibre_gl ...
Future versions of Flutter will fail to build if your app uses plugins that apply KGP.
```

### What this does

KGP is applied only below AGP 9, and `jvmTarget` moves from `android.kotlinOptions`, which AGP 9 removes, to the Kotlin extension:

```groovy
def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
if (agpMajor < 9) {
    apply plugin: 'kotlin-android'
}
```

The Kotlin sources are untouched.

### Why conditional, and not the plain migration

The [plugin-author guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) leads with dropping KGP outright, but the `kotlin.compilerOptions{}` DSL that route relies on needs KGP 2.0 or later, which is only guaranteed from **Flutter 3.44**. Taking it would raise this package's minimum from Flutter 3.29 to 3.44, the current stable: effectively "latest only".

The conditional route keeps the floor at 3.29 and costs four lines that are deletable. The day our minimum reaches 3.44 for other reasons, the condition goes away and we are on the documented path with no further work.

This is not hypothetical. `permission_handler_android` 14.0.0 took the unconditional route while still declaring `flutter: >=3.24.0`, so pub installs it on older Flutter and the Gradle build then dies on an unresolved `compilerOptions`. See #913.

### Verified on both paths

Locally, with Flutter 3.44.0 and the Android SDK at 36:

* **AGP 8.13.2**: the example app's debug APK builds. KGP is still applied here, so Flutter's warning still appears for apps on AGP 8. That is expected: this change removes the hard failure on AGP 9, it does not silence the warning today.
* **AGP 9.3.1 with Gradle 9.6.1 and `android.builtInKotlin=true`**: the plugin configures, compiles and packages:

```
> Task :maplibre_gl:compileDebugKotlin
> Task :maplibre_gl:compileDebugJavaWithJavac
> Task :maplibre_gl:bundleDebugAar
BUILD SUCCESSFUL
```

So on AGP 9 the condition correctly skips KGP and the `kotlin {}` extension is still there, provided by AGP, which is what the guide claims and what needed checking.

An earlier revision used `project.extensions.configure(KotlinAndroidProjectExtension)`, taken from the guide's Kotlin DSL section. In Groovy that closure delegates to the `Project`, so `compilerOptions` did not resolve and `:maplibre_gl` failed to configure. The form in this PR is the Groovy one the guide documents.

### What this does not unblock

The example app still cannot move to AGP 9, for reasons outside this package:

1. Flutter 3.44.0's own Gradle plugin fails on AGP 9's new DSL with a `NullPointerException`; it needs `android.newDsl=false`.
2. Past that, `device_info_plus` 12.3.0 does not declare `compileSdk`, which AGP 9 requires of every module.
3. Newer `device_info_plus` and `permission_handler_android` declare it but compile against SDK 37.
4. `file_picker` and `share_plus` 12 still apply KGP.

So #904, #883 and #803 stay where they are. What changes here is that an app on AGP 9 can use `maplibre_gl`.
