### PR TITLE
Docsite: open the homepage and the globe guide with a live turning globe

### DIFF
--- a/maplibre_gl_example/lib/examples/docs/doc_globe.dart
+++ b/maplibre_gl_example/lib/examples/docs/doc_globe.dart
@@ -71,6 +71,9 @@ class _DocGlobeBodyState extends State<_DocGlobeBody> {
     await controller.setProjection('globe');
     // Defaults for the sky colors; the halo is what matters here.
     await controller.setSky(const SkyProperties(atmosphereBlend: 1));
+    // Two platform round trips happened above; without this a widget disposed
+    // meanwhile would still install a timer that nothing ever cancels.
+    if (!mounted) return;
     _spinTimer ??= Timer.periodic(_tick, (_) {
       _longitude += _spinStep;
       if (_longitude > 180) _longitude -= 360;

--- a/maplibre_gl_example/lib/examples/docs/doc_globe.dart
+++ b/maplibre_gl_example/lib/examples/docs/doc_globe.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+import '../../page.dart';
+import '../../shared/shared.dart';
+
+/// Documentation hero demo: a slowly turning globe with its atmosphere.
+///
+/// Purely ambient, so every gesture is disabled: it sits at the top of the
+/// globe guide and of the docsite homepage as a living picture, not as a
+/// playground. The background colour matches the documentation site, so the
+/// globe floats on the page instead of sitting in a differently coloured box.
+///
+/// Two query parameters tune it per embed:
+/// `bg` (hex, no hash) overrides the background colour, and `stars=0` hides
+/// the star field; the homepage uses both to blend with either site theme.
+class DocGlobeExample extends ExamplePage {
+  const DocGlobeExample({super.key})
+    : super(
+        const Icon(Icons.public),
+        'Doc Globe',
+        category: ExampleCategory.advanced,
+        needsLocationPermission: false,
+      );
+
+  @override
+  Widget build(BuildContext context) => const _DocGlobeBody();
+}
+
+class _DocGlobeBody extends StatefulWidget {
+  const _DocGlobeBody();
+
+  @override
+  State<_DocGlobeBody> createState() => _DocGlobeBodyState();
+}
+
+class _DocGlobeBodyState extends State<_DocGlobeBody> {
+  /// --md-default-bg-color of the docsite's dark scheme.
+  static const _docsiteBackground = Color(0xFF0D1420);
+
+  /// Degrees of longitude per tick; one revolution takes about 75 seconds.
+  static const _spinStep = 0.24;
+  static const _tick = Duration(milliseconds: 50);
+
+  late final bool _stars;
+  late final Color _background;
+
+  MapLibreMapController? _controller;
+  Timer? _spinTimer;
+  double _longitude = 10;
+
+  @override
+  void initState() {
+    super.initState();
+    final params = Uri.base.queryParameters;
+    _stars = params['stars'] != '0' && params['stars'] != 'false';
+    final bg = int.tryParse(params['bg'] ?? '', radix: 16);
+    _background = bg == null ? _docsiteBackground : Color(0xFF000000 | bg);
+  }
+
+  void _onMapCreated(MapLibreMapController controller) {
+    _controller = controller;
+  }
+
+  Future<void> _onStyleLoaded() async {
+    final controller = _controller;
+    if (controller == null) return;
+    await controller.setProjection('globe');
+    // Defaults for the sky colors; the halo is what matters here.
+    await controller.setSky(const SkyProperties(atmosphereBlend: 1));
+    _spinTimer ??= Timer.periodic(_tick, (_) {
+      _longitude += _spinStep;
+      if (_longitude > 180) _longitude -= 360;
+      unawaited(
+        _controller?.moveCamera(CameraUpdate.newLatLng(LatLng(18, _longitude))),
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _spinTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _background,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          // The map canvas is transparent around the globe, so the star
+          // field painted underneath shows through as the night sky.
+          if (_stars) CustomPaint(painter: _StarFieldPainter(_background)),
+          MapLibreMap(
+            // Pinned to OpenFreeMap Liberty rather than the resolved demo
+            // style: a hero image should look the same on every visit.
+            styleString: ExampleConstants.fallbackMapStyle,
+            onMapCreated: _onMapCreated,
+            onStyleLoadedCallback: _onStyleLoaded,
+            initialCameraPosition: const CameraPosition(
+              target: LatLng(18, 10),
+              zoom: 2.1,
+            ),
+            scrollGesturesEnabled: false,
+            zoomGesturesEnabled: false,
+            rotateGesturesEnabled: false,
+            tiltGesturesEnabled: false,
+            dragEnabled: false,
+            doubleClickZoomEnabled: false,
+            compassEnabled: false,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A deterministic star field on the docsite's dark background.
+class _StarFieldPainter extends CustomPainter {
+  const _StarFieldPainter(this.background);
+
+  final Color background;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawRect(Offset.zero & size, Paint()..color = background);
+    // Seeded, so the sky does not twinkle on rebuilds.
+    final random = Random(7);
+    final star = Paint();
+    for (var i = 0; i < 220; i++) {
+      final brightness = 0.25 + random.nextDouble() * 0.65;
+      star.color = Colors.white.withValues(alpha: brightness);
+      canvas.drawCircle(
+        Offset(
+          random.nextDouble() * size.width,
+          random.nextDouble() * size.height,
+        ),
+        0.4 + random.nextDouble() * 0.9,
+        star,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _StarFieldPainter oldDelegate) => false;
+}

--- a/maplibre_gl_example/lib/main.dart
+++ b/maplibre_gl_example/lib/main.dart
@@ -71,6 +71,7 @@ import 'examples/docs/doc_geojson_source.dart';
 import 'examples/docs/doc_pmtiles.dart';
 import 'examples/docs/doc_heatmap.dart';
 import 'examples/docs/doc_expressions.dart';
+import 'examples/docs/doc_globe.dart';
 
 String? _initialExampleSlug() {
   if (!kIsWeb) return null;
@@ -210,6 +211,7 @@ final List<ExamplePage> _docPages = [
   const DocPMTilesExample(),
   const DocHeatmapExample(),
   const DocExpressionsExample(),
+  const DocGlobeExample(),
 ];
 
 class MapsDemo extends StatefulWidget {

--- a/website/docs/advanced/globe-terrain-sky.md
+++ b/website/docs/advanced/globe-terrain-sky.md
@@ -1,5 +1,14 @@
 # Globe, Terrain and Sky
 
+<iframe
+  class="example-iframe"
+  src="/flutter-maplibre-gl/demo/?example=doc-globe"
+  title="Globe projection"
+  loading="lazy"
+></iframe>
+
+The globe projection with its atmosphere, made of two calls: `setProjection('globe')` and `setSky()`.
+
 !!! note "Platform support"
     The projection, terrain and sky style root objects are **web only**. On Android and iOS `setProjection`, `setTerrain` and `setSky` throw an `UnsupportedError`, because MapLibre Native renders the mercator projection on a flat map and implements neither 3D terrain nor the sky yet. `setLight`, at the bottom of this page, works everywhere.
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -9,11 +9,6 @@ hide:
   <h1>MapLibre, natively in Flutter</h1>
   <p class="hero__tagline">Any tile provider or your own server, the full MapLibre style spec, and no API key to get started. One Dart API across Android, iOS, and web.</p>
   <div class="badge-row">
-    <span class="platform-badge platform-badge--android">Android</span>
-    <span class="platform-badge platform-badge--ios">iOS</span>
-    <span class="platform-badge platform-badge--web">Web</span>
-  </div>
-  <div class="badge-row">
     <a href="https://pub.dev/packages/maplibre_gl"><img src="https://img.shields.io/pub/v/maplibre_gl.svg?style=flat-square" alt="pub.dev version" /></a>
     <a href="https://github.com/maplibre/flutter-maplibre-gl"><img src="https://img.shields.io/github/stars/maplibre/flutter-maplibre-gl?style=flat-square&logo=github" alt="GitHub Stars" /></a>
     <a href="https://github.com/maplibre/flutter-maplibre-gl/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSD--3-blue?style=flat-square" alt="License" /></a>
@@ -26,9 +21,15 @@ hide:
 </div>
 
 <iframe
-  class="example-iframe"
-  src="/flutter-maplibre-gl/demo/?example=doc-full-map"
-  title="flutter-maplibre-gl live preview"
+  class="hero-globe hero-globe--light"
+  src="/flutter-maplibre-gl/demo/?example=doc-globe&stars=0&bg=ffffff"
+  title="The globe projection, live"
+  loading="lazy"
+></iframe>
+<iframe
+  class="hero-globe hero-globe--dark"
+  src="/flutter-maplibre-gl/demo/?example=doc-globe&stars=0&bg=0d1420"
+  title="The globe projection, live"
   loading="lazy"
 ></iframe>
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -21,17 +21,36 @@ hide:
 </div>
 
 <iframe
-  class="hero-globe hero-globe--light"
-  src="/flutter-maplibre-gl/demo/?example=doc-globe&stars=0&bg=ffffff"
+  class="hero-globe"
+  id="hero-globe"
   title="The globe projection, live"
   loading="lazy"
 ></iframe>
-<iframe
-  class="hero-globe hero-globe--dark"
-  src="/flutter-maplibre-gl/demo/?example=doc-globe&stars=0&bg=0d1420"
-  title="The globe projection, live"
-  loading="lazy"
-></iframe>
+<script>
+  // One iframe, pointed at the background that matches the active scheme.
+  // Shipping two and hiding one with CSS would boot the demo app twice on
+  // every visit: a hidden iframe is excluded from lazy loading, so both
+  // would download and run a Flutter engine each.
+  (function () {
+    var frame = document.getElementById("hero-globe");
+    var base = "/flutter-maplibre-gl/demo/?example=doc-globe&stars=0&bg=";
+    var current = null;
+    function apply() {
+      var next =
+        document.body.getAttribute("data-md-color-scheme") === "slate"
+          ? "0d1420"
+          : "ffffff";
+      if (next === current) return;
+      current = next;
+      frame.src = base + next;
+    }
+    apply();
+    new MutationObserver(apply).observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-md-color-scheme"],
+    });
+  })();
+</script>
 
 <div class="section-label">Why this library</div>
 

--- a/website/docs/stylesheets/extra.css
+++ b/website/docs/stylesheets/extra.css
@@ -672,6 +672,28 @@ body, .md-typeset {
   box-shadow: 0 6px 28px rgba(0, 0, 0, 0.4);
 }
 
+/* The homepage globe: frameless, so the demo's background (passed via its
+   `bg` query parameter, one iframe per color scheme) blends into the page
+   and the globe floats on it. */
+.hero-globe {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  max-height: 560px;
+  border: 0;
+  margin: 1.6rem 0 2rem;
+  display: block;
+  background: transparent;
+}
+.hero-globe--dark {
+  display: none;
+}
+[data-md-color-scheme="slate"] .hero-globe--light {
+  display: none;
+}
+[data-md-color-scheme="slate"] .hero-globe--dark {
+  display: block;
+}
+
 /* Two live examples side by side, for comparison pages. At half the 46rem
    content column each frame is only ~360px wide, so the default 3/2 ratio
    would leave a 240px-tall strip of map: square keeps it usable. Collapses
@@ -1070,35 +1092,6 @@ body, .md-typeset {
   align-items: center;
   margin-bottom: 0.9rem;
 }
-.platform-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.28rem 0.8rem;
-  border-radius: 100px;
-  font-size: 0.74rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  border: 1px solid transparent;
-}
-.platform-badge--android {
-  background: rgba(22, 163, 74, 0.10);
-  color: #15803d;
-  border-color: rgba(22, 163, 74, 0.22);
-}
-.platform-badge--ios {
-  background: rgba(100, 116, 139, 0.10);
-  color: var(--md-default-fg-color--light);
-  border-color: rgba(100, 116, 139, 0.20);
-}
-.platform-badge--web {
-  background: var(--ml-blue-soft);
-  color: var(--ml-blue);
-  border-color: rgba(31, 111, 235, 0.22);
-}
-[data-md-color-scheme="slate"] .platform-badge--android { color: #4ade80; }
-[data-md-color-scheme="slate"] .platform-badge--web { color: var(--ml-blue); }
-
 .badge-row img { height: 1.3rem; }
 
 /* CTA buttons */

--- a/website/docs/stylesheets/extra.css
+++ b/website/docs/stylesheets/extra.css
@@ -673,7 +673,7 @@ body, .md-typeset {
 }
 
 /* The homepage globe: frameless, so the demo's background (passed via its
-   `bg` query parameter, one iframe per color scheme) blends into the page
+   `bg` query parameter, set from the active scheme) blends into the page
    and the globe floats on it. */
 .hero-globe {
   width: 100%;
@@ -683,15 +683,6 @@ body, .md-typeset {
   margin: 1.6rem 0 2rem;
   display: block;
   background: transparent;
-}
-.hero-globe--dark {
-  display: none;
-}
-[data-md-color-scheme="slate"] .hero-globe--light {
-  display: none;
-}
-[data-md-color-scheme="slate"] .hero-globe--dark {
-  display: block;
 }
 
 /* Two live examples side by side, for comparison pages. At half the 46rem


### PR DESCRIPTION
## What this does

Docsite and example-app demo only, no package changes.

- A new `doc-globe` hero demo: the globe projection with its atmosphere, slowly turning (one revolution in about 75 seconds), every gesture disabled since it is a living picture, pinned to the OpenFreeMap Liberty style for a consistent look. Two query parameters tune it per embed: `bg` (hex) sets the colour behind the globe and `stars=0` hides the painted star field.
- **Homepage**: the flat `doc-full-map` iframe is replaced by the globe, frameless, with one iframe per colour scheme (`bg=ffffff` and `bg=0d1420`, no stars) swapped by CSS on `data-md-color-scheme`, so the globe floats directly on the page background in both themes. The three Android/iOS/Web badge chips under the tagline are removed, along with their now-dead CSS.
- **Globe guide**: gets the scenic version at the top, dark with the star field and the atmosphere halo.

## Validation

- `dart analyze --fatal-warnings --fatal-infos`: clean.
- `mkdocs build` passes and the built homepage carries both hero iframes.
- Verified live in the browser: light variant floats on white without stars, default keeps stars and halo, rotation runs, and the terrarium DEM terrain and atmosphere work end to end.

## Review follow-ups

Applied after the review on this branch:

- The homepage shipped two hero iframes and hid one with CSS. A hidden iframe is excluded from lazy loading, so both downloaded and ran a Flutter engine plus a GL JS instance on every visit to the landing page. There is one iframe now, pointed at the background of the active scheme and repointed when the reader toggles it.
- The example installed its spin timer after two awaits without rechecking `mounted`, so a widget disposed in between left a timer firing every 50 ms against a disposed controller with nothing holding a handle to cancel it.
