### PR TITLE
docs(android): describe what useHybridComposition actually selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,13 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * The PMTiles example and the web demo now read from the stable Protomaps demo archive. The previous dated planet build was pruned after a few days and served without CORS headers, which made the web demo load empty.
 * **Web**: the expressions example no longer throws "layer already exists" when the style reloads.
 * **Example app**: a new Manual Location Source page drives the puck from a simulated moving track, with start and stop, single pushes, tracking-mode switching and a live accuracy ring (#840).
+* **Android**: `MapLibreMap.useHybridComposition` documented its default as `true`, while the real default has been `false` since 0.16.0. Its API docs now state the actual default, describe which Android `View` each value selects and how Flutter embeds the map from there, and point out that the flag does not select Flutter's "Hybrid Composition" mode. `translucentTextureSurface` gained a note that it moves the map to a `TextureView` too, so the two options overlap. The "hybrid composition is currently broken" warning is gone: the `textureMode` fix in 0.26.1 made the opt-in work again (#816).
+* **Android**: the architecture page now covers Flutter's experimental Hybrid Composition++, which composites the map's `SurfaceView` natively on Android 14 and later with Vulkan. An app enables it in its own manifest and no change is needed in the plugin.
 
 ### Internal
 * **Example app**: dropped the obsolete `android.enableJetifier` flag. Every dependency has been AndroidX for years, and the transform was running out of Java heap space on the Flutter engine jar (#912).
 * **Example app**: `permission_handler` is held at 12.x. Version 14 of its Android implementation requires Flutter 3.44 and Android SDK 37 to build while declaring `flutter: >=3.24.0` (#913).
+* **Example app (Android)**: no longer overrides `MapLibreMap.useHybridComposition` by SDK version, so it now runs the plugin default like any other app. That was the only use of `device_info_plus`, which is dropped along with the pin that held it at 12.x for `win32` compatibility.
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -49,10 +49,13 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * The PMTiles example and the web demo now read from the stable Protomaps demo archive. The previous dated planet build was pruned after a few days and served without CORS headers, which made the web demo load empty.
 * **Web**: the expressions example no longer throws "layer already exists" when the style reloads.
 * **Example app**: a new Manual Location Source page drives the puck from a simulated moving track, with start and stop, single pushes, tracking-mode switching and a live accuracy ring (#840).
+* **Android**: `MapLibreMap.useHybridComposition` documented its default as `true`, while the real default has been `false` since 0.16.0. Its API docs now state the actual default, describe which Android `View` each value selects and how Flutter embeds the map from there, and point out that the flag does not select Flutter's "Hybrid Composition" mode. `translucentTextureSurface` gained a note that it moves the map to a `TextureView` too, so the two options overlap. The "hybrid composition is currently broken" warning is gone: the `textureMode` fix in 0.26.1 made the opt-in work again (#816).
+* **Android**: the architecture page now covers Flutter's experimental Hybrid Composition++, which composites the map's `SurfaceView` natively on Android 14 and later with Vulkan. An app enables it in its own manifest and no change is needed in the plugin.
 
 ### Internal
 * **Example app**: dropped the obsolete `android.enableJetifier` flag. Every dependency has been AndroidX for years, and the transform was running out of Java heap space on the Flutter engine jar (#912).
 * **Example app**: `permission_handler` is held at 12.x. Version 14 of its Android implementation requires Flutter 3.44 and Android SDK 37 to build while declaring `flutter: >=3.24.0` (#913).
+* **Example app (Android)**: no longer overrides `MapLibreMap.useHybridComposition` by SDK version, so it now runs the plugin default like any other app. That was the only use of `device_info_plus`, which is dropped along with the pin that held it at 12.x for `win32` compatibility.
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)
 

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -107,6 +107,12 @@ class MapLibreMap extends StatefulWidget {
   /// Enable translucent texture surface for the map.
   /// This allows the map to have a transparent background, useful for overlay scenarios.
   ///
+  /// This moves the map into a `TextureView` (MapLibre's `textureMode`) and
+  /// makes that view non-opaque, so it brings the same texture layer
+  /// composition as [MapLibreMap.useHybridComposition] and adds per-pixel
+  /// blending. Set `useHybridComposition` instead when you want the texture
+  /// layer with an opaque surface.
+  ///
   /// **Available only on Android. Has no effect on iOS or Web.**
   final bool translucentTextureSurface;
 
@@ -332,9 +338,37 @@ class MapLibreMap extends StatefulWidget {
   /// * All fade/transition animations have completed
   final OnMapIdleCallback? onMapIdle;
 
-  /// Set `MapLibreMap.useHybridComposition` to `false` in order use Virtual-Display
-  /// (better for Android 9 and below but may result in errors on Android 12)
-  /// or leave it `true` (default) to use Hybrid composition (Slower on Android 9 and below).
+  /// Which Android `View` the map renders into, which is what decides how
+  /// Flutter embeds it. Ignored on iOS and web.
+  ///
+  /// Defaults to `false`, and has done since 0.16.0: the map renders into a
+  /// `GLSurfaceView`. Flutter cannot redirect a `SurfaceView`'s drawing into a
+  /// texture, so it embeds the map through Virtual Display. The map's own
+  /// rendering is as direct as Android allows, at the price of Virtual
+  /// Display's known limitations around text input, accessibility and z-order.
+  ///
+  /// Set it to `true` to render into a `TextureView` instead, which is
+  /// MapLibre's `textureMode`. Flutter then composites the map as a texture
+  /// layer, so the map behaves like a regular widget: Flutter content can paint
+  /// over it, and the map itself can be transformed, clipped or animated.
+  /// Rendering into a `TextureView` costs more than a `SurfaceView` on every
+  /// Android version.
+  ///
+  /// Despite the name, this does not select Flutter's "Hybrid Composition"
+  /// mode. Both values go through `PlatformViewsService.initAndroidView`; what
+  /// changes is the native view, and Flutter picks Texture Layer Hybrid
+  /// Composition or Virtual Display from there. Apps on Android 14 or newer
+  /// with Vulkan can instead opt into Flutter's Hybrid Composition++, which
+  /// composites the `SurfaceView` natively and needs no change here. See
+  /// https://docs.flutter.dev/platform-integration/android/platform-views
+  ///
+  /// [MapLibreMap.translucentTextureSurface] also moves the map to a
+  /// `TextureView`, and on top of that makes the view non-opaque. Use this flag
+  /// when you want the texture layer without the transparency.
+  ///
+  /// Assign it before the first [MapLibreMap] is built, ideally before
+  /// `runApp()`. The mode is fixed once a platform view exists, so changing it
+  /// afterwards leaves maps already on screen untouched.
   static bool get useHybridComposition =>
       MapLibreMethodChannel.useHybridComposition;
 

--- a/maplibre_gl_example/lib/main.dart
+++ b/maplibre_gl_example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async' show unawaited;
 
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -191,28 +190,6 @@ class MapsDemo extends StatefulWidget {
 }
 
 class _MapsDemoState extends State<MapsDemo> {
-  @override
-  void initState() {
-    super.initState();
-    unawaited(initHybridComposition());
-  }
-
-  /// Determine the android version of the phone and turn off HybridComposition
-  /// on older sdk versions to improve performance for these
-  ///
-  /// !!! Hybrid composition is currently broken do no use !!!
-  Future<void> initHybridComposition() async {
-    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-      final androidInfo = await DeviceInfoPlugin().androidInfo;
-      final sdkVersion = androidInfo.version.sdkInt;
-      if (sdkVersion >= 29) {
-        MapLibreMap.useHybridComposition = true;
-      } else {
-        MapLibreMap.useHybridComposition = false;
-      }
-    }
-  }
-
   Future<void> _pushPage(BuildContext context, ExamplePage page) async {
     if (!kIsWeb && page.needsLocationPermission) {
       final status = await Permission.locationWhenInUse.status;

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -12,11 +12,6 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  # Held at 12.x: 13.x pulls win32 ^6, which no stable file_picker or share_plus
-  # accepts yet (both need win32 ^5.9). Windows is not a platform of this example,
-  # so the newer win32 buys nothing here. Lift all three together once a stable
-  # file_picker accepts win32 ^6.
-  device_info_plus: 12.3.0
   file_picker: ^11.0.2
   flutter:
     sdk: flutter

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -2,6 +2,12 @@ part of '../maplibre_gl_platform_interface.dart';
 
 class MapLibreMethodChannel extends MapLibrePlatform {
   late MethodChannel _channel;
+
+  /// Backing field of `MapLibreMap.useHybridComposition`, which is the
+  /// documented way to set this and carries the full explanation. Android only:
+  /// `false` leaves the map on a `SurfaceView`, which Flutter embeds through
+  /// Virtual Display; `true` turns on MapLibre's `textureMode` so the map
+  /// renders into a `TextureView` that Flutter composites as a texture layer.
   static bool useHybridComposition = false;
 
   Future<dynamic> _handleMethodCall(MethodCall call) async {

--- a/website/docs/concepts/architecture.md
+++ b/website/docs/concepts/architecture.md
@@ -93,20 +93,60 @@ if (kIsWeb) {
 }
 ```
 
-## Hybrid composition (Android)
+## Platform view mode (Android)
 
-On Android, Flutter offers two platform view rendering modes:
+On Android the map is a platform view, and Flutter has several ways to embed one.
+Which one you get is decided by the Android `View` the map renders into, and that
+is what `MapLibreMap.useHybridComposition` controls:
 
-- **Virtual displays** (default on older Android): renders into an off-screen surface
-- **Hybrid composition**: composites the native view directly into the Flutter layer tree
-
-For better touch handling and performance on Android 10+, you can enable hybrid composition:
+- **`false` (the default, since 0.16.0)**: the map renders into a `GLSurfaceView`.
+  Flutter cannot redirect a `SurfaceView`'s drawing into a texture, so it embeds
+  the map through Virtual Display. The map renders as directly as Android allows,
+  and you inherit Virtual Display's limitations around text input, accessibility
+  and z-order.
+- **`true`**: the map renders into a `TextureView`, which is MapLibre's
+  `textureMode`. Flutter composites it as a texture layer, so the map behaves
+  like a regular widget: Flutter content can paint over it, and the map itself
+  can be transformed, clipped or animated. A `TextureView` costs more to render
+  than a `SurfaceView` on every Android version.
 
 ```dart
 MapLibreMap.useHybridComposition = true; // call before runApp()
 ```
 
-The example app sets this automatically based on the Android SDK version.
+Set it before the first map is built. The mode is fixed once a platform view
+exists, so changing it later leaves maps already on screen untouched.
+
+Two things about this flag are worth knowing. Despite the name it does not select
+Flutter's "Hybrid Composition" mode: both values go through
+`PlatformViewsService.initAndroidView`, and Flutter chooses Texture Layer Hybrid
+Composition or Virtual Display based on the native view it finds. And the
+`translucentTextureSurface` map option moves the map to a `TextureView` as well,
+additionally making it non-opaque, so reach for `useHybridComposition` when you
+want the texture layer with an opaque surface.
+
+### Hybrid Composition++
+
+Flutter's [Hybrid Composition++](https://docs.flutter.dev/platform-integration/android/platform-views)
+composites platform views through the Android OS instead of through a texture, which
+removes the reason to choose between the two modes above: the map keeps its
+`SurfaceView` and still behaves like a widget. It needs Android 14 (API 34) or
+newer, Impeller and Vulkan, and Flutter falls back to the mode configured above
+on devices that do not qualify.
+
+It is opt-in per app, not per plugin, so nothing changes on the `maplibre_gl`
+side. Leave `useHybridComposition` at `false` and add this to your app's
+`AndroidManifest.xml`, inside `<application>`:
+
+```xml
+<meta-data
+    android:name="io.flutter.embedding.android.EnableHcpp"
+    android:value="true" />
+```
+
+For a local run, `flutter run --enable-hcpp` does the same thing. The flag is not
+accepted by `flutter build`, which is what the manifest entry is for. It is still
+experimental, so test it on the Android versions you support before shipping it.
 
 ## Callback lifecycle
 


### PR DESCRIPTION
`MapLibreMap.useHybridComposition` documented its default as `true`. It has been `false` since 0.16.0, when the default was flipped and the "hybrid composition is currently broken" warning was added to the example. #816 made the opt-in work again in 0.26.1, so that warning is obsolete.

While correcting that, two things turned out to be worth writing down.

**The flag does not select Flutter's Hybrid Composition.** Both values go through `PlatformViewsService.initAndroidView`, which is the same factory the plain `AndroidView` widget uses. Flutter's actual Hybrid Composition is `initExpensiveAndroidView`, which this plugin never calls. What the flag really changes is MapLibre's `textureMode`, and Flutter then picks its mode from the native view it finds at creation time: it cannot redirect a `GLSurfaceView`'s drawing into a texture, so it falls back to Virtual Display, while a `TextureView` gets Texture Layer Hybrid Composition.

**`translucentTextureSurface` already implies that same texture layer path**, because `MapLibreMapBuilder` turns `textureMode` on for it too. It additionally makes the view non-opaque. So the two options overlap, and the only thing `useHybridComposition` uniquely buys you is the texture layer with an opaque surface. Both dartdocs now say this, so nobody has to read the builder to find out.

The architecture page was rewritten to match, and gained a section on Flutter's experimental **Hybrid Composition++**. On API 34 and later with Vulkan it composites the map's `SurfaceView` natively, which removes the reason to choose between the two modes at all. It is opted into per app through the manifest, so it needs no change in this plugin.

Finally, the example app no longer overrides the flag by Android SDK version. It was forcing `true` on SDK 29 and up, which means our own example has been exercising the texture layer path while every other app runs the default. It now runs what users run. That was the only use of `device_info_plus`, dropped along with the pin holding it at 12.x for `win32` compatibility.

No library behaviour changes: dartdoc, website and example only.

### Verification

* `melos run analyze-all` clean and `dart format --set-exit-if-changed` clean on Flutter 3.44.0, the current stable that CI resolves to
* 452 tests pass (255 platform interface, 190 maplibre_gl, 7 web)
* claims checked against the sources rather than assumed: `MapRenderer.create` in maplibre-native at `47482f7f461a` picks the view from `getTextureMode()` alone, `TextureViewRenderThread` does `setOpaque(!isTranslucentSurface())`, `AndroidView` calls `initAndroidView` in `platform_view.dart`, and the mode selection and HCPP opt-in are as described in the engine's `docs/platforms/android/Android-Platform-Views.md`