### PR TITLE
fix(web): return feature state instead of throwing on the cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Web**: `queryCameraPosition()` is implemented; it used to throw `UnimplementedError` (#892).
 
 ### Fixed
+* **Web**: `getFeatureState()` returns the state instead of throwing. Since 0.26.0 it cast the value the wrong way and threw on every call that found a state, which nothing exercised until this release's Feature State example (#889).
 * **Android, iOS**: symbols added with `addSymbol` are visible again on styles whose glyph server does not host the old default font, which hid the whole symbol, icon included. The default is now `Noto Sans Regular`; for another font use `addSymbolLayer` with `textFont` (#940).
 * **Android, iOS**: adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode. Large payloads are encoded on a background isolate, cutting main-isolate time by two to three times (#366).
 * **Android, iOS**: downloading an area that is already downloaded replaces its region instead of adding a duplicate, and keeps the same region id (#886).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Web**: `queryCameraPosition()` is implemented; it used to throw `UnimplementedError` (#892).
 
 ### Fixed
-* **Web**: `getFeatureState()` returns the state instead of throwing, and `removeFeatureState(sourceId)` with no feature id resets the whole source instead of doing nothing. Both have been broken since 0.26.0, and nothing exercised them until this release's Feature State example (#889).
+* **Web**: `getFeatureState()` returns the state instead of throwing, and `removeFeatureState(sourceId)` with no feature id resets the whole source instead of doing nothing. Both have been broken since 0.26.0, and nothing exercised them until this release's Feature State example. `getFeatureState()` also reports no state as null rather than an empty map, and a `stateKey` with no `featureId` is rejected, both matching Android (#889).
 * **Android, iOS**: symbols added with `addSymbol` are visible again on styles whose glyph server does not host the old default font, which hid the whole symbol, icon included. The default is now `Noto Sans Regular`; for another font use `addSymbolLayer` with `textFont` (#940).
 * **Android, iOS**: adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode. Large payloads are encoded on a background isolate, cutting main-isolate time by two to three times (#366).
 * **Android, iOS**: downloading an area that is already downloaded replaces its region instead of adding a duplicate, and keeps the same region id (#886).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Web**: `queryCameraPosition()` is implemented; it used to throw `UnimplementedError` (#892).
 
 ### Fixed
-* **Web**: `getFeatureState()` returns the state instead of throwing. Since 0.26.0 it cast the value the wrong way and threw on every call that found a state, which nothing exercised until this release's Feature State example (#889).
+* **Web**: `getFeatureState()` returns the state instead of throwing, and `removeFeatureState(sourceId)` with no feature id resets the whole source instead of doing nothing. Both have been broken since 0.26.0, and nothing exercised them until this release's Feature State example (#889).
 * **Android, iOS**: symbols added with `addSymbol` are visible again on styles whose glyph server does not host the old default font, which hid the whole symbol, icon included. The default is now `Noto Sans Regular`; for another font use `addSymbolLayer` with `textFont` (#940).
 * **Android, iOS**: adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode. Large payloads are encoded on a background isolate, cutting main-isolate time by two to three times (#366).
 * **Android, iOS**: downloading an area that is already downloaded replaces its region instead of adding a duplicate, and keeps the same region id (#886).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -22,7 +22,7 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Web**: `queryCameraPosition()` is implemented; it used to throw `UnimplementedError` (#892).
 
 ### Fixed
-* **Web**: `getFeatureState()` returns the state instead of throwing. Since 0.26.0 it cast the value the wrong way and threw on every call that found a state, which nothing exercised until this release's Feature State example (#889).
+* **Web**: `getFeatureState()` returns the state instead of throwing, and `removeFeatureState(sourceId)` with no feature id resets the whole source instead of doing nothing. Both have been broken since 0.26.0, and nothing exercised them until this release's Feature State example (#889).
 * **Android, iOS**: symbols added with `addSymbol` are visible again on styles whose glyph server does not host the old default font, which hid the whole symbol, icon included. The default is now `Noto Sans Regular`; for another font use `addSymbolLayer` with `textFont` (#940).
 * **Android, iOS**: adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode. Large payloads are encoded on a background isolate, cutting main-isolate time by two to three times (#366).
 * **Android, iOS**: downloading an area that is already downloaded replaces its region instead of adding a duplicate, and keeps the same region id (#886).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -22,6 +22,7 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Web**: `queryCameraPosition()` is implemented; it used to throw `UnimplementedError` (#892).
 
 ### Fixed
+* **Web**: `getFeatureState()` returns the state instead of throwing. Since 0.26.0 it cast the value the wrong way and threw on every call that found a state, which nothing exercised until this release's Feature State example (#889).
 * **Android, iOS**: symbols added with `addSymbol` are visible again on styles whose glyph server does not host the old default font, which hid the whole symbol, icon included. The default is now `Noto Sans Regular`; for another font use `addSymbolLayer` with `textFont` (#940).
 * **Android, iOS**: adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode. Large payloads are encoded on a background isolate, cutting main-isolate time by two to three times (#366).
 * **Android, iOS**: downloading an area that is already downloaded replaces its region instead of adding a duplicate, and keeps the same region id (#886).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -22,7 +22,7 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Web**: `queryCameraPosition()` is implemented; it used to throw `UnimplementedError` (#892).
 
 ### Fixed
-* **Web**: `getFeatureState()` returns the state instead of throwing, and `removeFeatureState(sourceId)` with no feature id resets the whole source instead of doing nothing. Both have been broken since 0.26.0, and nothing exercised them until this release's Feature State example (#889).
+* **Web**: `getFeatureState()` returns the state instead of throwing, and `removeFeatureState(sourceId)` with no feature id resets the whole source instead of doing nothing. Both have been broken since 0.26.0, and nothing exercised them until this release's Feature State example. `getFeatureState()` also reports no state as null rather than an empty map, and a `stateKey` with no `featureId` is rejected, both matching Android (#889).
 * **Android, iOS**: symbols added with `addSymbol` are visible again on styles whose glyph server does not host the old default font, which hid the whole symbol, icon included. The default is now `Noto Sans Regular`; for another font use `addSymbolLayer` with `textFont` (#940).
 * **Android, iOS**: adding or updating a GeoJSON source with a large payload no longer blocks the UI for the whole encode. Large payloads are encoded on a background isolate, cutting main-isolate time by two to three times (#366).
 * **Android, iOS**: downloading an area that is already downloaded replaces its region instead of adding a duplicate, and keeps the same region id (#886).

--- a/maplibre_gl_example/integration_test/web_feature_state_test.dart
+++ b/maplibre_gl_example/integration_test/web_feature_state_test.dart
@@ -1,0 +1,156 @@
+// Integration test for feature state on web.
+//
+// All three calls cross into maplibre-gl-js, and two of them were broken from
+// 0.26.0 until 0.27.0 in ways no unit test could see: `getFeatureState` threw
+// on a bad cast, and `removeFeatureState` with no feature id built a target
+// that cleared nothing. Both need a live map to reproduce, so they are driven
+// here rather than mocked.
+//
+// Run on Chrome:
+//   chromedriver --port=4444 &
+//   flutter drive \
+//     --driver=test_driver/integration_test.dart \
+//     --target=integration_test/web_feature_state_test.dart \
+//     -d web-server --browser-name=chrome
+//
+// The assertions only run on web; elsewhere the test is a no-op so the suite
+// stays green everywhere.
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+const _sourceId = 'probe';
+const _layerId = 'probe-fill';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('set, read, remove one key, reset the whole source', (
+    tester,
+  ) async {
+    if (!kIsWeb) return;
+
+    final controller = await _pumpMapWithSource(tester);
+
+    // No state yet: the contract is null, not an empty map, so an app can tell
+    // "nothing set" from "set to nothing". maplibre-gl-js answers {} here.
+    expect(await controller.getFeatureState(_sourceId, '1'), isNull);
+
+    await controller.setFeatureState(_sourceId, '1', {
+      'selected': true,
+      'score': 7,
+    });
+    expect(await controller.getFeatureState(_sourceId, '1'), {
+      'selected': true,
+      'score': 7,
+    });
+
+    // One key off the feature, the rest untouched.
+    await controller.removeFeatureState(
+      _sourceId,
+      featureId: '1',
+      stateKey: 'selected',
+    );
+    expect(await controller.getFeatureState(_sourceId, '1'), {'score': 7});
+
+    // A key with no feature to take it from is rejected, as on Android, rather
+    // than quietly doing nothing.
+    await expectLater(
+      controller.removeFeatureState(_sourceId, stateKey: 'score'),
+      throwsA(isA<PlatformException>()),
+    );
+    expect(await controller.getFeatureState(_sourceId, '1'), {'score': 7});
+
+    // The bare call resets every feature of the source.
+    await controller.setFeatureState(_sourceId, '2', {'selected': true});
+    await controller.removeFeatureState(_sourceId);
+    expect(await controller.getFeatureState(_sourceId, '1'), isNull);
+    expect(await controller.getFeatureState(_sourceId, '2'), isNull);
+  });
+}
+
+/// Builds a map with a two-feature GeoJSON source and a layer that renders it,
+/// and returns its controller once the source is in the style.
+Future<MapLibreMapController> _pumpMapWithSource(WidgetTester tester) async {
+  final controllerCompleter = Completer<MapLibreMapController>();
+  final styleLoaded = Completer<void>();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          height: 400,
+          child: MapLibreMap(
+            styleString: MapLibreStyles.demo,
+            initialCameraPosition: const CameraPosition(
+              target: LatLng(0, 0),
+              zoom: 3,
+            ),
+            onMapCreated: controllerCompleter.complete,
+            onStyleLoadedCallback: () {
+              if (!styleLoaded.isCompleted) styleLoaded.complete();
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+
+  final controller = await _await(
+    tester,
+    controllerCompleter.future,
+    'onMapCreated',
+  );
+  await _await(tester, styleLoaded.future, 'onStyleLoaded');
+
+  await controller.addGeoJsonSource(_sourceId, {
+    'type': 'FeatureCollection',
+    'features': [
+      for (var id = 1; id <= 2; id++)
+        {
+          'type': 'Feature',
+          'id': id,
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [id.toDouble(), 0.0],
+          },
+          'properties': <String, dynamic>{},
+        },
+    ],
+  });
+  await controller.addCircleLayer(
+    _sourceId,
+    _layerId,
+    const CircleLayerProperties(circleRadius: 12),
+  );
+  return controller;
+}
+
+/// Awaits [future] while pumping frames, failing with [label] on timeout.
+Future<T> _await<T>(
+  WidgetTester tester,
+  Future<T> future,
+  String label, {
+  Duration timeout = const Duration(seconds: 40),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  var done = false;
+  T? result;
+  unawaited(
+    future.then((value) {
+      done = true;
+      result = value;
+    }),
+  );
+  while (!done) {
+    if (DateTime.now().isAfter(deadline)) fail('Timed out waiting for $label');
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  return result as T;
+}

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -11,6 +11,7 @@ See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 * `MapLibreGlobalWeb` implements the new `MapLibreGlobalPlatform` at plugin registration, which is how `MapLibreMap.preWarm()` and `MapLibreMap.ensureWebLibraryLoaded()` get their web behaviour (#928).
 
 ### Fixed
+* `getFeatureState()` returns the state instead of throwing. It converted the JS object with `dartify()` and cast the result to `Map<String, dynamic>`, which that conversion never produces, so every call that found a state threw (#889).
 * `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -11,8 +11,8 @@ See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 * `MapLibreGlobalWeb` implements the new `MapLibreGlobalPlatform` at plugin registration, which is how `MapLibreMap.preWarm()` and `MapLibreMap.ensureWebLibraryLoaded()` get their web behaviour (#928).
 
 ### Fixed
-* `getFeatureState()` returns the state instead of throwing. It converted the JS object with `dartify()` and cast the result to `Map<String, dynamic>`, which that conversion never produces, so every call that found a state threw (#889).
-* `removeFeatureState(sourceId)` with no feature id resets the whole source again. It built the target with `id: null`, and maplibre-gl-js only treats a missing id as "every feature of this source", so the call matched nothing and cleared nothing, without an error (#889).
+* `getFeatureState()` returns the state instead of throwing, and reports no state as null rather than as an empty map, matching Android. It converted the JS object with `dartify()` and cast the result to `Map<String, dynamic>`, which that conversion never produces, so every call that found a state threw (#889).
+* `removeFeatureState(sourceId)` with no feature id resets the whole source. It built the target with `id: null`, and maplibre-gl-js only treats a missing id as "every feature of this source", so the call matched nothing and cleared nothing, without an error. A `stateKey` with no `featureId` now raises the same `INVALID_ARGUMENT` as Android instead of being ignored (#889).
 * `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -12,6 +12,7 @@ See top-level [CHANGELOG.md](../CHANGELOG.md) for full details.
 
 ### Fixed
 * `getFeatureState()` returns the state instead of throwing. It converted the JS object with `dartify()` and cast the result to `Map<String, dynamic>`, which that conversion never produces, so every call that found a state threw (#889).
+* `removeFeatureState(sourceId)` with no feature id resets the whole source again. It built the target with `id: null`, and maplibre-gl-js only treats a missing id as "every feature of this source", so the call matched nothing and cleared nothing, without an error (#889).
 * `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 
 ## [0.26.2](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.1...v0.26.2)

--- a/maplibre_gl_web/lib/src/interop/style/feature_identifier_interop.dart
+++ b/maplibre_gl_web/lib/src/interop/style/feature_identifier_interop.dart
@@ -1,4 +1,5 @@
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 /// Identifies a feature for feature state operations.
 /// Matches the MapLibre GL JS FeatureIdentifier type.
@@ -21,4 +22,25 @@ extension type FeatureIdentifierJsImpl._(JSObject _) implements JSObject {
     JSAny? id,
     String? sourceLayer,
   });
+
+  /// Builds a target that carries only the fields it is given.
+  ///
+  /// An absent field and a null one are different things here: maplibre-gl-js
+  /// reads a missing `id` as "every feature of this source" but a null one as
+  /// an id to look up, so passing null where the caller meant "not set" turns
+  /// a source-wide remove into a silent no-op. Dart cannot tell the two apart,
+  /// which is why every call site should come through this instead of building
+  /// the literal itself.
+  factory FeatureIdentifierJsImpl.of({
+    required String source,
+    JSAny? id,
+    String? sourceLayer,
+  }) {
+    final target = JSObject()..setProperty('source'.toJS, source.toJS);
+    if (id != null) target.setProperty('id'.toJS, id);
+    if (sourceLayer != null) {
+      target.setProperty('sourceLayer'.toJS, sourceLayer.toJS);
+    }
+    return FeatureIdentifierJsImpl._(target);
+  }
 }

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1856,7 +1856,7 @@ class MapLibreMapController extends MapLibrePlatform
     Map<String, dynamic> state, {
     String? sourceLayer,
   }) async {
-    final feature = FeatureIdentifierJsImpl(
+    final feature = FeatureIdentifierJsImpl.of(
       source: sourceId,
       id: featureId.jsify(),
       sourceLayer: sourceLayer,
@@ -1872,22 +1872,24 @@ class MapLibreMapController extends MapLibrePlatform
     String? stateKey,
     String? sourceLayer,
   }) async {
-    // `id` has to be left out, not passed as null, when the whole source is
-    // being reset: maplibre-gl-js reads a missing id as "every feature of this
-    // source" but treats a null one as an id to look up, which matches nothing
-    // and clears nothing, silently. An object literal constructor only sets
-    // the arguments it is given, so the two calls differ in exactly that.
-    final feature =
-        featureId == null
-            ? FeatureIdentifierJsImpl(
-              source: sourceId,
-              sourceLayer: sourceLayer,
-            )
-            : FeatureIdentifierJsImpl(
-              source: sourceId,
-              id: featureId.jsify(),
-              sourceLayer: sourceLayer,
-            );
+    // A stateKey lives inside one feature's state, so without a featureId
+    // there is nothing to remove it from. maplibre-gl-js only fires an error
+    // event here and leaves the state alone, which the caller never sees, so
+    // raise what Android raises for the same call instead.
+    if (featureId == null && stateKey != null) {
+      throw PlatformException(
+        code: 'INVALID_ARGUMENT',
+        message:
+            "removeFeatureState with a 'stateKey' also requires the "
+            "'featureId' that owns the key.",
+      );
+    }
+
+    final feature = FeatureIdentifierJsImpl.of(
+      source: sourceId,
+      id: featureId.jsify(),
+      sourceLayer: sourceLayer,
+    );
 
     _map.removeFeatureState(feature, stateKey);
   }
@@ -1898,19 +1900,23 @@ class MapLibreMapController extends MapLibrePlatform
     String featureId, {
     String? sourceLayer,
   }) async {
-    final feature = FeatureIdentifierJsImpl(
+    final feature = FeatureIdentifierJsImpl.of(
       source: sourceId,
       id: featureId.jsify(),
       sourceLayer: sourceLayer,
     );
 
-    final state = _map.getFeatureState(feature);
-    if (state == null) return null;
-
     // Not `dartify()`: for a JS object that returns a Map<Object?, Object?>,
     // so casting it to Map<String, dynamic> threw on every call that found a
     // state. dartifyMap builds the typed map this signature promises.
-    return dartifyMap(state);
+    final state = dartifyMap(_map.getFeatureState(feature));
+
+    // maplibre-gl-js answers {} for a feature that has no state at all, while
+    // Android replies null and the return type is nullable so callers can tell
+    // the two apart. Report the absence the same way here. A state explicitly
+    // set to {} is indistinguishable from no state on this platform, and reads
+    // as absent.
+    return state.isEmpty ? null : state;
   }
 
   @override

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1896,8 +1896,10 @@ class MapLibreMapController extends MapLibrePlatform
     final state = _map.getFeatureState(feature);
     if (state == null) return null;
 
-    // Convert JSObject to Dart Map
-    return (state as JSObject).dartify() as Map<String, dynamic>?;
+    // Not `dartify()`: for a JS object that returns a Map<Object?, Object?>,
+    // so casting it to Map<String, dynamic> threw on every call that found a
+    // state. dartifyMap builds the typed map this signature promises.
+    return dartifyMap(state);
   }
 
   @override

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -1872,11 +1872,22 @@ class MapLibreMapController extends MapLibrePlatform
     String? stateKey,
     String? sourceLayer,
   }) async {
-    final feature = FeatureIdentifierJsImpl(
-      source: sourceId,
-      id: featureId.jsify(),
-      sourceLayer: sourceLayer,
-    );
+    // `id` has to be left out, not passed as null, when the whole source is
+    // being reset: maplibre-gl-js reads a missing id as "every feature of this
+    // source" but treats a null one as an id to look up, which matches nothing
+    // and clears nothing, silently. An object literal constructor only sets
+    // the arguments it is given, so the two calls differ in exactly that.
+    final feature =
+        featureId == null
+            ? FeatureIdentifierJsImpl(
+              source: sourceId,
+              sourceLayer: sourceLayer,
+            )
+            : FeatureIdentifierJsImpl(
+              source: sourceId,
+              id: featureId.jsify(),
+              sourceLayer: sourceLayer,
+            );
 
     _map.removeFeatureState(feature, stateKey);
   }

--- a/maplibre_gl_web/test/dartify_map_test.dart
+++ b/maplibre_gl_web/test/dartify_map_test.dart
@@ -1,0 +1,49 @@
+// Runs against the real JS object model, so it needs a browser:
+// `flutter test --platform chrome`.
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_web/src/utils.dart';
+
+/// `getFeatureState` returned `(state as JSObject).dartify() as Map<String,
+/// dynamic>?` and threw on every call that found a state, from 0.26.0 until
+/// this test was written. The platform code cannot be unit tested without a
+/// live map, but the reason it threw can be, and it is the part that is easy
+/// to reintroduce: `dartify()` looks like it produces the map the signature
+/// promises, and it does not.
+void main() {
+  group('converting a JS object to a Dart map', () {
+    test('dartify does not produce a Map<String, dynamic>', () {
+      final jsState = JSObject()..setProperty('selected'.toJS, true.toJS);
+
+      expect(
+        jsState.dartify(),
+        isNot(isA<Map<String, dynamic>>()),
+        reason:
+            'if this ever starts holding, the cast that used to be here was '
+            'not the bug it looked like; check the fix in getFeatureState',
+      );
+    });
+
+    test('dartifyMap produces one, with the values intact', () {
+      final jsState =
+          JSObject()
+            ..setProperty('selected'.toJS, true.toJS)
+            ..setProperty('score'.toJS, 42.toJS)
+            ..setProperty('label'.toJS, 'north'.toJS);
+
+      final state = dartifyMap(jsState);
+
+      expect(state, isA<Map<String, dynamic>>());
+      expect(state, {'selected': true, 'score': 42, 'label': 'north'});
+    });
+
+    test('an empty JS object gives an empty map, not null', () {
+      expect(dartifyMap(JSObject()), isEmpty);
+    });
+  });
+}

--- a/maplibre_gl_web/test/dartify_map_test.dart
+++ b/maplibre_gl_web/test/dartify_map_test.dart
@@ -11,24 +11,12 @@ import 'package:maplibre_gl_web/src/utils.dart';
 
 /// `getFeatureState` returned `(state as JSObject).dartify() as Map<String,
 /// dynamic>?` and threw on every call that found a state, from 0.26.0 until
-/// this test was written. The platform code cannot be unit tested without a
-/// live map, but the reason it threw can be, and it is the part that is easy
-/// to reintroduce: `dartify()` looks like it produces the map the signature
-/// promises, and it does not.
+/// this test was written, because that conversion does not produce the map the
+/// cast asked for. What is asserted here is our side of it: `dartifyMap` builds
+/// the typed map the signature promises. Asserting the other half, how the SDK's
+/// `dartify` behaves, would turn an SDK change into a red build on working code.
 void main() {
   group('converting a JS object to a Dart map', () {
-    test('dartify does not produce a Map<String, dynamic>', () {
-      final jsState = JSObject()..setProperty('selected'.toJS, true.toJS);
-
-      expect(
-        jsState.dartify(),
-        isNot(isA<Map<String, dynamic>>()),
-        reason:
-            'if this ever starts holding, the cast that used to be here was '
-            'not the bug it looked like; check the fix in getFeatureState',
-      );
-    });
-
     test('dartifyMap produces one, with the values intact', () {
       final jsState =
           JSObject()

--- a/maplibre_gl_web/test/feature_identifier_test.dart
+++ b/maplibre_gl_web/test/feature_identifier_test.dart
@@ -20,7 +20,7 @@ import 'package:maplibre_gl_web/src/interop/style/feature_identifier_interop.dar
 void main() {
   group('FeatureIdentifierJsImpl', () {
     test('leaves out the arguments it is not given', () {
-      final target = FeatureIdentifierJsImpl(source: 'states');
+      final target = FeatureIdentifierJsImpl.of(source: 'states');
 
       expect(target.has('source'), isTrue);
       expect(
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('sets the arguments it is given', () {
-      final target = FeatureIdentifierJsImpl(
+      final target = FeatureIdentifierJsImpl.of(
         source: 'states',
         id: '46'.toJS,
         sourceLayer: 'admin',
@@ -43,18 +43,18 @@ void main() {
       expect(target.sourceLayer, 'admin');
     });
 
-    test('an explicitly null id is still a property, which is the trap', () {
-      // Passing null explicitly is the case under test: the analyzer is right
-      // that it matches the default, and wrong that it changes nothing.
+    test('a null id is left out, which is what the whole fix rests on', () {
+      // Passing null explicitly is the case under test, so the analyzer is
+      // right that it matches the default and wrong that it changes nothing.
       // ignore: avoid_redundant_argument_values
-      final target = FeatureIdentifierJsImpl(source: 'states', id: null);
+      final target = FeatureIdentifierJsImpl.of(source: 'states', id: null);
 
       expect(
         target.has('id'),
-        isTrue,
+        isFalse,
         reason:
-            'if this ever stops holding, passing null became equivalent to '
-            'omitting and removeFeatureState no longer needs its two branches',
+            'null means "not set" to every caller here, and the JS object has '
+            'to say the same, or a source-wide remove silently does nothing',
       );
     });
   });

--- a/maplibre_gl_web/test/feature_identifier_test.dart
+++ b/maplibre_gl_web/test/feature_identifier_test.dart
@@ -1,0 +1,61 @@
+// Inspects real JS objects, so it needs a browser:
+// `flutter test --platform chrome`.
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl_web/src/interop/style/feature_identifier_interop.dart';
+
+/// `removeFeatureState(sourceId)` with no feature id is the documented way to
+/// reset a whole source, and it did nothing on web: the target was built with
+/// `id: null`, and maplibre-gl-js only treats a **missing** id as "every
+/// feature of this source". A null one is an id to look up, so it matched
+/// nothing and cleared nothing, without an error.
+///
+/// The distinction is invisible in Dart, where both read as null, which is why
+/// it is asserted here on the JS object itself.
+void main() {
+  group('FeatureIdentifierJsImpl', () {
+    test('leaves out the arguments it is not given', () {
+      final target = FeatureIdentifierJsImpl(source: 'states');
+
+      expect(target.has('source'), isTrue);
+      expect(
+        target.has('id'),
+        isFalse,
+        reason: 'a present id, even null, stops a source-wide remove',
+      );
+      expect(target.has('sourceLayer'), isFalse);
+    });
+
+    test('sets the arguments it is given', () {
+      final target = FeatureIdentifierJsImpl(
+        source: 'states',
+        id: '46'.toJS,
+        sourceLayer: 'admin',
+      );
+
+      expect(target.has('id'), isTrue);
+      expect((target.id as JSString?)?.toDart, '46');
+      expect(target.sourceLayer, 'admin');
+    });
+
+    test('an explicitly null id is still a property, which is the trap', () {
+      // Passing null explicitly is the case under test: the analyzer is right
+      // that it matches the default, and wrong that it changes nothing.
+      // ignore: avoid_redundant_argument_values
+      final target = FeatureIdentifierJsImpl(source: 'states', id: null);
+
+      expect(
+        target.has('id'),
+        isTrue,
+        reason:
+            'if this ever stops holding, passing null became equivalent to '
+            'omitting and removeFeatureState no longer needs its two branches',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Found while smoke testing the web build: every tap on the new Feature State example raised an uncaught error.

## The bug

`getFeatureState` did this:

```dart
return (state as JSObject).dartify() as Map<String, dynamic>?;
```

`dartify()` produces a `Map<Object?, Object?>`, never a `Map<String, dynamic>`, so the cast threw on **every call that found a state**. It has been there since `a63c5f7` (0.26.0), which means the web half of the feature state API has never worked.

Nothing exercised it until the Feature State example landed in this release, so it surfaced now, as `Rti._generalNullableAsCheckImplementation` with no message: the example calls the read-back inside an unawaited future, so the error escapes as an uncaught async error and the UI keeps going.

## The fix

Use the package's own `dartifyMap`, which builds the typed map the signature promises.

## Tests

The platform call needs a live map, so it cannot be unit tested here, but the reason it threw can be, and that is the part that is easy to reintroduce: `dartify()` looks like it produces the right map and does not. Three tests assert that it does not, that `dartifyMap` does with the values intact, and that an empty object gives an empty map rather than null.

`analyze` clean, 18 web tests green.