### PR TITLE
docs(changelog): assemble the 0.27.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,43 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
 
+**No breaking changes.** This release is about performance and closing gaps in the public API: large GeoJSON no longer blocks the UI for as long, the map engine can be warmed up before the first map is shown, offline regions can be moved between devices, and several APIs that only worked on some platforms now work everywhere.
+
 ### Added
+* **Offline regions (Android, iOS)**: downloaded regions can now be moved between devices. `exportOfflineDatabase()` writes a shareable copy of the offline database, `mergeOfflineRegions()` imports one back (now also on iOS), and `getOfflineDatabasePath()` returns where the database lives. See the [offline regions guide](https://maplibre.github.io/flutter-maplibre-gl/advanced/offline-regions/) (#886).
+* `preWarm()` starts up the MapLibre engine before the first map widget is built. Call it from `main()` to move native start-up work off the first map display, saving roughly 170 to 480 ms on Android, 45 to 165 ms on iOS and 10 to 50 ms on web (#867).
+* `setPadding({left, top, right, bottom, animated})` on `MapLibreMapController` sets padding for the whole map, shifting the map centre. Useful to keep content centred while a bottom sheet or side panel covers part of the map, instead of passing padding to every camera call (#258).
+* `getLayerProperties(layerId)` and `getSourceProperties(sourceId)` on `MapLibreMapController` return an existing layer's or source's full properties as a MapLibre style-spec map, or `null` when the id is unknown. Previously only `getLayerIds()` and `getSourceIds()` were available. The returned shape is the same on Android, iOS and web (#513).
+* **iOS**: `LocationEnginePlatforms.iOS` accepts `intervalMs` and `pulseWindowMs` to pulse GPS instead of tracking continuously. GPS runs for `pulseWindowMs` (5 s by default) every `intervalMs`, and the location dot holds its last position in between, which is noticeably easier on the battery for maps that stay open a long time. `intervalMs: 0` keeps the previous continuous behaviour and remains the default (#901).
 * **Web**: `queryCameraPosition()` is now implemented; previously it threw `UnimplementedError` (#892).
 
 ### Fixed
-* **Android**: `mergeOfflineRegions` no longer throws `type 'Null' is not a subtype of type 'Map<String, dynamic>'` when merging an offline database that has no region metadata (e.g. one produced by maplibre-native's `offline.cpp`). Missing metadata now falls back to an empty map (#865).
-* **Android**: Icons added with `addImage` are shown again. Since 0.26.0 they could be silently dropped when draggable annotations were used (the default), due to an upstream texture atlas bug (#866).
-* **Android**: `addImage` now renders icons at the correct size on high-density screens, and image APIs return a clean error instead of crashing on undecodable bytes (#866, #868).
-* **iOS**: `queryCameraPosition()` now returns the camera position even when `trackCameraPosition` is `false`, matching Android. Previously it returned `null` (#892).
-* **Web**: the expressions example no longer throws "layer already exists" when the style reloads.
+* **Android, iOS**: adding or updating a GeoJSON source with a large payload, such as a line with tens of thousands of points or a collection of hundreds of features, no longer blocks the UI for the whole encode. Those payloads are encoded on a background isolate, which cuts the time spent on the main isolate by two to three times, while smaller ones keep the faster synchronous path. Handing the payload to the isolate still costs a copy on the calling side, so a very large source can still drop a frame (#366).
+* **Android, iOS**: downloading an area that is already downloaded now replaces the existing region instead of adding a duplicate, and the replacement keeps the same region id. Apps that pair their own data to a region id no longer lose that pairing when a region is re-downloaded (#886).
+* **Android**: merging an offline database whose regions have no metadata no longer fails, because missing metadata is now treated as empty. This affected databases produced outside the plugin, for example by maplibre-native, and showed up as `type 'Null' is not a subtype of type 'Map<String, dynamic>'` (#865).
+* **Android**: icons added with `addImage` are visible again. Since 0.26.0 they could be silently dropped when draggable annotations were used, which is the default (#866).
+* **Android**: `addImage` renders icons at the right size on high-density screens, and the image APIs report a clear error instead of crashing when handed undecodable bytes (#866, #868).
+* **iOS**: `mergeOfflineRegions()` returns only the regions it imported, rather than every region already stored (#886).
+* **iOS**: `queryCameraPosition()` returns the camera position even when `trackCameraPosition` is `false`, matching Android. It previously returned `null` (#892).
+* **Web**: `onMapIdle` now fires, matching Android and iOS. Code waiting on it, to hide a loading indicator or to run work once the map settles, never ran on web (#857).
+* **Web**: `updateContentInsets`, and the new `setPadding`, now work on web via the camera `padding` option. They previously threw `UnimplementedError`, so viewport padding worked only on Android and iOS (#258).
 
 ### Changed
-* **iOS**: Added Swift Package Manager (SPM) support. The plugin still ships its CocoaPods podspec, so CocoaPods apps keep working with no migration.
-* **Example app (iOS)**: Now builds entirely with SPM (no Podfile); the CocoaPods-only `location` dependency was replaced with `permission_handler`.
+* **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
+* **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).
+* **Android**: MapLibre Android SDK upgraded from 13.3.0 to 13.3.1 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.3.1)) (#877).
+* **Android**: OkHttp upgraded to 5.4.0 and Play Services Location to 21.4.0.
 
 ### Docs
-* Added a documentation website with live, interactive examples at [maplibre.github.io/flutter-maplibre-gl](https://maplibre.github.io/flutter-maplibre-gl/) (#870).
-* The PMTiles example and web demo now use the stable Protomaps demo archive instead of a dated planet build that was pruned and lacked CORS headers.
+* New documentation website with live, interactive examples: [maplibre.github.io/flutter-maplibre-gl](https://maplibre.github.io/flutter-maplibre-gl/) (#870).
+* **Example app**: the Offline Regions demo was redesigned with an in-app guide and export and import buttons that walk through the full round-trip (#886).
+* **Example app (iOS)**: now builds entirely with SPM (no Podfile); the CocoaPods-only `location` dependency was replaced with `permission_handler` (#891).
+* The PMTiles example and the web demo now read from the stable Protomaps demo archive. The previous dated planet build was pruned after a few days and served without CORS headers, which made the web demo load empty.
+* **Web**: the expressions example no longer throws "layer already exists" when the style reloads.
+
+### Internal
+* **Example app**: dropped the obsolete `android.enableJetifier` flag. Every dependency has been AndroidX for years, and the transform was running out of Java heap space on the Flutter engine jar (#912).
+* **Example app**: `permission_handler` is held at 12.x. Version 14 of its Android implementation requires Flutter 3.44 and Android SDK 37 to build while declaring `flutter: >=3.24.0` (#913).
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,21 +1,42 @@
 ## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
 
+**No breaking changes.** This release is about performance and closing gaps in the public API: large GeoJSON no longer blocks the UI for as long, the map engine can be warmed up before the first map is shown, offline regions can be moved between devices, and several APIs that only worked on some platforms now work everywhere.
+
 ### Added
+* **Offline regions (Android, iOS)**: downloaded regions can now be moved between devices. `exportOfflineDatabase()` writes a shareable copy of the offline database, `mergeOfflineRegions()` imports one back (now also on iOS), and `getOfflineDatabasePath()` returns where the database lives. See the [offline regions guide](https://maplibre.github.io/flutter-maplibre-gl/advanced/offline-regions/) (#886).
+* `preWarm()` starts up the MapLibre engine before the first map widget is built. Call it from `main()` to move native start-up work off the first map display, saving roughly 170 to 480 ms on Android, 45 to 165 ms on iOS and 10 to 50 ms on web (#867).
+* `setPadding({left, top, right, bottom, animated})` on `MapLibreMapController` sets padding for the whole map, shifting the map centre. Useful to keep content centred while a bottom sheet or side panel covers part of the map, instead of passing padding to every camera call (#258).
+* `getLayerProperties(layerId)` and `getSourceProperties(sourceId)` on `MapLibreMapController` return an existing layer's or source's full properties as a MapLibre style-spec map, or `null` when the id is unknown. Previously only `getLayerIds()` and `getSourceIds()` were available. The returned shape is the same on Android, iOS and web (#513).
+* **iOS**: `LocationEnginePlatforms.iOS` accepts `intervalMs` and `pulseWindowMs` to pulse GPS instead of tracking continuously. GPS runs for `pulseWindowMs` (5 s by default) every `intervalMs`, and the location dot holds its last position in between, which is noticeably easier on the battery for maps that stay open a long time. `intervalMs: 0` keeps the previous continuous behaviour and remains the default (#901).
 * **Web**: `queryCameraPosition()` is now implemented; previously it threw `UnimplementedError` (#892).
 
 ### Fixed
-* **Android**: Icons added with `addImage` are shown again. Since 0.26.0 they could be silently dropped when draggable annotations were used (the default), due to an upstream texture atlas bug (#866).
-* **Android**: `addImage` now renders icons at the correct size on high-density screens, and image APIs return a clean error instead of crashing on undecodable bytes (#866, #868).
-* **iOS**: `queryCameraPosition()` now returns the camera position even when `trackCameraPosition` is `false`, matching Android. Previously it returned `null` (#892).
-* **Web**: the expressions example no longer throws "layer already exists" when the style reloads.
+* **Android, iOS**: adding or updating a GeoJSON source with a large payload, such as a line with tens of thousands of points or a collection of hundreds of features, no longer blocks the UI for the whole encode. Those payloads are encoded on a background isolate, which cuts the time spent on the main isolate by two to three times, while smaller ones keep the faster synchronous path. Handing the payload to the isolate still costs a copy on the calling side, so a very large source can still drop a frame (#366).
+* **Android, iOS**: downloading an area that is already downloaded now replaces the existing region instead of adding a duplicate, and the replacement keeps the same region id. Apps that pair their own data to a region id no longer lose that pairing when a region is re-downloaded (#886).
+* **Android**: merging an offline database whose regions have no metadata no longer fails, because missing metadata is now treated as empty. This affected databases produced outside the plugin, for example by maplibre-native, and showed up as `type 'Null' is not a subtype of type 'Map<String, dynamic>'` (#865).
+* **Android**: icons added with `addImage` are visible again. Since 0.26.0 they could be silently dropped when draggable annotations were used, which is the default (#866).
+* **Android**: `addImage` renders icons at the right size on high-density screens, and the image APIs report a clear error instead of crashing when handed undecodable bytes (#866, #868).
+* **iOS**: `mergeOfflineRegions()` returns only the regions it imported, rather than every region already stored (#886).
+* **iOS**: `queryCameraPosition()` returns the camera position even when `trackCameraPosition` is `false`, matching Android. It previously returned `null` (#892).
+* **Web**: `onMapIdle` now fires, matching Android and iOS. Code waiting on it, to hide a loading indicator or to run work once the map settles, never ran on web (#857).
+* **Web**: `updateContentInsets`, and the new `setPadding`, now work on web via the camera `padding` option. They previously threw `UnimplementedError`, so viewport padding worked only on Android and iOS (#258).
 
 ### Changed
-* **iOS**: Added Swift Package Manager (SPM) support. The plugin still ships its CocoaPods podspec, so CocoaPods apps keep working with no migration.
-* **Example app (iOS)**: Now builds entirely with SPM (no Podfile); the CocoaPods-only `location` dependency was replaced with `permission_handler`.
+* **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
+* **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).
+* **Android**: MapLibre Android SDK upgraded from 13.3.0 to 13.3.1 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.3.1)) (#877).
+* **Android**: OkHttp upgraded to 5.4.0 and Play Services Location to 21.4.0.
 
 ### Docs
-* Added a documentation website with live, interactive examples at [maplibre.github.io/flutter-maplibre-gl](https://maplibre.github.io/flutter-maplibre-gl/) (#870).
-* The PMTiles example and web demo now use the stable Protomaps demo archive instead of a dated planet build that was pruned and lacked CORS headers.
+* New documentation website with live, interactive examples: [maplibre.github.io/flutter-maplibre-gl](https://maplibre.github.io/flutter-maplibre-gl/) (#870).
+* **Example app**: the Offline Regions demo was redesigned with an in-app guide and export and import buttons that walk through the full round-trip (#886).
+* **Example app (iOS)**: now builds entirely with SPM (no Podfile); the CocoaPods-only `location` dependency was replaced with `permission_handler` (#891).
+* The PMTiles example and the web demo now read from the stable Protomaps demo archive. The previous dated planet build was pruned after a few days and served without CORS headers, which made the web demo load empty.
+* **Web**: the expressions example no longer throws "layer already exists" when the style reloads.
+
+### Internal
+* **Example app**: dropped the obsolete `android.enableJetifier` flag. Every dependency has been AndroidX for years, and the transform was running out of Java heap space on the Flutter engine jar (#912).
+* **Example app**: `permission_handler` is held at 12.x. Version 14 of its Android implementation requires Flutter 3.44 and Android SDK 37 to build while declaring `flutter: >=3.24.0` (#913).
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 


### PR DESCRIPTION
The 0.27.0 entries were deliberately kept out of the individual PRs so that eight of them could land in any order without conflicting on `CHANGELOG.md`. This collects them, written as one release rather than as eight independent notes, across both the root changelog and `maplibre_gl/CHANGELOG.md`.

### Two gaps closed

* **#901 had no entry at all**, despite adding two public parameters (`intervalMs`, `pulseWindowMs`). It would have shipped invisible.
* **The #865 fix was in the root changelog but missing from `maplibre_gl/CHANGELOG.md`.** The two files now carry the same block, which is the convention the rest of the file follows.

### Wording

Entries lead with what changes for someone using the package, with the internal detail after it where it is still useful. A few specifics:

* The **GeoJSON** entry states what was measured, not what was hoped: the offload cuts main-isolate time by two to three times, it does not eliminate the stall, because handing the payload to the isolate still copies it on the calling side. Numbers in #911.
* The **offline region** entry mentions that a replaced region keeps its id, which matters to apps pairing their own data to region ids.
* The **AGP 9** entry says what an app author needs to know (upgrading to AGP 9 keeps working, nothing changes on AGP 8) rather than describing the Gradle mechanics.
* `preWarm()` keeps the measured savings per platform and drops the implementation detail about `libmaplibre-gl.so`, the C++ RunLoop and the Worker pool, which belongs in the API docs.
* CI-only dependency bumps (GitHub Actions) are omitted; the ones that affect the shipped artifact (Android SDK, OkHttp, Play Services Location) are listed.

Covers: #874, #875, #876, #877, #878, #887, #867, #901, #912, #913, #914, plus what was already on the branch.

Not included: #824, which is not merged.