### PR TITLE
Example app: make the demo style fallback work on every platform

### DIFF
--- a/maplibre_gl_example/lib/examples/layers/various_sources.dart
+++ b/maplibre_gl_example/lib/examples/layers/various_sources.dart
@@ -135,25 +135,28 @@ class FullMapState extends State<FullMap> {
   }
 
   static Future<void> addVector(MapLibreMapController controller) async {
+    // OpenMapTiles-schema vector tiles without an API key. The source id is
+    // namespaced: the OpenFreeMap fallback style has its own source called
+    // "openmaptiles", and adding a second source with that name throws.
     await controller.addSource(
-      "openmaptiles",
+      "example-vector-tiles",
       const VectorSourceProperties(
-        tiles: ['https://demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf'],
-        maxzoom: 14,
+        url: 'https://tiles.openfreemap.org/planet',
         attribution:
-            '<a href="https://maplibre.org">© MapLibre contributors</a',
+            '<a href="https://openfreemap.org">OpenFreeMap</a> '
+            '<a href="https://www.openmaptiles.org/">© OpenMapTiles</a>',
       ),
     );
 
     await controller.addLayer(
-      "openmaptiles",
+      "example-vector-tiles",
       "water-fill",
       const FillLayerProperties(fillColor: "#0080ff", fillOpacity: 0.5),
       sourceLayer: "water",
     );
 
     await controller.addLayer(
-      "openmaptiles",
+      "example-vector-tiles",
       "roads",
       const LineLayerProperties(
         lineColor: "#ff69b4",
@@ -434,70 +437,73 @@ class FullMapState extends State<FullMap> {
     );
   }
 
-  final _stylesAndLoaders = [
-    const StyleInfo(
+  // The base style goes through ExampleConstants.demoMapStyle so this page
+  // benefits from the startup fallback when demotiles.maplibre.org is
+  // rate-limited or unreachable, like every other example page.
+  late final _stylesAndLoaders = [
+    StyleInfo(
       name: "Vector",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addVector,
-      position: CameraPosition(target: LatLng(33.3832, -118.4333), zoom: 6),
+      position: const CameraPosition(
+        target: LatLng(33.3832, -118.4333),
+        zoom: 6,
+      ),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "Countries GeoJSON",
-      // Using the raw github file version of MapLibreStyles.DEMO here, because we need to
-      // specify a different baseStyle for consecutive elements in this list,
-      // otherwise the map will not update
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addCountries,
-      position: CameraPosition(target: LatLng(20, 0), zoom: 2),
+      position: const CameraPosition(target: LatLng(20, 0), zoom: 2),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "DEM Hillshade",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addDemHillshade,
-      position: CameraPosition(
+      position: const CameraPosition(
         target: LatLng(46.5, 8.0),
         zoom: 8,
         bearing: 80,
         tilt: 60,
       ),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "DEM Color Relief",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addDemColorRelief,
-      position: CameraPosition(target: LatLng(46.5, 8.0), zoom: 8),
+      position: const CameraPosition(target: LatLng(46.5, 8.0), zoom: 8),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "Geojson cluster",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addGeojsonCluster,
-      position: CameraPosition(target: LatLng(33.5, -118.1), zoom: 5),
+      position: const CameraPosition(target: LatLng(33.5, -118.1), zoom: 5),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "Raster",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addRaster,
-      position: CameraPosition(target: LatLng(40, -100), zoom: 3),
+      position: const CameraPosition(target: LatLng(40, -100), zoom: 3),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "Image",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addImage,
-      position: CameraPosition(target: LatLng(43, -75), zoom: 6),
+      position: const CameraPosition(target: LatLng(43, -75), zoom: 6),
     ),
-    const StyleInfo(
+    StyleInfo(
       name: "Heatmap",
-      baseStyle: MapLibreStyles.demo,
+      baseStyle: ExampleConstants.demoMapStyle,
       addDetails: addHeatMap,
-      position: CameraPosition(target: LatLng(33.5, -118.1), zoom: 2),
+      position: const CameraPosition(target: LatLng(33.5, -118.1), zoom: 2),
     ),
     //video only supported on web
     if (kIsWeb)
-      const StyleInfo(
+      StyleInfo(
         name: "Video",
-        baseStyle: MapLibreStyles.demo,
+        baseStyle: ExampleConstants.demoMapStyle,
         addDetails: addVideo,
-        position: CameraPosition(
+        position: const CameraPosition(
           target: LatLng(37.562984, -122.514426),
           zoom: 17,
           bearing: -96,
@@ -517,7 +523,13 @@ class FullMapState extends State<FullMap> {
   Future<void> _onStyleLoadedCallback() async {
     if (controller == null) return;
     final styleInfo = _stylesAndLoaders[selectedStyleId];
-    await styleInfo.addDetails(controller!);
+    try {
+      await styleInfo.addDetails(controller!);
+    } catch (error) {
+      // An example whose remote data is unreachable must not block the
+      // camera move or the switch to the next example.
+      debugPrint('VariousSources: "${styleInfo.name}" failed to load: $error');
+    }
     await controller!.animateCamera(
       CameraUpdate.newCameraPosition(styleInfo.position),
     );

--- a/maplibre_gl_example/lib/main.dart
+++ b/maplibre_gl_example/lib/main.dart
@@ -103,11 +103,13 @@ Future<void> main() async {
           : "debug"} mode',
     );
   } else {
-    // demotiles.maplibre.org rate-limits aggressively (HTTP 429); pick a
-    // reachable default style before the gallery builds any map.
     WidgetsFlutterBinding.ensureInitialized();
-    await ExampleConstants.resolveDemoMapStyle();
   }
+
+  // demotiles.maplibre.org rate-limits aggressively (HTTP 429); pick a
+  // reachable default style before the gallery builds any map, on every
+  // platform.
+  await ExampleConstants.resolveDemoMapStyle();
 
   runApp(const MapLibreExampleApp());
 }
@@ -223,14 +225,12 @@ class MapsDemo extends StatefulWidget {
 
 class _MapsDemoState extends State<MapsDemo> {
   Future<void> _pushPage(BuildContext context, ExamplePage page) async {
-    if (!kIsWeb) {
-      // Re-check right before the map loads: demotiles' limiter answers per
-      // request, so the startup probe can pass and the page's style request
-      // still get a 429 minutes later. A recent success skips the probe.
-      await ExampleConstants.resolveDemoMapStyle(
-        maxAge: const Duration(seconds: 30),
-      );
-    }
+    // Re-check right before the map loads: demotiles' limiter answers per
+    // request, so the startup probe can pass and the page's style request
+    // still get a 429 minutes later. A recent success skips the probe.
+    await ExampleConstants.resolveDemoMapStyle(
+      maxAge: const Duration(seconds: 30),
+    );
     if (!kIsWeb && page.needsLocationPermission) {
       final status = await Permission.locationWhenInUse.status;
       if (!status.isGranted) {

--- a/maplibre_gl_example/lib/main.dart
+++ b/maplibre_gl_example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -106,10 +108,13 @@ Future<void> main() async {
     WidgetsFlutterBinding.ensureInitialized();
   }
 
-  // demotiles.maplibre.org rate-limits aggressively (HTTP 429); pick a
-  // reachable default style before the gallery builds any map, on every
-  // platform.
-  await ExampleConstants.resolveDemoMapStyle();
+  // demotiles.maplibre.org rate-limits aggressively (HTTP 429); start the
+  // probe that picks a reachable default style here, but do not await it.
+  // The probe waits up to 4 seconds for a server that may be hanging, and
+  // web/index.html has an empty body, so awaiting it would leave the page
+  // blank for that long, on every embed, including the ones that show a map
+  // built from a local asset.
+  unawaited(ExampleConstants.resolveDemoMapStyle());
 
   runApp(const MapLibreExampleApp());
 }
@@ -119,6 +124,12 @@ class MapLibreExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final initialPage =
+        [
+          ..._allPages,
+          ..._docPages,
+        ].where((p) => p.slug == _initialExampleSlug()).firstOrNull;
+
     return MaterialApp(
       title: 'MapLibre Examples',
       debugShowCheckedModeBanner: false,
@@ -138,11 +149,36 @@ class MapLibreExampleApp extends StatelessWidget {
       ),
       themeMode: ThemeMode.system,
       home:
-          [
-            ..._allPages,
-            ..._docPages,
-          ].where((p) => p.slug == _initialExampleSlug()).firstOrNull ??
-          const MapsDemo(),
+          initialPage == null
+              ? const MapsDemo()
+              : _DemoStyleGate(page: initialPage),
+    );
+  }
+}
+
+/// Holds a directly opened example (`?example=<slug>`) back until the demo
+/// style probe has settled, because the page reads
+/// [ExampleConstants.demoMapStyle] while it builds. The gallery does not need
+/// this: it opens on a list of examples and awaits the same future when one
+/// of them is tapped.
+class _DemoStyleGate extends StatelessWidget {
+  const _DemoStyleGate({required this.page});
+
+  final ExamplePage page;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      // Always the same future, so a rebuild here never starts a new probe.
+      future: ExampleConstants.resolveDemoMapStyle(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return page;
+      },
     );
   }
 }
@@ -225,12 +261,11 @@ class MapsDemo extends StatefulWidget {
 
 class _MapsDemoState extends State<MapsDemo> {
   Future<void> _pushPage(BuildContext context, ExamplePage page) async {
-    // Re-check right before the map loads: demotiles' limiter answers per
-    // request, so the startup probe can pass and the page's style request
-    // still get a 429 minutes later. A recent success skips the probe.
-    await ExampleConstants.resolveDemoMapStyle(
-      maxAge: const Duration(seconds: 30),
-    );
+    // The page reads ExampleConstants.demoMapStyle while it builds, so wait
+    // for the probe started in main() to settle. Tapping a second example
+    // while it is still in flight awaits that same probe instead of putting
+    // a second burst of requests on the limiter.
+    await ExampleConstants.resolveDemoMapStyle();
     if (!kIsWeb && page.needsLocationPermission) {
       final status = await Permission.locationWhenInUse.status;
       if (!status.isGranted) {

--- a/maplibre_gl_example/lib/shared/constants.dart
+++ b/maplibre_gl_example/lib/shared/constants.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:maplibre_gl/maplibre_gl.dart';
 
 /// Common constants used across examples
@@ -129,13 +128,13 @@ class ExampleConstants {
       'https://demotiles.maplibre.org/tiles/0/0/0.pbf',
     ];
     const timeout = Duration(seconds: 4);
-    final client = HttpClient()..connectionTimeout = timeout;
+    // package:http works on every platform, web included, where a CORS or
+    // rate-limit failure surfaces as an exception and lands in the fallback.
+    final client = http.Client();
     try {
       final statuses = await Future.wait(
         probes.map((url) async {
-          final request = await client.getUrl(Uri.parse(url)).timeout(timeout);
-          final response = await request.close().timeout(timeout);
-          await response.drain<void>();
+          final response = await client.get(Uri.parse(url)).timeout(timeout);
           return response.statusCode;
         }),
       );
@@ -157,7 +156,7 @@ class ExampleConstants {
         'demo style unreachable ($error); falling back to $fallbackMapStyle',
       );
     } finally {
-      client.close(force: true);
+      client.close();
     }
   }
 

--- a/maplibre_gl_example/lib/shared/constants.dart
+++ b/maplibre_gl_example/lib/shared/constants.dart
@@ -62,8 +62,9 @@ class ExampleConstants {
 
   /// Demo map style URL (default). demotiles.maplibre.org is aggressively
   /// rate-limited (HTTP 429); [resolveDemoMapStyle] swaps in
-  /// [fallbackMapStyle] when it is unreachable (probed at startup and again
-  /// right before each example page opens).
+  /// [fallbackMapStyle] when it is unreachable. Await [resolveDemoMapStyle]
+  /// before reading this, otherwise you may read the value the probe is
+  /// about to replace.
   static String demoMapStyle = preferredDemoMapStyle;
 
   /// The canonical MapLibre demo style.
@@ -91,14 +92,9 @@ class ExampleConstants {
           ? const ['Open Sans Semibold']
           : const ['Noto Sans Bold'];
 
-  /// Sticky flag: once the demo style probe fails we stay on
-  /// [fallbackMapStyle] for the rest of the session (a limiter that just
-  /// rejected us will most likely reject the map's burst of requests too).
-  static bool _demoStyleFellBack = false;
-
-  /// When the last successful probe completed, for [resolveDemoMapStyle]'s
-  /// maxAge memoization.
-  static DateTime? _lastSuccessfulProbe;
+  /// The one style probe of this session, created by the first call to
+  /// [resolveDemoMapStyle]. Every later call awaits this same future.
+  static Future<void>? _resolution;
 
   /// Probes the demo style AND its tile endpoint, falling back to
   /// [fallbackMapStyle] when either fails. Probing the style alone is not
@@ -106,19 +102,18 @@ class ExampleConstants {
   /// the tile paths are already rate-limited with 429, which would render
   /// the style background with no tiles.
   ///
-  /// The rate limiter answers per request (429 with retry-after: 0), so a
-  /// probe that passed at startup proves nothing minutes later. Call this
-  /// again right before opening a map page, passing [maxAge] to skip the
-  /// network round-trip when a recent probe already succeeded. Once fallen
-  /// back the choice is sticky and this returns immediately.
-  static Future<void> resolveDemoMapStyle({Duration? maxAge}) async {
-    if (_demoStyleFellBack) return;
-    final lastSuccess = _lastSuccessfulProbe;
-    if (maxAge != null &&
-        lastSuccess != null &&
-        DateTime.now().difference(lastSuccess) < maxAge) {
-      return;
-    }
+  /// The probe runs at most once per session: the first caller starts it,
+  /// everyone else awaits the same future and gets the same answer, so the
+  /// resolved style is sticky and the app never puts a second burst on a
+  /// limiter that rejects bursts. Awaiting this is therefore cheap, and safe
+  /// to do from a widget that rebuilds.
+  ///
+  /// Start it early, but do not block the first frame on it: it can take
+  /// seconds when demotiles is unreachable.
+  static Future<void> resolveDemoMapStyle() =>
+      _resolution ??= _probeDemoMapStyle();
+
+  static Future<void> _probeDemoMapStyle() async {
     // Probe with a small CONCURRENT burst: the limiter tends to pass
     // isolated requests while rejecting bursts, and a real map load is a
     // burst of style + sprite + glyphs + tiles.
@@ -140,17 +135,13 @@ class ExampleConstants {
       );
       final failed = statuses.indexWhere((code) => code >= 400);
       if (failed != -1) {
-        _demoStyleFellBack = true;
         demoMapStyle = fallbackMapStyle;
         debugPrint(
           'demo style unreachable (${probes[failed]}: '
           'HTTP ${statuses[failed]}); falling back to $fallbackMapStyle',
         );
-        return;
       }
-      _lastSuccessfulProbe = DateTime.now();
     } catch (error) {
-      _demoStyleFellBack = true;
       demoMapStyle = fallbackMapStyle;
       debugPrint(
         'demo style unreachable ($error); falling back to $fallbackMapStyle',


### PR DESCRIPTION
## What this does

Example-app only, no package changes. demotiles.maplibre.org rate-limits aggressively and can be unreachable from some networks (429, or CORS-failing responses on web); the example app has a fallback to OpenFreeMap Liberty for exactly that case, but three things kept it from working:

- The startup probe used `dart:io`'s `HttpClient`, which cannot run on web, and both the startup probe and the per-page re-check were skipped on web anyway. The probe now uses `package:http` (already a dependency) and runs on every platform; a CORS or rate-limit failure surfaces as an exception and lands in the same fallback.
- **Various Sources** hardcoded the demo style instead of going through the resolved one, so it never benefited from the fallback.
- The Vector example added a source named `openmaptiles`, which collides with the source of the same name inside the OpenFreeMap Liberty fallback style (the add throws and kills the page's style-loaded callback). It is renamed and pointed at OpenFreeMap's vector tiles, whose OpenMapTiles schema serves the same `water` and `transportation` layers.
- One example whose remote data is unreachable no longer blocks the camera move or the switch to the next example: the add is wrapped and logged.

## Validation

- `dart analyze`: clean (the one info is pre-existing on the base branch).
- Verified live in the browser: with demotiles blocked, the pages fall back to Liberty and the DEM examples render.

## Note for merging

Independent of the #957..#960 stack. `various_sources.dart` will conflict trivially with #958 (which adds a DEM Color Relief entry to the same list): whichever merges second re-adds the entry in the resolved-style format.

## Review follow-ups

Applied after the review on this branch:

- The probe no longer gates the first frame. It was awaited before `runApp`, and the example's `web/index.html` has an empty body, so an unreachable demo server left a blank page for the whole timeout, once per iframe on a docs site that embeds this app about nineteen times. The app starts first now, and the deep-linked route shows a spinner on the shared future instead of nothing.
- Concurrent callers share one probe. `_pushPage` had no in-flight guard, so a second tap started a second burst against a limiter that rejects bursts, and the resulting 429 flipped the session to the fallback even when the demo server was fine. `resolveDemoMapStyle()` is now one lazily started future for the session.
- Consequence worth knowing: the thirty second re-probe is gone with it, so a session that starts on the demo style stays there even if the limiter starts rejecting later. On web that re-probe was inert anyway, since the browser cache served it from `max-age=600`.
