### PR TITLE
chore: bump MapLibre Native (Android 13.4.1, iOS 6.28.0) and drop two unused Android dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
 * **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).
-* **Android**: MapLibre Android SDK upgraded from 13.3.0 to 13.3.1 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.3.1)) (#877).
+* **Android**: MapLibre Android SDK upgraded from 13.3.0 to 13.4.1 ([13.4.0](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.4.0), [13.4.1](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.4.1) upstream release notes) (#877, #929).
+* **iOS**: MapLibre iOS upgraded from 6.27.0 to 6.28.0 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.28.0)). Among the fixes it brings: the map view is no longer blurry in landscape on iPad, and `MLNNetworkConfiguration` now forwards `didReceiveResponse` to its delegate (#929).
+* **Android, iOS**: panning a pitched map no longer moves the camera past the horizon, and a layer whose `source-layer` or `source-id` changes now notifies its observer, both from the SDK upgrades above (#929).
 * **Android**: OkHttp upgraded to 5.4.0 and Play Services Location to 21.4.0.
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * **iOS**: MapLibre iOS upgraded from 6.27.0 to 6.28.0 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.28.0)). Among the fixes it brings: the map view is no longer blurry in landscape on iPad, and `MLNNetworkConfiguration` now forwards `didReceiveResponse` to its delegate (#929).
 * **Android, iOS**: panning a pitched map no longer moves the camera past the horizon, and a layer whose `source-layer` or `source-id` changes now notifies its observer, both from the SDK upgrades above (#929).
 * **Android**: OkHttp upgraded to 5.4.0 and Play Services Location to 21.4.0.
+* **Android**: the `android-plugin-annotation-v9` and `android-plugin-offline-v9` dependencies are gone, so apps pull two fewer artifacts. Neither was ever used: annotations here are drawn as style layers against the core SDK, and the offline plugin's only trace in this repository was a manifest rule that removed the activity it contributes. They came in with the folder restructure in #453 (#929).
 
 ### Docs
 * New documentation website with live, interactive examples: [maplibre.github.io/flutter-maplibre-gl](https://maplibre.github.io/flutter-maplibre-gl/) (#870).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -43,6 +43,7 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 * **iOS**: MapLibre iOS upgraded from 6.27.0 to 6.28.0 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.28.0)). Among the fixes it brings: the map view is no longer blurry in landscape on iPad, and `MLNNetworkConfiguration` now forwards `didReceiveResponse` to its delegate (#929).
 * **Android, iOS**: panning a pitched map no longer moves the camera past the horizon, and a layer whose `source-layer` or `source-id` changes now notifies its observer, both from the SDK upgrades above (#929).
 * **Android**: OkHttp upgraded to 5.4.0 and Play Services Location to 21.4.0.
+* **Android**: the `android-plugin-annotation-v9` and `android-plugin-offline-v9` dependencies are gone, so apps pull two fewer artifacts. Neither was ever used: annotations here are drawn as style layers against the core SDK, and the offline plugin's only trace in this repository was a manifest rule that removed the activity it contributes. They came in with the folder restructure in #453 (#929).
 
 ### Docs
 * New documentation website with live, interactive examples: [maplibre.github.io/flutter-maplibre-gl](https://maplibre.github.io/flutter-maplibre-gl/) (#870).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -39,7 +39,9 @@ If your app adds style content in `onMapCreated` or `initState`, move that code 
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. It still ships its CocoaPods podspec, so apps on CocoaPods keep working with no migration (#891).
 * **Android**: the plugin no longer applies the Kotlin Gradle Plugin when the app builds with AGP 9 or later, where doing so breaks the build. On AGP 8 nothing changes, so the minimum Flutter version stays at 3.29 (#905).
-* **Android**: MapLibre Android SDK upgraded from 13.3.0 to 13.3.1 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.3.1)) (#877).
+* **Android**: MapLibre Android SDK upgraded from 13.3.0 to 13.4.1 ([13.4.0](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.4.0), [13.4.1](https://github.com/maplibre/maplibre-native/releases/tag/android-v13.4.1) upstream release notes) (#877, #929).
+* **iOS**: MapLibre iOS upgraded from 6.27.0 to 6.28.0 ([upstream release notes](https://github.com/maplibre/maplibre-native/releases/tag/ios-v6.28.0)). Among the fixes it brings: the map view is no longer blurry in landscape on iPad, and `MLNNetworkConfiguration` now forwards `didReceiveResponse` to its delegate (#929).
+* **Android, iOS**: panning a pitched map no longer moves the camera past the horizon, and a layer whose `source-layer` or `source-id` changes now notifies its observer, both from the SDK upgrades above (#929).
 * **Android**: OkHttp upgraded to 5.4.0 and Play Services Location to 21.4.0.
 
 ### Docs

--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -65,8 +65,6 @@ android {
         // Using OpenGL instead of new Vulkan-based renderer for now, as it is more stable and has better performance on older devices.
         // If we want to use the Vulkan-based renderer in the future, we can switch to the regular SDK dependency below and remove the exclusion above.
         implementation 'org.maplibre.gl:android-sdk-opengl:13.4.1'
-        implementation 'org.maplibre.gl:android-plugin-annotation-v9:3.0.2'
-        implementation 'org.maplibre.gl:android-plugin-offline-v9:3.0.2'
         implementation 'com.squareup.okhttp3:okhttp:5.4.0'
         implementation 'com.google.android.gms:play-services-base:18.10.0'
         implementation 'com.google.android.gms:play-services-location:21.4.0'

--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -64,7 +64,7 @@ android {
     dependencies {
         // Using OpenGL instead of new Vulkan-based renderer for now, as it is more stable and has better performance on older devices.
         // If we want to use the Vulkan-based renderer in the future, we can switch to the regular SDK dependency below and remove the exclusion above.
-        implementation 'org.maplibre.gl:android-sdk-opengl:13.3.1'
+        implementation 'org.maplibre.gl:android-sdk-opengl:13.4.1'
         implementation 'org.maplibre.gl:android-plugin-annotation-v9:3.0.2'
         implementation 'org.maplibre.gl:android-plugin-offline-v9:3.0.2'
         implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/maplibre_gl/android/src/main/AndroidManifest.xml
+++ b/maplibre_gl/android/src/main/AndroidManifest.xml
@@ -1,11 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="org.maplibre.maplibregl">
-  
-  <!-- Remove OfflineActivity from the offline plugin as it's not needed for Flutter -->
-  <application>
-    <activity
-        android:name="org.maplibre.android.plugins.offline.ui.OfflineActivity"
-        tools:node="remove" />
-  </application>
+<manifest package="org.maplibre.maplibregl">
 </manifest>

--- a/maplibre_gl/ios/maplibre_gl.podspec
+++ b/maplibre_gl/ios/maplibre_gl.podspec
@@ -16,7 +16,7 @@ MapLibre GL Flutter plugin.
   s.dependency 'Flutter'
   # When updating the dependency version,
   # make sure to also update the version in Package.swift.
-  s.dependency 'MapLibre', '6.27.0'
+  s.dependency 'MapLibre', '6.28.0'
   s.swift_version = '5.0'
   s.ios.deployment_target = '13.0'
 end

--- a/maplibre_gl/ios/maplibre_gl/Package.swift
+++ b/maplibre_gl/ios/maplibre_gl/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // When updating the dependency version,
         // make sure to also update the version in maplibre_gl.podspec.
-        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", exact: "6.27.0"),
+        .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution.git", exact: "6.28.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Android 13.3.1 -> 13.4.1, iOS 6.27.0 -> 6.28.0, plus the removal of two dependencies that turned out never to be used.

### Nothing for apps to do

The AAR metadata of 13.4.1 is byte-identical to 13.3.1 (`minCompileSdk=34`, `minAndroidGradlePluginVersion=1.0.0`) and its list of transitive dependencies is unchanged, so no app has to raise a compile SDK or an AGP version for this.

### What the bumps bring

Shared core:

* panning a pitched map is clamped to the horizon ([#4362](https://github.com/maplibre/maplibre-native/pull/4362))
* a layer whose `source-layer` or `source-id` changes now notifies its observer ([#4372](https://github.com/maplibre/maplibre-native/pull/4372))
* a PMTiles metadata decompression failure becomes an error response instead of an uncaught exception ([#4399](https://github.com/maplibre/maplibre-native/pull/4399))

iOS:

* the map view is no longer blurry in landscape on iPad, caused by an orientation-varying scale factor ([#4373](https://github.com/maplibre/maplibre-native/pull/4373))
* `MLNNetworkConfiguration` forwards `didReceiveResponse` to its delegate ([#4393](https://github.com/maplibre/maplibre-native/pull/4393))

Android:

* an overly broad ProGuard keep rule for enums is gone ([#4365](https://github.com/maplibre/maplibre-native/pull/4365))
* the default `OkHttpClient` is only created when it is needed ([#4411](https://github.com/maplibre/maplibre-native/pull/4411))

Neither release has a breaking-changes section.

### Unblocks #889, on Android only

13.4.0 adds feature state to the Android SDK ([#4219](https://github.com/maplibre/maplibre-native/pull/4219)), which is the Android half of #889. iOS does not expose it: the core has it, but there is no binding under `platform/darwin`, so that half remains upstream work. Not implemented here, this only makes it possible.

### Dropping android-plugin-annotation-v9 and android-plugin-offline-v9

These were pinned at 3.0.2 and are not used at all. The Android source tree has no import from `org.maplibre.android.plugins`: annotations in this plugin are drawn as style layers straight against the core SDK, which is why the icon bug fixed for this release (#866) was a core texture atlas problem rather than a plugin one. The offline plugin's only trace was an `AndroidManifest.xml` rule whose only job was to remove, with `tools:node="remove"`, the single activity that plugin contributes. So the package shipped its bytecode and then spent a manifest rule cancelling its one visible effect. Both came in with the folder restructure in #453.

Upgrading them to 4.0.0 instead would have meant migrating coordinates, since 4.0.0 drops the `-v9` suffix, for two dependencies nothing calls, and would have kept shipping them. Removing is the answer.

Also worth noting: 3.0.2 was built against MapLibre Android 11.3.0 while this package ships 13.4.1, so two-majors-old plugin bytecode was running against the current SDK. That mismatch is gone rather than merely reduced.

### Verification

Not taken on trust from CI:

* the example builds on Android (`flutter build apk --debug`) and iOS (`flutter build ios --debug --no-codesign`) with Flutter 3.44.0
* the resolved versions are the intended ones: `org.maplibre.gl:android-sdk-opengl:13.4.1` on `debugCompileClasspath`, and `maplibre-gl-native-distribution -> 6.28.0` in the example's `Package.resolved`
* the AAR metadata and POM dependency lists of 13.3.1 and 13.4.1 were compared directly rather than assumed unchanged
* after the removal: zero `android-plugin-*` entries on `debugCompileClasspath`, `androidx.annotation` and `androidx.lifecycle` still resolve so the Java still compiles, a clean rebuild of the module succeeds, and the merged manifest has no reference to `OfflineActivity`

Since this changes the rendering engine, it should land before the smoke tests for this release rather than after.