### PR TITLE
fix: forward sourceLayer when adding a heatmap layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Fixed
+* **Android/iOS**: `addHeatmapLayer` now forwards `sourceLayer` to the platform side. It was accepted by the Dart API but never included in the `heatmapLayer#add` method-channel arguments, so a heatmap layer over a vector tile source was left with no `source-layer` and rendered nothing. `source-layer` is required for vector tile sources; GeoJSON-backed heatmap layers were unaffected, which is why this went unnoticed.
+
 ## [0.26.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.0...v0.26.1)
 
 > **Note:** Several users reported crashes on a range of Android devices after upgrading to 0.26.0, particularly on older / less recent hardware. These issues are addressed in 0.26.1 (see the Android fixes below).

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -772,6 +772,7 @@ final class MapLibreMapController
   private boolean addHeatmapLayer(
       String layerName,
       String sourceName,
+      String sourceLayer,
       Float minZoom,
       Float maxZoom,
       String belowLayerId,
@@ -783,6 +784,9 @@ final class MapLibreMapController
     }
     HeatmapLayer layer = new HeatmapLayer(layerName, sourceName);
     layer.setProperties(properties);
+    if (sourceLayer != null) {
+      layer.setSourceLayer(sourceLayer);
+    }
     if (minZoom != null) {
       layer.setMinZoom(minZoom);
     }
@@ -1576,6 +1580,7 @@ final class MapLibreMapController
           final String sourceId = call.argument("sourceId");
           final String layerId = call.argument("layerId");
           final String belowLayerId = call.argument("belowLayerId");
+          final String sourceLayer = call.argument("sourceLayer");
           final Double minzoom = call.argument("minzoom");
           final Double maxzoom = call.argument("maxzoom");
           final PropertyValue[] properties =
@@ -1583,6 +1588,7 @@ final class MapLibreMapController
           if (!addHeatmapLayer(
               layerId,
               sourceId,
+              sourceLayer,
               minzoom != null ? minzoom.floatValue() : null,
               maxzoom != null ? maxzoom.floatValue() : null,
               belowLayerId,

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -746,12 +746,14 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
             guard let layerId = arguments["layerId"] as? String else { return }
             guard let properties = arguments["properties"] as? [String: Any] else { return }
             let belowLayerId = arguments["belowLayerId"] as? String
+            let sourceLayer = arguments["sourceLayer"] as? String
             let minzoom = arguments["minzoom"] as? Double
             let maxzoom = arguments["maxzoom"] as? Double
             let addResult = addHeatmapLayer(
                 sourceId: sourceId,
                 layerId: layerId,
                 belowLayerId: belowLayerId,
+                sourceLayerIdentifier: sourceLayer,
                 minimumZoomLevel: minzoom,
                 maximumZoomLevel: maxzoom,
                 properties: properties
@@ -1821,6 +1823,7 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         sourceId: String,
         layerId: String,
         belowLayerId: String?,
+        sourceLayerIdentifier: String?,
         minimumZoomLevel: Double?,
         maximumZoomLevel: Double?,
         properties: [String: Any]
@@ -1834,6 +1837,9 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 heatmapLayer: layer,
                 properties: properties
             )
+            if let sourceLayerIdentifier = sourceLayerIdentifier {
+                layer.sourceLayerIdentifier = sourceLayerIdentifier
+            }
             if let minimumZoomLevel = minimumZoomLevel {
                 layer.minimumZoomLevel = Float(minimumZoomLevel)
             }

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -989,6 +989,7 @@ class MapLibreMethodChannel extends MapLibrePlatform {
       'sourceId': sourceId,
       'layerId': layerId,
       'belowLayerId': belowLayerId,
+      'sourceLayer': sourceLayer,
       'minzoom': minzoom,
       'maxzoom': maxzoom,
       'properties': properties,

--- a/maplibre_gl_platform_interface/test/method_channel_layer_test.dart
+++ b/maplibre_gl_platform_interface/test/method_channel_layer_test.dart
@@ -107,6 +107,29 @@ void main() {
       expect(methodCalls[0].method, 'heatmapLayer#add');
     });
 
+    test('addHeatmapLayer forwards sourceLayer', () async {
+      // source-layer is required for vector tile sources, so dropping it here
+      // leaves the layer bound to no source layer and rendering nothing.
+      await platform.addHeatmapLayer(
+        'heat-source',
+        'heatmap-layer',
+        {'heatmap-radius': 30},
+        sourceLayer: 'default',
+        belowLayerId: 'below-layer',
+        minzoom: 5,
+        maxzoom: 15,
+      );
+
+      final args = methodCalls[0].arguments as Map;
+      expect(args['sourceId'], 'heat-source');
+      expect(args['layerId'], 'heatmap-layer');
+      expect(args['sourceLayer'], 'default');
+      expect(args['belowLayerId'], 'below-layer');
+      expect(args['minzoom'], 5.0);
+      expect(args['maxzoom'], 15.0);
+      expect((args['properties'] as Map)['heatmap-radius'], 30);
+    });
+
     test('addLayer sends correct method', () async {
       await platform.addLayer('image-layer', 'image-source', 5, 15);
 


### PR DESCRIPTION
## Problem

`addHeatmapLayer` accepts a `sourceLayer` argument, but it is never included in the `heatmapLayer#add` method-channel arguments, and neither platform handler sets a source layer on the created layer.

Per the style spec, `source-layer` is *"Required for vector tile sources; prohibited for all other source types, including GeoJSON sources."* So a heatmap layer over a vector tile source ends up bound to no source layer and renders nothing. There is no error — the layer is created successfully and simply stays empty.

GeoJSON-backed heatmap layers are unaffected (`source-layer` is prohibited there), which is likely why this went unnoticed — the heatmap docs example is GeoJSON-based. The web implementation already forwards `sourceLayer` correctly; only the method-channel path drops it.

## Fix

Mirrors what the other five layer types already do in the same files:

- `method_channel_maplibre_gl.dart` — include `'sourceLayer'` in the arguments map
- Android — read the argument and call `layer.setSourceLayer(...)`
- iOS — accept `sourceLayerIdentifier` and set `layer.sourceLayerIdentifier`

## Tests

The existing `addHeatmapLayer sends correct method` test asserted only the method name and never inspected the arguments — every other layer type's test checks them, which is why this slipped through. Extended it to assert the full argument map.

Verified by reverting the one-line Dart change: the new test fails with `sourceLayer` → `Actual: <null>`, and passes with it.

Both platforms compiled against a real app (Android `assembleDevDebug`, iOS device + simulator builds).