### PR TITLE
fix(ios): stop a pre-layout camera event from poisoning cameraPosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * **Android**: a map no longer goes permanently blank after the host activity is destroyed and recreated, whether by the "Don't keep activities" developer option or under memory pressure. The MapView is rebuilt against the new activity and the camera position is restored (#805).
 * **Android**: a map survives configuration changes such as rotation, restoring the camera position across the activity recreation (#805).
 
+* **iOS**: `controller.cameraPosition` no longer gets stuck holding a non-finite zoom. Camera events that arrive before the map view has been laid out carried a `NaN` zoom, which was cached and handed to every later reader until the next camera event, so on a map the user had not touched yet, content anchored to the camera was placed wrongly. The zoom now falls back to the map view's own, and the Dart side refuses to cache a camera with non-finite components (#903).
+
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
 * **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -32,6 +32,8 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * **Android**: a map no longer goes permanently blank after the host activity is destroyed and recreated, whether by the "Don't keep activities" developer option or under memory pressure. The MapView is rebuilt against the new activity and the camera position is restored (#805).
 * **Android**: a map survives configuration changes such as rotation, restoring the camera position across the activity recreation (#805).
 
+* **iOS**: `controller.cameraPosition` no longer gets stuck holding a non-finite zoom. Camera events that arrive before the map view has been laid out carried a `NaN` zoom, which was cached and handed to every later reader until the next camera event, so on a map the user had not touched yet, content anchored to the camera was placed wrongly. The zoom now falls back to the map view's own, and the Dart side refuses to cache a camera with non-finite components (#903).
+
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
 * **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Extensions.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Extensions.swift
@@ -2,12 +2,20 @@ import MapLibre
 
 extension MLNMapCamera {
     func toDict(mapView: MLNMapView) -> [String: Any] {
-        let zoom = MLNZoomLevelForAltitude(
+        // MLNZoomLevelForAltitude derives the zoom from the view size, so a
+        // camera event that arrives before the map view has a laid-out frame
+        // divides by zero and yields a non-finite zoom. Sending that over the
+        // channel poisons the controller's cached camera position on the Dart
+        // side, and on a map nobody touches no later event arrives to correct
+        // it (#903). The map view's own zoomLevel needs no view size and is
+        // always finite, so it stands in.
+        let computedZoom = MLNZoomLevelForAltitude(
             altitude,
             pitch,
             centerCoordinate.latitude,
             mapView.frame.size
         )
+        let zoom = computedZoom.isFinite ? Double(computedZoom) : mapView.zoomLevel
         return ["bearing": heading,
                 "target": centerCoordinate.toArray(),
                 "tilt": pitch,

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -188,14 +188,22 @@ class MapLibreMapController extends ChangeNotifier {
     });
 
     _maplibrePlatform.onCameraMovePlatform.add((cameraPosition) {
-      _cameraPosition = cameraPosition;
-      onCameraMove?.call(cameraPosition);
+      // A camera carrying NaN or infinity is dropped rather than cached or
+      // forwarded, so one bad event cannot outlive itself. See
+      // [isFiniteCameraPosition].
+      if (isFiniteCameraPosition(cameraPosition)) {
+        _cameraPosition = cameraPosition;
+        onCameraMove?.call(cameraPosition);
+      }
       if (!isDisposed) notifyListeners();
     });
 
     _maplibrePlatform.onCameraIdlePlatform.add((cameraPosition) {
+      // The moving flag and the callback are not conditional: an unusable
+      // camera still means the movement ended, and leaving isCameraMoving true
+      // would be worse than a stale position.
       _isCameraMoving = false;
-      if (cameraPosition != null) {
+      if (isFiniteCameraPosition(cameraPosition)) {
         _cameraPosition = cameraPosition;
       }
       onCameraIdle?.call();
@@ -369,8 +377,30 @@ class MapLibreMapController extends ChangeNotifier {
 
   /// Returns the most recent camera position reported by the platform side.
   /// Will be null, if [MapLibreMap.trackCameraPosition] is false.
+  ///
+  /// Only readings whose components are all finite are kept here, so this never
+  /// returns a camera containing NaN or infinity. If you need a guaranteed
+  /// fresh reading rather than the last reported one, use
+  /// [queryCameraPosition], which round-trips to the platform.
   CameraPosition? get cameraPosition => _cameraPosition;
   CameraPosition? _cameraPosition;
+
+  /// Whether every component of [position] is a finite number.
+  ///
+  /// iOS derives the zoom from the map view's size, so a camera event arriving
+  /// before the view has been laid out can carry a non-finite zoom. Such a
+  /// reading is dropped instead of cached: keeping it would leave
+  /// [cameraPosition] poisoned until the next camera event, and on a map the
+  /// user never touches that event never comes.
+  @visibleForTesting
+  static bool isFiniteCameraPosition(CameraPosition? position) {
+    if (position == null) return false;
+    return position.zoom.isFinite &&
+        position.bearing.isFinite &&
+        position.tilt.isFinite &&
+        position.target.latitude.isFinite &&
+        position.target.longitude.isFinite;
+  }
 
   final MapLibrePlatform _maplibrePlatform;
 

--- a/maplibre_gl/test/camera_position_cache_test.dart
+++ b/maplibre_gl/test/camera_position_cache_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+import 'helpers/fake_platform.dart';
+
+/// iOS derives the zoom from the map view's size, so a camera event arriving
+/// before the view has been laid out can carry a non-finite zoom. The controller
+/// used to cache whatever it was handed, which left `cameraPosition` poisoned
+/// until the next camera event, and on an untouched map that event never comes
+/// (#903).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeMapLibrePlatform platform;
+  late MapLibreMapController controller;
+
+  const good = CameraPosition(target: LatLng(48.85, 2.35), zoom: 12);
+
+  setUp(() {
+    platform = FakeMapLibrePlatform();
+    controller = MapLibreMapController(
+      maplibrePlatform: platform,
+      initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+      annotationOrder: AnnotationType.values,
+      annotationConsumeTapEvents: AnnotationType.values,
+    );
+    platform.reset();
+  });
+
+  group('isFiniteCameraPosition', () {
+    test('accepts an ordinary camera', () {
+      expect(MapLibreMapController.isFiniteCameraPosition(good), isTrue);
+    });
+
+    test('rejects null', () {
+      expect(MapLibreMapController.isFiniteCameraPosition(null), isFalse);
+    });
+
+    test('rejects a NaN zoom', () {
+      expect(
+        MapLibreMapController.isFiniteCameraPosition(
+          const CameraPosition(target: LatLng(0, 0), zoom: double.nan),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects an infinite zoom', () {
+      expect(
+        MapLibreMapController.isFiniteCameraPosition(
+          const CameraPosition(target: LatLng(0, 0), zoom: double.infinity),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a non-finite bearing or tilt', () {
+      expect(
+        MapLibreMapController.isFiniteCameraPosition(
+          const CameraPosition(target: LatLng(0, 0), bearing: double.nan),
+        ),
+        isFalse,
+      );
+      expect(
+        MapLibreMapController.isFiniteCameraPosition(
+          const CameraPosition(target: LatLng(0, 0), tilt: double.nan),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a non-finite target', () {
+      expect(
+        MapLibreMapController.isFiniteCameraPosition(
+          const CameraPosition(target: LatLng(double.nan, 2.35)),
+        ),
+        isFalse,
+      );
+      expect(
+        MapLibreMapController.isFiniteCameraPosition(
+          const CameraPosition(target: LatLng(48.85, double.nan)),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('cameraPosition cache', () {
+    test('a camera move updates the cache and notifies', () {
+      platform.onCameraMovePlatform(good);
+
+      expect(controller.cameraPosition, good);
+    });
+
+    test('a non-finite camera move does not reach the cache', () {
+      platform.onCameraMovePlatform(good);
+      platform.onCameraMovePlatform(
+        const CameraPosition(target: LatLng(0, 0), zoom: double.nan),
+      );
+
+      expect(
+        controller.cameraPosition,
+        good,
+        reason: 'the last good reading must survive a poisoned event',
+      );
+    });
+
+    test('a non-finite camera move is not forwarded to onCameraMove', () {
+      final seen = <CameraPosition>[];
+      final observed = MapLibreMapController(
+        maplibrePlatform: platform,
+        initialCameraPosition: const CameraPosition(target: LatLng(0, 0)),
+        annotationOrder: AnnotationType.values,
+        annotationConsumeTapEvents: AnnotationType.values,
+        onCameraMove: seen.add,
+      );
+      addTearDown(observed.dispose);
+
+      platform.onCameraMovePlatform(
+        const CameraPosition(target: LatLng(0, 0), zoom: double.nan),
+      );
+      platform.onCameraMovePlatform(good);
+
+      expect(seen, [good]);
+    });
+
+    test('a non-finite camera idle does not reach the cache', () {
+      platform.onCameraMovePlatform(good);
+      platform.onCameraIdlePlatform(
+        const CameraPosition(target: LatLng(0, 0), zoom: double.nan),
+      );
+
+      expect(controller.cameraPosition, good);
+    });
+
+    test('a non-finite camera idle still ends the movement', () {
+      platform.onCameraMoveStartedPlatform(null);
+      expect(controller.isCameraMoving, isTrue);
+
+      platform.onCameraIdlePlatform(
+        const CameraPosition(target: LatLng(0, 0), zoom: double.nan),
+      );
+
+      expect(
+        controller.isCameraMoving,
+        isFalse,
+        reason: 'a bad position must not leave the map stuck as moving',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #903. Thanks @josipmatisic-dev for a report that came with the root cause, the file and line, and the Sentry rate.

### The bug

`MLNZoomLevelForAltitude` derives the zoom from the map view's size, so a camera event arriving before the view has a laid-out frame divides by zero and produces a non-finite zoom. The controller cached whatever it was handed. Since the next camera event only arrives from user interaction, a map nobody has touched keeps returning `NaN` from `cameraPosition` indefinitely, and anything anchored to it lands in the wrong place.

### Fixed on both sides

Either fix alone leaves a hole, so both are here:

* **iOS**: when the derived zoom is not finite, fall back to `mapView.zoomLevel`, which needs no view size and is always finite.
* **Dart**: the controller drops a camera whose components are not all finite instead of caching or forwarding it, so a bad reading from any platform cannot outlive the event that carried it.

The camera-idle handler still clears `isCameraMoving` and still fires `onCameraIdle` for an unusable position. A bad reading still means the movement ended, and leaving the map stuck as moving would be worse than a stale position.

### Tests

11 tests in `maplibre_gl/test/camera_position_cache_test.dart`, covering `isFiniteCameraPosition` and the two handlers. Verified they fail without the fix, with exactly the reported symptom:

```
cameraPosition cache a non-finite camera move does not reach the cache [E]
  Expected: CameraPosition(bearing: 0.0, target: LatLng(48.85, 2.35), tilt: 0.0, zoom: 12.0)
    Actual: CameraPosition(bearing: 0.0, target: LatLng(0.0, 0.0), tilt: 0.0, zoom: NaN)
```

Three of them fail on the old code; the one asserting that a bad idle event still ends the movement passes either way, since it guards this change rather than the original bug.

### Deliberately not touched

`MLNMapCamera.fromDict` has the same view-size dependency in reverse, via `MLNAltitudeForZoomLevel`. It is what applies the **initial** camera (`MapLibreMapController.swift:169`), which by definition runs before layout, so making it reject non-finite altitudes would silently drop that camera instead of fixing anything. Worth a look with a device, separately.

The reported workaround, calling `queryCameraPosition()`, keeps working and is still the way to force a fresh reading; `cameraPosition`'s doc comment now says so.