### PR TITLE
chore: release 0.27.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,16 +66,19 @@ Before changing any versions ensure:
 3. Apply rule above (minor vs patch bump).
 
 ## Update Version Numbers
-Edit `pubspec.yaml` in each package:
-- `maplibre_gl_platform_interface`
-- `maplibre_gl_web`
-- `maplibre_gl`
-
-Ensure internal dependencies point to the new version (same number across all three). Example snippet:
-```yaml
-dependencies:
-  maplibre_gl_platform_interface: ^0.25.0
+Run the bump script from the repository root:
+```bash
+./scripts/bump_version.sh 0.25.0
 ```
+It sets `version:` in every workspace package (`maplibre_gl`, `maplibre_gl_platform_interface`, `maplibre_gl_web`, plus the unpublished `maplibre_gl_example` and `scripts`), moves the internal `maplibre_gl_*` constraints to the new version, and updates the `maplibre_gl: ^x.y.z` install snippets in `README.md` and `website/docs`. Add `--dry-run` to see the edits first.
+
+It then prints which changelogs and which section of the migration guide still need writing, since those need prose and are left to you.
+
+Once the changelogs are written, verify the whole workspace agrees:
+```bash
+./scripts/bump_version.sh --check
+```
+This fails if any package is on a different version, if an internal constraint is stale (which publishes fine but resolves to the previous release), if a changelog has no section for the version, or if a docs snippet still pins the old one.
 
 ## Update the Changelog
 In root `CHANGELOG.md`:

--- a/maplibre_gl/pubspec.yaml
+++ b/maplibre_gl/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl
 description: A Flutter plugin for integrating MapLibre Maps inside a Flutter application on Android, iOS and web platforms.
-version: 0.26.2
+version: 0.27.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace
@@ -13,8 +13,8 @@ dependencies:
   collection: ^1.19.1
   flutter:
     sdk: flutter
-  maplibre_gl_platform_interface: ^0.26.2
-  maplibre_gl_web: ^0.26.2
+  maplibre_gl_platform_interface: ^0.27.0
+  maplibre_gl_web: ^0.27.0
 
 dev_dependencies:
   flutter_test:

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_gl_example
 description: Demonstrates how to use the maplibre_gl plugin.
 publish_to: 'none'
-version: 0.26.2
+version: 0.27.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace

--- a/maplibre_gl_platform_interface/CHANGELOG.md
+++ b/maplibre_gl_platform_interface/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
+
+See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
+
+### Added
+* `getLayerProperties(layerId)` and `getSourceProperties(sourceId)`, returning an existing layer's or source's full properties as a MapLibre style-spec map, or `null` when the id is unknown (#513).
+* `LocationEnginePlatforms.iOS` accepts `intervalMs` and `pulseWindowMs`, forwarded to the iOS location engine so GPS can be pulsed instead of tracked continuously (#901).
+
+### Fixed
+* Adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode: those payloads are encoded on a background isolate, while smaller ones keep the faster synchronous path. Writes to the same source id stay in the order they were issued (#366).
+
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 
 No platform-interface changes; version aligned with the `maplibre_gl` 0.26.2 release. See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.

--- a/maplibre_gl_platform_interface/pubspec.yaml
+++ b/maplibre_gl_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl_platform_interface
 description: A common platform interface for the maplibre_gl plugin. This package is only intended to be used by the maplibre_gl package.
-version: 0.26.2
+version: 0.27.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,5 +1,15 @@
 See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
+## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
+
+### Added
+* `queryCameraPosition()` is now implemented; it previously threw `UnimplementedError` (#892).
+* `updateContentInsets()`, and the new `setPadding()`, are implemented through the camera `padding` option; both previously threw `UnimplementedError` (#258).
+* `getLayerProperties(layerId)` and `getSourceProperties(sourceId)` read an existing layer's or source's properties from the live style, in the same shape as Android and iOS (#513).
+
+### Fixed
+* `onMapIdle` now fires, matching Android and iOS. Code waiting on it never ran on web (#857).
+
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 
 No web-specific changes; version aligned with the `maplibre_gl` 0.26.2 release. See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.

--- a/maplibre_gl_web/pubspec.yaml
+++ b/maplibre_gl_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maplibre_gl_web
 description: Web platform implementation of maplibre_gl. This package is only intended to be used by the maplibre_gl package.
-version: 0.26.2
+version: 0.27.0
 repository: https://github.com/maplibre/flutter-maplibre-gl
 issue_tracker: https://github.com/maplibre/flutter-maplibre-gl/issues
 resolution: workspace
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   image: ^4.8.0
-  maplibre_gl_platform_interface: ^0.26.2
+  maplibre_gl_platform_interface: ^0.27.0
   meta: ^1.16.0
   web: ^1.1.1
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bump every package in the workspace to one shared version, as RELEASE.md requires.
+#
+# What this touches:
+#   - version: in the pubspec of every workspace package
+#   - the internal maplibre_gl_* dependency constraints, so they follow the bump
+#   - the maplibre_gl: ^x.y.z install snippets in README.md and website/docs
+#
+# What it deliberately does not touch: changelogs and the migration guide. Those
+# need prose, so the script only reports whether they mention the new version.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+warn() { echo -e "${YELLOW}[bump]${NC} $*"; }
+info() { echo -e "${GREEN}[bump]${NC} $*"; }
+err()  { echo -e "${RED}[bump]${NC} $*" >&2; }
+
+# Every package carrying a version:. maplibre_gl_example and scripts are not
+# published, but RELEASE.md keeps the whole workspace on one number.
+PACKAGES=(maplibre_gl maplibre_gl_platform_interface maplibre_gl_web maplibre_gl_example scripts)
+
+# Changelogs that get their own page on pub.dev, plus the root one.
+CHANGELOGS=(CHANGELOG.md maplibre_gl/CHANGELOG.md maplibre_gl_platform_interface/CHANGELOG.md maplibre_gl_web/CHANGELOG.md)
+
+# Files documenting the version an app should depend on.
+DOC_FILES=(README.md website/docs/index.md website/docs/getting-started.md website/docs/migration.md)
+
+usage() {
+  cat <<EOF
+Bump all workspace packages to a single version.
+
+Usage: $0 <new-version> [--dry-run]
+       $0 --check
+
+Arguments:
+  <new-version>   Target version, e.g. 0.27.0 (no leading v).
+
+Options:
+  --dry-run       Print the edits without writing anything.
+  --check         Verify the workspace is self-consistent and exit. Fails when
+                  packages disagree on the version, when an internal constraint
+                  is stale, or when a changelog has no section for it. Safe to
+                  run in CI.
+  -h, --help      Show this help.
+
+Typical release flow (see RELEASE.md):
+  $0 0.27.0
+  # write the changelog sections and the migration guide entry
+  $0 --check
+EOF
+}
+
+# Reads the authoritative current version from the main package.
+current_version() {
+  local v
+  v="$(sed -n 's/^version: *//p' "$ROOT_DIR/maplibre_gl/pubspec.yaml" | head -1)"
+  if [[ -z "$v" ]]; then
+    err "No version: found in maplibre_gl/pubspec.yaml"; exit 1
+  fi
+  echo "$v"
+}
+
+# perl rather than sed -i, which differs between macOS and GNU. The strings go
+# through the environment so nothing in them is read as pattern syntax.
+replace_in_file() {
+  local file="$1"
+  PAT="$2" REPL="$3" perl -0777 -pi -e 's/\Q$ENV{PAT}\E/$ENV{REPL}/g' "$ROOT_DIR/$file"
+}
+
+count_in_file() {
+  local file="$1" pattern="$2" n
+  [[ -f "$ROOT_DIR/$file" ]] || { echo 0; return 0; }
+  # grep -c already prints 0 when nothing matches; || true keeps its exit
+  # status from tripping set -e.
+  n="$(grep -c -F -- "$pattern" "$ROOT_DIR/$file" 2>/dev/null || true)"
+  echo "${n:-0}"
+}
+
+do_check() {
+  local failures=0
+  local expected
+  expected="$(current_version)"
+  info "Checking the workspace against version $expected"
+
+  for pkg in "${PACKAGES[@]}"; do
+    local file="$pkg/pubspec.yaml" found
+    if [[ ! -f "$ROOT_DIR/$file" ]]; then
+      warn "$file is missing, skipping"; continue
+    fi
+    found="$(sed -n 's/^version: *//p' "$ROOT_DIR/$file" | head -1)"
+    if [[ "$found" != "$expected" ]]; then
+      err "$file is at ${found:-<none>}, expected $expected"; failures=$((failures + 1))
+    fi
+  done
+
+  # An internal constraint left on an older version publishes fine but resolves
+  # to the previous release, so it has to match exactly.
+  for file in maplibre_gl/pubspec.yaml maplibre_gl_web/pubspec.yaml; do
+    while IFS= read -r line; do
+      local constraint="${line##*: }"
+      if [[ "$constraint" != "^$expected" ]]; then
+        err "$file: '$line' should be ^$expected"; failures=$((failures + 1))
+      fi
+    done < <(grep -E '^  maplibre_gl(_platform_interface|_web): \^' "$ROOT_DIR/$file" || true)
+  done
+
+  for file in "${CHANGELOGS[@]}"; do
+    if ! grep -qE "^## \[?$(printf '%s' "$expected" | sed 's/\./\\./g')" "$ROOT_DIR/$file"; then
+      err "$file has no section for $expected"; failures=$((failures + 1))
+    fi
+  done
+
+  for file in "${DOC_FILES[@]}"; do
+    [[ -f "$ROOT_DIR/$file" ]] || continue
+    while IFS= read -r line; do
+      if [[ "$line" != *"^$expected" ]]; then
+        err "$file: '$(echo "$line" | xargs)' should pin ^$expected"; failures=$((failures + 1))
+      fi
+    done < <(grep -E '^ *maplibre_gl: \^[0-9]' "$ROOT_DIR/$file" || true)
+  done
+
+  if [[ $failures -gt 0 ]]; then
+    err "$failures problem(s) found"; return 1
+  fi
+  info "Workspace is consistent at $expected"
+}
+
+DRY_RUN=false
+NEW_VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) do_check; exit $? ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) err "Unknown option: $1"; usage; exit 1 ;;
+    *)
+      if [[ -n "$NEW_VERSION" ]]; then err "Unexpected argument: $1"; exit 1; fi
+      NEW_VERSION="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$NEW_VERSION" ]]; then
+  err "Missing target version"; usage; exit 1
+fi
+
+# Pre-1.0 releases use x.y.z with no build metadata (RELEASE.md), and a
+# prerelease suffix is still allowed so a release candidate can be cut.
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  err "'$NEW_VERSION' is not a version like 0.27.0 (drop any leading v)"; exit 1
+fi
+
+OLD_VERSION="$(current_version)"
+
+if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+  err "maplibre_gl is already at $NEW_VERSION"; exit 1
+fi
+
+info "$OLD_VERSION -> $NEW_VERSION"
+$DRY_RUN && warn "Dry run, nothing will be written"
+
+# (file, literal to find, replacement) triples, built before writing so a dry
+# run and a real run report exactly the same thing.
+declare -a EDITS=()
+
+for pkg in "${PACKAGES[@]}"; do
+  file="$pkg/pubspec.yaml"
+  if [[ ! -f "$ROOT_DIR/$file" ]]; then
+    warn "$file is missing, skipping"; continue
+  fi
+  if [[ "$(count_in_file "$file" "version: $OLD_VERSION")" == "0" ]]; then
+    warn "$file has no 'version: $OLD_VERSION', skipping"; continue
+  fi
+  EDITS+=("$file|version: $OLD_VERSION|version: $NEW_VERSION")
+done
+
+for file in maplibre_gl/pubspec.yaml maplibre_gl_web/pubspec.yaml; do
+  for dep in maplibre_gl_platform_interface maplibre_gl_web; do
+    if [[ "$(count_in_file "$file" "$dep: ^$OLD_VERSION")" != "0" ]]; then
+      EDITS+=("$file|$dep: ^$OLD_VERSION|$dep: ^$NEW_VERSION")
+    fi
+  done
+done
+
+for file in "${DOC_FILES[@]}"; do
+  if [[ "$(count_in_file "$file" "maplibre_gl: ^$OLD_VERSION")" != "0" ]]; then
+    EDITS+=("$file|maplibre_gl: ^$OLD_VERSION|maplibre_gl: ^$NEW_VERSION")
+  fi
+done
+
+for edit in "${EDITS[@]}"; do
+  IFS='|' read -r file pattern replacement <<< "$edit"
+  n="$(count_in_file "$file" "$pattern")"
+  info "$file: $pattern -> $replacement (${n}x)"
+  $DRY_RUN || replace_in_file "$file" "$pattern" "$replacement"
+done
+
+if $DRY_RUN; then
+  exit 0
+fi
+
+echo
+info "Version numbers updated. Remaining, by hand:"
+
+for file in "${CHANGELOGS[@]}"; do
+  if grep -qE "^## \[?$(printf '%s' "$NEW_VERSION" | sed 's/\./\\./g')" "$ROOT_DIR/$file"; then
+    info "  [x] $file documents $NEW_VERSION"
+  else
+    warn "  [ ] $file needs a $NEW_VERSION section"
+  fi
+done
+
+if grep -q "Upgrading to $NEW_VERSION" "$ROOT_DIR/website/docs/migration.md" 2>/dev/null; then
+  info "  [x] website/docs/migration.md documents $NEW_VERSION"
+else
+  warn "  [ ] website/docs/migration.md needs an 'Upgrading to $NEW_VERSION' section"
+fi
+
+warn "  [ ] smoke test the example on Android, iOS and web (RELEASE.md)"
+warn "  [ ] melos analyze && melos test"
+echo
+info "Then re-run '$0 --check' before opening the release PR."

--- a/scripts/pubspec.yaml
+++ b/scripts/pubspec.yaml
@@ -3,7 +3,7 @@ description: code generation for flutter-maplibre-gl
 publish_to: 'none'
 resolution: workspace
 
-version: 0.26.2
+version: 0.27.0
 
 environment:
   sdk: ">=3.7.0 <4.0.0"

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -16,7 +16,7 @@
 
     ```yaml title="pubspec.yaml"
     dependencies:
