### PR TITLE
docs(readme): give the screenshots a width so the columns match

### DIFF
--- a/maplibre_gl/README.md
+++ b/maplibre_gl/README.md
@@ -28,11 +28,11 @@
 
 | **3D buildings** | **Clustering** | **Globe, on web** |
 |:---:|:---:|:---:|
-| ![Midtown Manhattan with the camera pitched and rotated](https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/buildings-3d.webp) | ![GeoJSON points clustered with live counts](https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/cluster.webp) | ![globe projection rendered by MapLibre GL JS](https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/globe.webp) |
+| <img src="https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/buildings-3d.webp" width="270" alt="Midtown Manhattan with the camera pitched and rotated"> | <img src="https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/cluster.webp" width="270" alt="GeoJSON points clustered with live counts"> | <img src="https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/globe.webp" width="270" alt="globe projection rendered by MapLibre GL JS"> |
 
 | **Data-driven styling** | **Heatmaps** | **Annotations** |
 |:---:|:---:|:---:|
-| ![countries coloured and faded by their own properties](https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/expressions.webp) | ![point density drawn on the GPU](https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/heatmap.webp) | ![symbol markers with custom icons and labels](https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/annotations.webp) |
+| <img src="https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/expressions.webp" width="270" alt="countries coloured and faded by their own properties"> | <img src="https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/heatmap.webp" width="270" alt="point density drawn on the GPU"> | <img src="https://raw.githubusercontent.com/maplibre/flutter-maplibre-gl/main/maplibre_gl/screenshots/annotations.webp" width="270" alt="symbol markers with custom icons and labels"> |
 
 All of these are live in the [demo](https://maplibre.org/flutter-maplibre-gl/demo/), and every [guide](https://maplibre.org/flutter-maplibre-gl/) embeds an interactive map you can pan and click.
 


### PR DESCRIPTION
The screenshot table renders with uneven columns: `Globe, on web` is visibly smaller than its neighbours, and `Heatmaps` is smaller than the two next to it.

It is not the images. All six are 1280x720.

Markdown image syntax carries no width, and the images only get `max-width: 100%`, so they shrink freely and have no say in how wide their column is. With `table-layout: auto` the width falls to the header text, specifically its longest unbreakable word. `Globe, on web` breaks into `Globe,` / `on` / `web`, six characters, against `buildings` and `Clustering`. Same story in the second row, where `Heatmaps` is the shortest.

The order of the rendered widths matches the order of those words in both rows.

Giving each image an explicit `width` fixes it: the columns come out equal, and `max-width: 100%` still shrinks the images below that on narrow viewports. The header block of this README already uses sized `<img>` tags, so the syntax is known to render on both GitHub and pub.dev. Alt text is unchanged.