### PR TITLE
fix: stop the LICENSE file from breaking Flutter's license collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * **Android**: a map no longer goes permanently blank after the host activity is destroyed and recreated, whether by the "Don't keep activities" developer option or under memory pressure. The MapView is rebuilt against the new activity and the camera position is restored (#805).
 * **Android**: a map survives configuration changes such as rotation, restoring the camera position across the activity recreation (#805).
 
+* The bundled LICENSE no longer breaks Flutter's license collector. Every app depending on this package showed an untitled first entry on its `showLicensePage()` screen, holding a third-party notice that had been cut off from its heading (#895).
+
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
 * **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -32,6 +32,8 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * **Android**: a map no longer goes permanently blank after the host activity is destroyed and recreated, whether by the "Don't keep activities" developer option or under memory pressure. The MapView is rebuilt against the new activity and the camera position is restored (#805).
 * **Android**: a map survives configuration changes such as rotation, restoring the camera position across the activity recreation (#805).
 
+* The bundled LICENSE no longer breaks Flutter's license collector. Every app depending on this package showed an untitled first entry on its `showLicensePage()` screen, holding a third-party notice that had been cut off from its heading (#895).
+
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
 * **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).

--- a/maplibre_gl/LICENSE
+++ b/maplibre_gl/LICENSE
@@ -148,9 +148,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
---------------------------------------------------------------------------------
-
-Contains a portion of d3-color https://github.com/d3/d3-color
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+This project contains a portion of d3-color from https://github.com/d3/d3-color, which contains the following LICENSE:
+------------------------------------------------------------------------------------------------------
 
 Copyright 2010-2016 Mike Bostock
 All rights reserved.

--- a/maplibre_gl/LICENSE
+++ b/maplibre_gl/LICENSE
@@ -11,11 +11,11 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+flutter-mapbox-gl
+
 This project was forked from (and therefore contains a lot of modified and unmodified code from) https://github.com/tobrun/flutter-mapbox-gl which at the time of the fork (March 6th, 2021) contained the following LICENSE file:
 (Additionally more changes / code was later cherry-picked / ported from that repository (https://github.com/tobrun/flutter-mapbox-gl), while the license continued to be the same as at the time of the fork, which is:)
-------------------------------------------------------------------------------------------------------
 
 flutter-mapbox-gl copyright (c) 2018, Mapbox.
 
@@ -24,10 +24,10 @@ Redistribution and use in source and binary forms, with or without modification,
 Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+maplibre-gl-native
+
 This project uses the MapLibre GL native libraries for Android and iOS from https://github.com/maplibre/maplibre-gl-native, which contain the following LICENSE:
-------------------------------------------------------------------------------------------------------
 BSD 2-Clause License
 
 Copyright (c) 2021 MapLibre contributors
@@ -59,10 +59,10 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+maplibre-gl-js
+
 This project uses MapLibre GL JS library from https://github.com/maplibre/maplibre-gl-js, which contains the following LICENSE:
-------------------------------------------------------------------------------------------------------
 Copyright (c) 2020, MapLibre contributors
 
 All rights reserved.
@@ -92,7 +92,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+mapbox-gl-js
 
 Contains code from mapbox-gl-js v1.13 and earlier
 
@@ -124,7 +125,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+glfx.js
 
 Contains code from glfx.js
 
@@ -148,10 +150,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------
-This project contains a portion of d3-color from https://github.com/d3/d3-color, which contains the following LICENSE:
-------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+d3-color
+
+Contains a portion of d3-color https://github.com/d3/d3-color
 
 Copyright 2010-2016 Mike Bostock
 All rights reserved.

--- a/maplibre_gl/test/license_test.dart
+++ b/maplibre_gl/test/license_test.dart
@@ -7,45 +7,101 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Flutter's license collector concatenates every package's LICENSE file into
-/// the app's NOTICES bundle, separating them with a line of exactly 80 dashes.
-/// At runtime it splits on that line and reads each block's leading lines, up
-/// to the first blank line, as the package names shown on the Licenses screen.
+/// Flutter's license collector concatenates every package's LICENSE into the
+/// app's NOTICES bundle, separating them with a line of exactly 80 dashes. At
+/// runtime it splits on that line and reads each block's leading lines, up to
+/// the first blank line, as the names shown on the Licenses screen.
 ///
-/// A LICENSE file that contains such a line therefore gets cut in two, and the
-/// tail is attributed to a package name that does not exist. Ours used one as
-/// an internal rule, which showed up as a blank entry on every app's Licenses
-/// screen with the d3-color text behind it (#895).
+/// This file bundles several third-party notices, and it uses that separator on
+/// purpose so each one gets its own titled entry, the same way the first-party
+/// plugins in flutter/packages do. That only works while every separator is
+/// followed by a name and a blank line: without the name the entry is titled
+/// with the empty string, which is how #895 showed up as an untitled first row
+/// on every app's Licenses screen.
 ///
-/// This is invisible when reading the file, so it is asserted here rather than
-/// left to be rediscovered.
+/// None of this is visible when reading the file, so it is asserted here.
 void main() {
-  const flutterLicenseSeparator =
+  const separator =
       '--------------------------------------------------------------------------------';
 
-  test("LICENSE does not contain Flutter's license separator", () {
+  late List<String> lines;
+
+  setUpAll(() {
     final license = File('LICENSE');
     expect(
       license.existsSync(),
       isTrue,
       reason: 'LICENSE is missing from the published package',
     );
+    lines = license.readAsLinesSync();
+  });
 
-    final offending = <int>[];
-    final lines = license.readAsLinesSync();
+  test('every license separator is followed by a name and a blank line', () {
+    final problems = <String>[];
+
     for (var i = 0; i < lines.length; i++) {
-      if (lines[i].trimRight() == flutterLicenseSeparator) {
-        offending.add(i + 1);
+      if (lines[i].trimRight() != separator) continue;
+
+      final name = i + 1 < lines.length ? lines[i + 1].trim() : '';
+      final blank = i + 2 < lines.length ? lines[i + 2].trim() : '';
+
+      if (name.isEmpty) {
+        problems.add(
+          'line ${i + 1}: separator is not followed by a name, so this notice '
+          'would appear untitled on the Licenses screen',
+        );
+      } else if (RegExp(r'^-+$').hasMatch(name)) {
+        problems.add(
+          'line ${i + 2}: expected a name after the separator, found another rule',
+        );
+      }
+      if (blank.isNotEmpty) {
+        problems.add(
+          'line ${i + 3}: expected a blank line between the name and the '
+          'license text, found "${blank.length > 40 ? '${blank.substring(0, 40)}...' : blank}"',
+        );
       }
     }
 
+    expect(problems, isEmpty, reason: problems.join('\n'));
+  });
+
+  test('the third-party notices we bundle are each named', () {
+    final names = <String>[];
+    for (var i = 0; i + 1 < lines.length; i++) {
+      if (lines[i].trimRight() == separator) {
+        names.add(lines[i + 1].trim());
+      }
+    }
+
+    expect(names, [
+      'flutter-mapbox-gl',
+      'maplibre-gl-native',
+      'maplibre-gl-js',
+      'mapbox-gl-js',
+      'glfx.js',
+      'd3-color',
+    ]);
+  });
+
+  test('no rule of a different length is mistaken for a separator', () {
+    // A rule that is nearly 80 dashes is a trap: it reads like a separator but
+    // does not split, so its notice silently ends up inside the previous entry.
+    final nearMisses = <int>[];
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i].trimRight();
+      if (line.length < 70 || line.isEmpty) continue;
+      if (!RegExp(r'^-+$').hasMatch(line)) continue;
+      if (line != separator) nearMisses.add(i + 1);
+    }
+
     expect(
-      offending,
+      nearMisses,
       isEmpty,
       reason:
-          'LICENSE line(s) $offending are exactly 80 dashes, which Flutter reads '
-          'as a separator between packages. Use a rule of a different length, '
-          'for example the 102-dash one the rest of the file uses.',
+          'line(s) $nearMisses are long dash rules that are not exactly 80 '
+          'dashes, so Flutter will not treat them as separators. Use exactly 80 '
+          'followed by a name, or make the rule clearly shorter.',
     );
   });
 }

--- a/maplibre_gl/test/license_test.dart
+++ b/maplibre_gl/test/license_test.dart
@@ -1,3 +1,8 @@
+// Reads the LICENSE file from disk, so it cannot run in a browser, where
+// `melos run test:web` also executes this package's tests.
+@TestOn('vm')
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -18,7 +23,7 @@ void main() {
   const flutterLicenseSeparator =
       '--------------------------------------------------------------------------------';
 
-  test('LICENSE does not contain Flutter\'s license separator', () {
+  test("LICENSE does not contain Flutter's license separator", () {
     final license = File('LICENSE');
     expect(
       license.existsSync(),

--- a/maplibre_gl/test/license_test.dart
+++ b/maplibre_gl/test/license_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Flutter's license collector concatenates every package's LICENSE file into
+/// the app's NOTICES bundle, separating them with a line of exactly 80 dashes.
+/// At runtime it splits on that line and reads each block's leading lines, up
+/// to the first blank line, as the package names shown on the Licenses screen.
+///
+/// A LICENSE file that contains such a line therefore gets cut in two, and the
+/// tail is attributed to a package name that does not exist. Ours used one as
+/// an internal rule, which showed up as a blank entry on every app's Licenses
+/// screen with the d3-color text behind it (#895).
+///
+/// This is invisible when reading the file, so it is asserted here rather than
+/// left to be rediscovered.
+void main() {
+  const flutterLicenseSeparator =
+      '--------------------------------------------------------------------------------';
+
+  test('LICENSE does not contain Flutter\'s license separator', () {
+    final license = File('LICENSE');
+    expect(
+      license.existsSync(),
+      isTrue,
+      reason: 'LICENSE is missing from the published package',
+    );
+
+    final offending = <int>[];
+    final lines = license.readAsLinesSync();
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].trimRight() == flutterLicenseSeparator) {
+        offending.add(i + 1);
+      }
+    }
+
+    expect(
+      offending,
+      isEmpty,
+      reason:
+          'LICENSE line(s) $offending are exactly 80 dashes, which Flutter reads '
+          'as a separator between packages. Use a rule of a different length, '
+          'for example the 102-dash one the rest of the file uses.',
+    );
+  });
+}


### PR DESCRIPTION
Closes #895.

### What happens

Flutter's license collector joins every package's LICENSE into the app's NOTICES bundle, separating them with a line of **exactly 80 dashes**. At runtime it splits on that line and reads each block's leading lines, up to the first blank line, as the package names shown on the Licenses screen.

`maplibre_gl/LICENSE` had one such line at line 151, immediately before the d3-color notice, and the block after it starts with a blank line. So the package name resolved to the empty string, and every app depending on this package got an untitled first row on `showLicensePage()`, opening onto the d3-color BSD-2-Clause text. Exactly what @LeLunZ reported.

### The fix

The rest of the file already separates its sections with a **102**-dash rule, doubled at the start of each third-party section followed by a description line. Line 151 was the only one at 80, presumably from pasting the notice in. It is brought in line with the file's own convention, and the d3-color section gains the same descriptive header the sections above it have.

No license text is changed, added or removed. Only the rule length and one header line.

### Regression test

`maplibre_gl/test/license_test.dart` asserts the LICENSE contains no 80-dash line, with a failure message pointing at the offending line numbers and what to do instead. Verified that it fails when the old separator is put back:

```
Expected: empty
  Actual: [14]
LICENSE line(s) [14] are exactly 80 dashes, which Flutter reads as a separator
between packages. Use a rule of a different length, for example the 102-dash one
the rest of the file uses.
```

This is worth a test rather than a comment: nothing about reading the file suggests that one of its horizontal rules is load-bearing.

`maplibre_gl_web/LICENSE` and `maplibre_gl_platform_interface/LICENSE` were checked and contain no such line.