### PR TITLE
chore(deps): bump androidx.core:core-ktx from 1.17.0 to 1.18.0

### DIFF
--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -83,5 +83,5 @@ kotlin {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.17.0'
+    implementation 'androidx.core:core-ktx:1.18.0'
 }


### PR DESCRIPTION
Supersedes #803, which proposed 1.19.0.

### Why not 1.19.0

The AAR metadata of `androidx.core:core` and `androidx.core:core-ktx` states what a consumer needs:

| version | minCompileSdk | minAndroidGradlePluginVersion |
|---------|---------------|-------------------------------|
| 1.17.0 (current) | 36 | 8.9.1 |
| **1.18.0 (this PR)** | **36** | **8.9.1** |
| 1.19.0 (#803) | 37 | 9.1.0 |

Read from `META-INF/com/android/build/gradle/aar-metadata.properties` in each artifact.

`checkAarMetadata` runs in the consuming app, not here, so 1.19.0 would require every app using this plugin to move to compileSdk 37 and AGP 9.1. That is what CI reports on #803:

\`\`\`
Execution failed for task ':app:checkReleaseAarMetadata'.
  1. Dependency 'androidx.core:core:1.19.0' requires libraries and applications that
     compileSdk of at least 37.
  2. Dependency 'androidx.core:core:1.19.0' requires Android Gradle plugin 9.1.0 or higher.
\`\`\`

### Why 1.18.0 is free

It declares exactly what 1.17.0 already declares, so it asks nothing new of anyone. It is the highest version we can take before the compileSdk 37 and AGP 9.1 wall, and taking it means #803 is not simply left rotting.

No changelog entry: this is an internal transitive dependency with no user-visible behaviour change, matching how the other androidx bumps in this cycle were handled.