### PR TITLE
docs(changelog): fix the bold marker on the first line of the 0.27.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
 
-**No breaking API change**s: nothing stops compiling. Android and Web apps each need one small change, below. The rest closes platform gaps in the public API and cuts what the map costs at start-up and on data updates.\
+**No breaking API changes**: nothing stops compiling. Android and Web apps each need one small change, below. The rest closes platform gaps in the public API and cuts what the map costs at start-up and on data updates.\
 The plugin also has a **documentation site** now, at [**maplibre.org/flutter-maplibre-gl**](https://maplibre.org/flutter-maplibre-gl/): guides for every part of the API, each with a live example you can pan and click, running the real plugin compiled for web.
 
 ### Actions needed

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
 
-**No breaking API change**s: nothing stops compiling. Android and Web apps each need one small change, below. The rest closes platform gaps in the public API and cuts what the map costs at start-up and on data updates.\
+**No breaking API changes**: nothing stops compiling. Android and Web apps each need one small change, below. The rest closes platform gaps in the public API and cuts what the map costs at start-up and on data updates.\
 The plugin also has a **documentation site** now, at [**maplibre.org/flutter-maplibre-gl**](https://maplibre.org/flutter-maplibre-gl/): guides for every part of the API, each with a live example you can pan and click, running the real plugin compiled for web.
 
 ### Actions needed


### PR DESCRIPTION
One character's worth of change, on the most read line of the release.

`**No breaking API change**s:` closes the bold before the `s`, so pub.dev renders it as **No breaking API change**s. Verified through `package:markdown` with the `gitHubWeb` extension set, which is what pub.dev renders with:

```
<p><strong>No breaking API change</strong>s: nothing stops compiling. ...
```

After the fix: `<strong>No breaking API changes</strong>: ...`

Both the root and `maplibre_gl` copies are updated and stay byte-identical.