### PR TITLE
fix(ios): report a feature that cannot be encoded instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,15 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Android**: merging an offline database whose regions carry no metadata, such as one produced by maplibre-native, no longer fails with `type 'Null' is not a subtype of type 'Map<String, dynamic>'` (#865).
 * **iOS**: `mergeOfflineRegions()` returns only the regions it imported, not every region already stored (#886).
 * **iOS**: `queryRenderedFeatures()` and `querySourceFeatures()` no longer drop a feature they cannot encode. One that failed to serialize was skipped, so the call answered with a shorter list and no way to tell that anything was missing; it now reports the failure. Android was never affected (#949).
+* **iOS**: `queryRenderedFeaturesInRect()` applies the `filter` it is given. The filter was ignored, so the call answered with every feature in the rectangle (#949).
+* **iOS**: `queryRenderedFeatures()` and `querySourceFeatures()` report a call they cannot answer, such as one made before the style has loaded, instead of leaving the caller waiting forever (#949).
 * **iOS**: `queryCameraPosition()` returns the camera position even when `trackCameraPosition` is `false`, matching Android. It used to return `null` (#892).
 * **iOS**: `controller.cameraPosition` no longer sticks on a `NaN` zoom from a camera event that arrived before the first layout, which misplaced camera-anchored content on maps the user had not touched (#903).
 * **Web**: `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 * **Web**: `updateContentInsets` and the new `setPadding` no longer throw `UnimplementedError` (#258).
 * **Web**: `querySourceFeatures()` reports a call made before the style has loaded, matching Android and iOS. It answered with an empty list, which the caller cannot tell apart from a source holding no features (#952).
 * The bundled LICENSE no longer breaks Flutter's license collector, which showed an untitled, truncated first entry on every dependent app's `showLicensePage()` (#895).
+
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. The CocoaPods podspec still ships, so CocoaPods apps need no migration (#891).
 * **Android**: the Kotlin Gradle Plugin is applied only below AGP 9, so builds on AGP 9 or later no longer break. Nothing changes on AGP 8 (#905).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,13 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Android**: icons added with `addImage` are visible again, at the right size on high-density screens, and undecodable bytes report a clear error instead of crashing. Since 0.26.0 icons could be dropped whenever draggable annotations were in use, which is the default (#866, #868).
 * **Android**: merging an offline database whose regions carry no metadata, such as one produced by maplibre-native, no longer fails with `type 'Null' is not a subtype of type 'Map<String, dynamic>'` (#865).
 * **iOS**: `mergeOfflineRegions()` returns only the regions it imported, not every region already stored (#886).
+* **iOS**: `queryRenderedFeatures()` and `querySourceFeatures()` no longer drop a feature they cannot encode. One that failed to serialize was skipped, so the call answered with a shorter list and no way to tell that anything was missing; it now reports the failure. Android was never affected (#949).
 * **iOS**: `queryCameraPosition()` returns the camera position even when `trackCameraPosition` is `false`, matching Android. It used to return `null` (#892).
 * **iOS**: `controller.cameraPosition` no longer sticks on a `NaN` zoom from a camera event that arrived before the first layout, which misplaced camera-anchored content on maps the user had not touched (#903).
 * **Web**: `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 * **Web**: `updateContentInsets` and the new `setPadding` no longer throw `UnimplementedError` (#258).
 * **Web**: `querySourceFeatures()` reports a call made before the style has loaded, matching Android and iOS. It answered with an empty list, which the caller cannot tell apart from a source holding no features (#952).
 * The bundled LICENSE no longer breaks Flutter's license collector, which showed an untitled, truncated first entry on every dependent app's `showLicensePage()` (#895).
-
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. The CocoaPods podspec still ships, so CocoaPods apps need no migration (#891).
 * **Android**: the Kotlin Gradle Plugin is applied only below AGP 9, so builds on AGP 9 or later no longer break. Nothing changes on AGP 8 (#905).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -35,12 +35,12 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Android**: icons added with `addImage` are visible again, at the right size on high-density screens, and undecodable bytes report a clear error instead of crashing. Since 0.26.0 icons could be dropped whenever draggable annotations were in use, which is the default (#866, #868).
 * **Android**: merging an offline database whose regions carry no metadata, such as one produced by maplibre-native, no longer fails with `type 'Null' is not a subtype of type 'Map<String, dynamic>'` (#865).
 * **iOS**: `mergeOfflineRegions()` returns only the regions it imported, not every region already stored (#886).
+* **iOS**: `queryRenderedFeatures()` and `querySourceFeatures()` no longer drop a feature they cannot encode. One that failed to serialize was skipped, so the call answered with a shorter list and no way to tell that anything was missing; it now reports the failure. Android was never affected (#949).
 * **iOS**: `queryCameraPosition()` returns the camera position even when `trackCameraPosition` is `false`, matching Android. It used to return `null` (#892).
 * **iOS**: `controller.cameraPosition` no longer sticks on a `NaN` zoom from a camera event that arrived before the first layout, which misplaced camera-anchored content on maps the user had not touched (#903).
 * **Web**: `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 * **Web**: `updateContentInsets` and the new `setPadding` no longer throw `UnimplementedError` (#258).
 * The bundled LICENSE no longer breaks Flutter's license collector, which showed an untitled, truncated first entry on every dependent app's `showLicensePage()` (#895).
-
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. The CocoaPods podspec still ships, so CocoaPods apps need no migration (#891).
 * **Android**: the Kotlin Gradle Plugin is applied only below AGP 9, so builds on AGP 9 or later no longer break. Nothing changes on AGP 8 (#905).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -36,11 +36,14 @@ The plugin also has a **documentation site** now, at [**maplibre.org/flutter-map
 * **Android**: merging an offline database whose regions carry no metadata, such as one produced by maplibre-native, no longer fails with `type 'Null' is not a subtype of type 'Map<String, dynamic>'` (#865).
 * **iOS**: `mergeOfflineRegions()` returns only the regions it imported, not every region already stored (#886).
 * **iOS**: `queryRenderedFeatures()` and `querySourceFeatures()` no longer drop a feature they cannot encode. One that failed to serialize was skipped, so the call answered with a shorter list and no way to tell that anything was missing; it now reports the failure. Android was never affected (#949).
+* **iOS**: `queryRenderedFeaturesInRect()` applies the `filter` it is given. The filter was ignored, so the call answered with every feature in the rectangle (#949).
+* **iOS**: `queryRenderedFeatures()` and `querySourceFeatures()` report a call they cannot answer, such as one made before the style has loaded, instead of leaving the caller waiting forever (#949).
 * **iOS**: `queryCameraPosition()` returns the camera position even when `trackCameraPosition` is `false`, matching Android. It used to return `null` (#892).
 * **iOS**: `controller.cameraPosition` no longer sticks on a `NaN` zoom from a camera event that arrived before the first layout, which misplaced camera-anchored content on maps the user had not touched (#903).
 * **Web**: `onMapIdle` now fires, matching Android and iOS; code waiting on it never ran (#857).
 * **Web**: `updateContentInsets` and the new `setPadding` no longer throw `UnimplementedError` (#258).
 * The bundled LICENSE no longer breaks Flutter's license collector, which showed an untitled, truncated first entry on every dependent app's `showLicensePage()` (#895).
+
 ### Changed
 * **iOS**: the plugin supports Flutter's Swift Package Manager integration. The CocoaPods podspec still ships, so CocoaPods apps need no migration (#891).
 * **Android**: the Kotlin Gradle Plugin is applied only below AGP 9, so builds on AGP 9 or later no longer break. Nothing changes on AGP 8 (#905).

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -472,7 +472,6 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             if let filter = arguments["filter"] as? [Any] {
                 filterExpression = NSPredicate(mglJSONObject: filter)
             }
-            var reply = [String: NSObject]()
             var features: [MLNFeature] = []
             if let x = arguments["x"] as? Double, let y = arguments["y"] as? Double {
                 features = mapView.visibleFeatures(
@@ -490,20 +489,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 var height = bottom - top
                 features = mapView.visibleFeatures(in: CGRect(x: left, y: top, width: width, height: height), styleLayerIdentifiers: styleLayerIdentifiers, predicate: filterExpression)
             }
-            var featuresJson = [String]()
-            for feature in features {
-                let dictionary = feature.geoJSONDictionary()
-                if let theJSONData = try? JSONSerialization.data(
-                    withJSONObject: dictionary,
-                    options: []
-                ),
-                    let theJSONText = String(data: theJSONData, encoding: .utf8)
-                {
-                    featuresJson.append(theJSONText)
-                }
-            }
-            reply["features"] = featuresJson as NSObject
-            result(reply)
+            result(featuresReply(features, methodName: "queryRenderedFeatures"))
         case "map#setTelemetryEnabled":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             let telemetryEnabled = arguments["enabled"] as? Bool
@@ -1355,7 +1341,6 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 filterExpression = NSPredicate(mglJSONObject: filter)
             }
 
-            var reply = [String: NSObject]()
             var features: [MLNFeature] = []
 
             guard let style = mapView.style else { return }
@@ -1367,20 +1352,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 }
             }
 
-            var featuresJson = [String]()
-            for feature in features {
-                let dictionary = feature.geoJSONDictionary()
-                if let theJSONData = try? JSONSerialization.data(
-                    withJSONObject: dictionary,
-                    options: []
-                ),
-                    let theJSONText = String(data: theJSONData, encoding: .utf8)
-                {
-                    featuresJson.append(theJSONText)
-                }
-            }
-            reply["features"] = featuresJson as NSObject
-            result(reply)
+            result(featuresReply(features, methodName: "querySourceFeatures"))
 
         case "style#getLayerIds":
             var layerIds = [String]()
@@ -2401,14 +2373,16 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         )
     }
 
-    /// Serializes features for the channel as JSON strings, like
-    /// `map#querySourceFeatures`, so nested properties survive intact.
+    /// Serializes features for the channel as JSON strings, so nested
+    /// properties survive intact. Shared by every call that answers with
+    /// features.
     ///
     /// Returns a `FlutterError` if any feature fails to serialize, rather than
-    /// skipping it. A short list is worse than an error here: the caller pages
-    /// through leaves by `point_count` and would silently step over the gap,
-    /// and Android cannot lose a feature this way, so dropping one would also
-    /// make the two platforms disagree.
+    /// skipping it. A short list is worse than an error: the caller has no way
+    /// to tell that something is missing, a cluster caller paging through
+    /// leaves by `point_count` would silently step over the gap, and Android
+    /// cannot lose a feature this way, so dropping one would also make the two
+    /// platforms disagree on the same call.
     private func featuresReply(
         _ features: [MLNFeature],
         methodName: String

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -463,33 +463,65 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             }
             result(nil)
         case "map#queryRenderedFeatures":
-            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            guard let arguments = methodCall.arguments as? [String: Any] else {
+                result(FlutterError(
+                    code: "INVALID_ARGUMENT",
+                    message: "queryRenderedFeatures needs a map of arguments.",
+                    details: nil
+                ))
+                return
+            }
             var styleLayerIdentifiers: Set<String>?
             if let layerIds = arguments["layerIds"] as? [String], !layerIds.isEmpty {
                 styleLayerIdentifiers = Set<String>(layerIds)
             }
+            // queryRenderedFeatures sends the filter as a JSON array,
+            // queryRenderedFeaturesInRect as the same expression already
+            // encoded as a JSON string. Reading only one of the two shapes
+            // would drop the filter without telling the caller.
             var filterExpression: NSPredicate?
             if let filter = arguments["filter"] as? [Any] {
                 filterExpression = NSPredicate(mglJSONObject: filter)
+            } else if let filter = arguments["filter"] as? String,
+                      let data = filter.data(using: .utf8),
+                      let jsonFilter = try? JSONSerialization.jsonObject(
+                          with: data,
+                          options: .fragmentsAllowed
+                      ),
+                      !(jsonFilter is NSNull)
+            {
+                filterExpression = NSPredicate(mglJSONObject: jsonFilter)
             }
             var features: [MLNFeature] = []
+            // The Dart-side name of the call, for anything reported back.
+            var queryName = "queryRenderedFeatures"
             if let x = arguments["x"] as? Double, let y = arguments["y"] as? Double {
                 features = mapView.visibleFeatures(
                     at: CGPoint(x: x, y: y),
                     styleLayerIdentifiers: styleLayerIdentifiers,
                     predicate: filterExpression
                 )
-            }
-            if let top = arguments["top"] as? Double,
-               let bottom = arguments["bottom"] as? Double,
-               let left = arguments["left"] as? Double,
-               let right = arguments["right"] as? Double
+            } else if let top = arguments["top"] as? Double,
+                      let bottom = arguments["bottom"] as? Double,
+                      let left = arguments["left"] as? Double,
+                      let right = arguments["right"] as? Double
             {
-                var width = right - left
-                var height = bottom - top
+                queryName = "queryRenderedFeaturesInRect"
+                let width = right - left
+                let height = bottom - top
                 features = mapView.visibleFeatures(in: CGRect(x: left, y: top, width: width, height: height), styleLayerIdentifiers: styleLayerIdentifiers, predicate: filterExpression)
+            } else {
+                result(FlutterError(
+                    code: "INVALID_ARGUMENT",
+                    message: "queryRenderedFeatures needs either 'x' and 'y', or "
+                        + "'left', 'top', 'right' and 'bottom', as numbers. "
+                        + "Answering with an empty list would look like a query "
+                        + "that found nothing.",
+                    details: nil
+                ))
+                return
             }
-            result(featuresReply(features, methodName: "queryRenderedFeatures"))
+            result(featuresReply(features, methodName: queryName))
         case "map#setTelemetryEnabled":
             guard let arguments = methodCall.arguments as? [String: Any] else { return }
             let telemetryEnabled = arguments["enabled"] as? Bool
@@ -1329,8 +1361,16 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             result(nil)
 
         case "map#querySourceFeatures":
-            guard let arguments = methodCall.arguments as? [String: Any] else { return }
-            guard let sourceId = arguments["sourceId"] as? String else { return }
+            guard let arguments = methodCall.arguments as? [String: Any],
+                  let sourceId = arguments["sourceId"] as? String
+            else {
+                result(FlutterError(
+                    code: "INVALID_ARGUMENT",
+                    message: "querySourceFeatures needs a 'sourceId' string.",
+                    details: nil
+                ))
+                return
+            }
 
             var sourceLayerId = Set<String>()
             if let layerId = arguments["sourceLayerId"] as? String {
@@ -1343,7 +1383,10 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
 
             var features: [MLNFeature] = []
 
-            guard let style = mapView.style else { return }
+            guard let style = mapView.style else {
+                result(MethodCallError.styleNotFound.flutterError)
+                return
+            }
             if let source = style.source(withIdentifier: sourceId) {
                 if let vectorSource = source as? MLNVectorTileSource {
                     features = vectorSource.features(sourceLayerIdentifiers: sourceLayerId, predicate: filterExpression)
@@ -2388,24 +2431,32 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         methodName: String
     ) -> Any {
         var featuresJson = [String]()
-        for feature in features {
-            guard let data = try? JSONSerialization.data(
-                withJSONObject: feature.geoJSONDictionary(),
-                options: []
-            ),
-                let json = String(data: data, encoding: .utf8)
+        for (index, feature) in features.enumerated() {
+            let dictionary = feature.geoJSONDictionary()
+            // JSONSerialization raises an Objective-C exception, which Swift
+            // cannot catch, for an object it considers invalid: a non-finite
+            // coordinate, or an attribute of a type it does not write. Asking
+            // first is what turns that trap into the error below.
+            guard JSONSerialization.isValidJSONObject(dictionary),
+                  let json = jsonString(from: dictionary)
             else {
+                let identifier = feature.identifier ?? "none"
+                let details: String = "Feature at index \(index) of "
+                    + "\(features.count), id \(identifier), is not valid JSON: "
+                    + "it holds a non-finite number, or a value of a type JSON "
+                    + "cannot carry. The \(featuresJson.count) features before "
+                    + "it encoded fine."
                 return FlutterError(
                     code: "FEATURE_ENCODING_FAILED",
                     message: "\(methodName) could not encode one of the features "
                         + "it found as GeoJSON, so the result would have been "
                         + "incomplete without saying so.",
-                    details: nil
+                    details: details
                 )
             }
             featuresJson.append(json)
         }
-        return ["features": featuresJson as NSObject] as NSObject
+        return ["features": featuresJson]
     }
 
     func setFeature(sourceId: String, geojsonFeature: String) -> Result<Void, MethodCallError> {

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1730,6 +1730,10 @@ class MapLibreMapController extends ChangeNotifier {
   }
 
   /// Query rendered (i.e. visible) features at a point in screen coordinates
+  ///
+  /// On iOS this throws a [PlatformException] with code
+  /// `FEATURE_ENCODING_FAILED` if one of the features found cannot be encoded
+  /// as GeoJSON, rather than answering with a list that is silently short.
   Future<List> queryRenderedFeatures(
     Point<double> point,
     List<String> layerIds,
@@ -1743,6 +1747,10 @@ class MapLibreMapController extends ChangeNotifier {
   /// Unlike [queryRenderedFeatures], which takes the filter expression itself,
   /// [filter] is that expression encoded as a JSON string, for example
   /// `'["==", "type", "park"]'`.
+  ///
+  /// On iOS this throws a [PlatformException] with code
+  /// `FEATURE_ENCODING_FAILED` if one of the features found cannot be encoded
+  /// as GeoJSON, rather than answering with a list that is silently short.
   Future<List> queryRenderedFeaturesInRect(
     Rect rect,
     List<String> layerIds,
@@ -1761,6 +1769,10 @@ class MapLibreMapController extends ChangeNotifier {
   /// regardless of whether they are currently rendered by the current style.
   ///
   /// Note: On web, this will probably only work for GeoJson source, not for vector tiles
+  ///
+  /// On iOS this throws a [PlatformException] with code
+  /// `FEATURE_ENCODING_FAILED` if one of the features found cannot be encoded
+  /// as GeoJSON, rather than answering with a list that is silently short.
   Future<List> querySourceFeatures(
     String sourceId,
     String? sourceLayerId,


### PR DESCRIPTION
Closes #949.

`queryRenderedFeatures()` and `querySourceFeatures()` on iOS serialized each feature with `try?` and appended only on success, so a feature `JSONSerialization` rejected was skipped. The call still succeeded, answering with a shorter list and nothing to say a feature was missing. That is a wrong answer rather than a failure: code that counts the results, pages through them, or asserts a tap hit something gets a plausible but incorrect one.

Android was never affected. Its equivalent uses `feature.toJson()` for every feature and cannot lose one, so the same call behaved differently on the two platforms.

Both iOS call sites now go through one helper that reports the failure with a `FEATURE_ENCODING_FAILED` error instead of quietly shortening the list. The helper also removes the third copy of that serialization loop.

Found while reviewing #946, which introduced the same pattern in new code. It was fixed there before merge; this PR fixes the two places that already shipped with it.

## Verified

* `melos run format-all`, clean.
* `melos run analyze-all`, clean in all four plugin packages. The example reports one pre-existing `unnecessary_ignore` unrelated to this branch.

## Not verified

**The Swift has not been compiled.** The iOS build failed on a full disk before Swift compilation. The change is small and mechanical, the two call sites now call a helper that holds the code they already had, but it has not been through a compiler. Please build iOS before merging.

There is no runtime test either. Reproducing the original bug needs a feature whose attributes `JSONSerialization` rejects, which no fixture in the repo has today.

## Conflict note

#946 adds an identical `featuresReply` helper for its cluster calls. Whichever merges second will conflict on that function, and the resolution is to keep one copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