-      maplibre_gl: ^0.26.2
+      maplibre_gl: ^0.27.0
     ```
 
     Then run `flutter pub get` to install the package.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -75,7 +75,7 @@ hide:
 
 ```yaml
 dependencies:
-  maplibre_gl: ^0.26.2
+  maplibre_gl: ^0.27.0
 ```
 
 **2. Add the map widget**

--- a/website/docs/migration.md
+++ b/website/docs/migration.md
@@ -1,5 +1,40 @@
 # Migration Guide
 
+## Upgrading to 0.27.0
+
+No breaking changes. Update your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  maplibre_gl: ^0.27.0
+```
+
+Then run `flutter pub upgrade maplibre_gl`. See the [CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for the full list of changes.
+
+### Minimum SDK versions
+
+Unchanged from 0.26.x.
+
+| Platform | Minimum version |
+|----------|----------------|
+| Android  | API 21 (Android 5.0) |
+| iOS      | iOS 12 |
+| Flutter  | 3.29.0 |
+| Dart     | 3.7.0 |
+
+### Behaviour changes
+
+None of these need a code change, but they are the places where code that worked before starts behaving differently.
+
+* **Web**: `onMapIdle` now fires. If you worked around it never running on web, that workaround can go.
+* **Web**: `queryCameraPosition()`, `updateContentInsets()` and the new `setPadding()` no longer throw `UnimplementedError`, so any guard you put around them for web is no longer needed.
+* **iOS**: `mergeOfflineRegions()` returns only the regions it imported, instead of every region already stored. If you used its return value as the full list, call `getListOfRegions()` for that.
+* **Android, iOS**: downloading an area that is already downloaded replaces the existing region rather than adding a duplicate, and the replacement keeps the same region id.
+
+### Android apps on AGP 9
+
+The plugin no longer applies the Kotlin Gradle Plugin when your app builds with Android Gradle Plugin 9 or later, which is what broke that build before. Apps on AGP 8 are unaffected and need no change.
+
 ## Upgrading to 0.26.2
 
 See the [CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for the full list of changes.
@@ -19,11 +54,4 @@ Check the CHANGELOG for any breaking changes introduced in 0.26.x. If you were o
 
 ## Upgrading from earlier 0.26 releases
 
-No structural changes to the public API. Update your `pubspec.yaml`:
-
-```yaml
-dependencies:
-  maplibre_gl: ^0.26.2
-```
-
-Run `flutter pub upgrade maplibre_gl` and check the CHANGELOG for any deprecation notices.
+No structural changes to the public API. Run `flutter pub upgrade maplibre_gl` and check the CHANGELOG for any deprecation notices.


### PR DESCRIPTION
Bumps the whole workspace to 0.27.0 and adds the script that does it.

### The bump

`scripts/bump_version.sh 0.27.0` produced every version edit here:

* `version:` in `maplibre_gl`, `maplibre_gl_platform_interface`, `maplibre_gl_web`, and in the unpublished `maplibre_gl_example` and `scripts`, which RELEASE.md keeps on the same number
* the internal `maplibre_gl_platform_interface` and `maplibre_gl_web` constraints, so they point at 0.27.0 rather than resolving back to 0.26.2 once published
* the `maplibre_gl: ^x.y.z` install snippets in `website/docs`

`flutter pub get` resolves the workspace at the new version, which is the check that catches a missed internal constraint.

### The script

`--dry-run` prints the edits without writing. `--check` verifies the workspace is self-consistent and is safe to run in CI: it fails when packages disagree on the version, when an internal constraint is stale, when a changelog has no section for the current version, or when a docs snippet still pins an older one. It deliberately does not write changelogs, it only reports which ones are missing.

RELEASE.md now points at it instead of listing the files to edit by hand.

### Changelogs

`maplibre_gl_platform_interface` and `maplibre_gl_web` are published packages with their own pub.dev pages, and both have real changes this cycle, so both get a 0.27.0 section rather than a "no changes" placeholder:

* platform interface: `getLayerProperties`/`getSourceProperties`, the iOS location `intervalMs`/`pulseWindowMs`, and the off-isolate GeoJSON encode
* web: `queryCameraPosition`, `updateContentInsets` and `setPadding`, `getLayerProperties`/`getSourceProperties`, and the `onMapIdle` fix

### Migration guide

New "Upgrading to 0.27.0" section. There are no breaking changes, so it lists the behaviour changes instead: the cases where existing code keeps compiling but starts doing something different, such as `onMapIdle` firing on web for the first time, the web APIs that no longer throw `UnimplementedError`, `mergeOfflineRegions` on iOS returning only what it imported, and a re-downloaded region replacing the old one while keeping its id. Plus a note that apps on AGP 9 now build.

### Not done here

The smoke tests RELEASE.md asks for, on an Android device, an iOS device and web, still need to run before this is tagged.
