### PR TITLE
docs(migration): document the Android style-content change in 0.27.0

### DIFF
--- a/website/docs/migration.md
+++ b/website/docs/migration.md
@@ -57,7 +57,6 @@ None of these need a code change, but they are the places where code that worked
 * **Web**: `queryCameraPosition()`, `updateContentInsets()` and the new `setPadding()` no longer throw `UnimplementedError`, so any guard you put around them for web is no longer needed.
 * **iOS**: `mergeOfflineRegions()` returns only the regions it imported, instead of every region already stored. If you used its return value as the full list, call `getListOfRegions()` for that.
 * **Android, iOS**: downloading an area that is already downloaded replaces the existing region rather than adding a duplicate, and the replacement keeps the same region id.
-* **Android, iOS**: the attribution (i) button is tinted black by default instead of the SDK's blue, which was hard to read over most map backgrounds. Pass `attributionButtonColor` to `MapLibreMap` to choose your own tint, for example a light one over a dark style.
 
 ### Android apps on AGP 9
 

--- a/website/docs/migration.md
+++ b/website/docs/migration.md
@@ -2,7 +2,9 @@
 
 ## Upgrading to 0.27.0
 
-No breaking changes. Update your `pubspec.yaml`:
+No breaking API changes, so nothing stops compiling. Android apps do need one change, described under [Android: style content](#android-style-content) below.
+
+Update your `pubspec.yaml`:
 
 ```yaml
 dependencies:
@@ -10,6 +12,31 @@ dependencies:
 ```
 
 Then run `flutter pub upgrade maplibre_gl`. See the [CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for the full list of changes.
+
+### Android: style content
+
+A map on Android now survives its host activity being destroyed and recreated, whether by the "Don't keep activities" developer option, by a configuration change such as rotation, or under memory pressure. The `MapView` is rebuilt and the camera position is restored for you.
+
+What is not restored automatically is style content: sources, layers, images and runtime style switches. Apply those inside `onStyleLoadedCallback`, which fires again after each recreation, so the content comes back with the new map:
+
+```dart
+MapLibreMapController? _controller;
+
+MapLibreMap(
+  onMapCreated: (controller) => _controller = controller,
+  onStyleLoadedCallback: () async {
+    // Runs on the first style load and again after every activity recreation.
+    await _controller?.addGeoJsonSource('route', routeGeoJson);
+    await _controller?.addLineLayer(
+      'route',
+      'route-line',
+      const LineLayerProperties(lineColor: '#ff0000'),
+    );
+  },
+)
+```
+
+If your app adds that content in `onMapCreated` or `initState` instead, move it into `onStyleLoadedCallback`. Without the move, the map comes back after a recreation with the base style only, and your own layers missing.
 
 ### Minimum SDK versions
 
@@ -30,6 +57,7 @@ None of these need a code change, but they are the places where code that worked
 * **Web**: `queryCameraPosition()`, `updateContentInsets()` and the new `setPadding()` no longer throw `UnimplementedError`, so any guard you put around them for web is no longer needed.
 * **iOS**: `mergeOfflineRegions()` returns only the regions it imported, instead of every region already stored. If you used its return value as the full list, call `getListOfRegions()` for that.
 * **Android, iOS**: downloading an area that is already downloaded replaces the existing region rather than adding a duplicate, and the replacement keeps the same region id.
+* **Android, iOS**: the attribution (i) button is tinted black by default instead of the SDK's blue, which was hard to read over most map backgrounds. Pass `attributionButtonColor` to `MapLibreMap` to choose your own tint, for example a light one over a dark style.
 
 ### Android apps on AGP 9
 


### PR DESCRIPTION
Follow-up to #824.

The migration guide's 0.27.0 section still opened with "No breaking changes", which is no longer accurate. #824 makes a map on Android survive its host activity being destroyed and recreated, and while the `MapView` and the camera come back automatically, style content does not: sources, layers, images and runtime style switches have to be applied inside `onStyleLoadedCallback`, which fires again after each recreation.

An app that adds that content in `onMapCreated` or `initState` will come back from a recreation showing the base style with its own layers missing. That is a migration step, and the migration guide is where someone upgrading looks for it, so it gets its own section with a snippet rather than living only in the changelog.

Also adds the attribution button now defaulting to black instead of the SDK's blue, under the behaviour changes that need no code change but are visible.

No code changes.