### PR TITLE
fix(android): apply KGP when AGP does not compile Kotlin itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+* **Android**: 0.27.0 failed to configure with `Could not find method kotlin()` on AGP 9 whenever the app has `android.builtInKotlin=false`, which the Flutter template writes into every app created with 3.44 or later. The plugin took AGP 9 to mean AGP compiles Kotlin itself, but with that flag off nothing did, so the build only got through with `android.builtInKotlin=true` added by hand. The plugin now applies the Kotlin Gradle Plugin whenever AGP has not taken Kotlin over, so the workaround can be dropped (#1008).
+
+### Docs
+* The [minimum versions](https://maplibre.org/flutter-maplibre-gl/getting-started/#minimum-versions) table names the JDK requirement: the Android build targets Java 21, so JDK 17 fails with `invalid source release: 21` (#1018).
+
 ## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
 
 The plugin has a **documentation site** now, at [**maplibre.org/flutter-maplibre-gl**](https://maplibre.org/flutter-maplibre-gl/): a guide for every part of the API, each with a live map you can pan and click.

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Fixed
+* **Android**: 0.27.0 failed to configure with `Could not find method kotlin()` on AGP 9 whenever the app has `android.builtInKotlin=false`, which the Flutter template writes into every app created with 3.44 or later. The plugin took AGP 9 to mean AGP compiles Kotlin itself, but with that flag off nothing did, so the build only got through with `android.builtInKotlin=true` added by hand. The plugin now applies the Kotlin Gradle Plugin whenever AGP has not taken Kotlin over, so the workaround can be dropped (#1008).
+
+### Docs
+* The [minimum versions](https://maplibre.org/flutter-maplibre-gl/getting-started/#minimum-versions) table names the JDK requirement: the Android build targets Java 21, so JDK 17 fails with `invalid source release: 21` (#1018).
+
 ## [0.27.0](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.26.2...v0.27.0)
 
 The plugin has a **documentation site** now, at [**maplibre.org/flutter-maplibre-gl**](https://maplibre.org/flutter-maplibre-gl/): a guide for every part of the API, each with a live map you can pan and click.

--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -23,15 +23,13 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-// Flutter is moving Kotlin compilation into AGP itself. From AGP 9 a plugin that
-// applies the Kotlin Gradle Plugin breaks the host app's build, and Flutter already
-// warns about it today (#905). Applying KGP only below AGP 9 keeps this plugin
-// working on both, without forcing the package minimum to Flutter 3.44, which the
-// unconditional migration would require. Drop the condition, and apply nothing,
-// once that floor is normal for us.
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
-    apply plugin: 'kotlin-android'
+// Who compiles our Kotlin depends on the app: from AGP 9 the Android Gradle plugin does, but
+// only where built-in Kotlin is on, and the Flutter template turns it off (#905, #1008, #1018).
+// Flutter 3.44 and later then apply KGP for us, though not always before this script runs. So
+// apply it only when no Kotlin extension exists yet, through pluginManager, which keeps Flutter's
+// scan for KGP-applying plugins from naming the package.
+if (project.extensions.findByName('kotlin') == null) {
+    project.pluginManager.apply('kotlin-android')
 }
 
 android {
@@ -72,8 +70,8 @@ android {
 }
 
 // Set through the Kotlin extension rather than android.kotlinOptions, which AGP 9
-// removes. The extension is present whether KGP was applied above or AGP provides
-// Kotlin itself.
+// removes. The extension is there either way: AGP registered it, or the block above
+// applied KGP because AGP had not.
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -209,5 +209,6 @@ Future<void> main() async {
 | Flutter  | 3.29.0 |
 | Dart     | 3.7.0 |
 | Android  | API 21 (Android 5.0) |
+| JDK      | 21, to build the Android side |
 | iOS      | iOS 13 |
 | Web      | WebGL2, see [Requirements](#requirements) |


### PR DESCRIPTION
Closes #1008. Closes #1018.

0.27.0 fails to configure on AGP 9 for anyone whose app carries `android.builtInKotlin=false`, which is what the Flutter template writes into every app created with 3.44 or later:

```
* Where:
Build file '.../maplibre_gl-0.27.0/android/build.gradle' line: 77
> Could not find method kotlin() for arguments [...] on project ':maplibre_gl'
```

### Root cause

#914 applied KGP only below AGP 9, taking AGP 9 to mean "AGP compiles Kotlin". AGP only does that where built-in Kotlin is on. There are three states, not two, and `android.builtInKotlin=false` is the third: AGP does not compile Kotlin, we did not apply KGP, so nobody registers the `kotlin` extension and line 77 has nothing to configure.

### What this does

Asks who owns Kotlin compilation instead of inferring it from a version number:

```groovy
if (project.extensions.findByName('kotlin') == null) {
    project.pluginManager.apply('kotlin-android')
}
```

Two details worth calling out:

* **Why not read the flag.** AGP 9.3 already warns that `android.builtInKotlin=false` is deprecated and removed in AGP 10. Code that reads the flag would, once it becomes a no-op, apply KGP alongside AGP's own Kotlin compilation, which is the `Storage ... is already registered` failure reported in #1018. Asking whether the extension exists is the same question one step closer to the truth, and self-corrects when the flag goes.
* **Why `pluginManager`.** Flutter's "plugins that apply KGP" warning comes from a regex scan of the build script (`FlutterPluginUtils.detectApplyingKotlinGradlePlugin`), so with `apply plugin:` it names the package even in apps where the branch never runs, as #1018 observed. Through `pluginManager` we stay out of that list, and Flutter's own fallback applies KGP for us where it can. #905 stays closed either way: where AGP owns Kotlin, this applies nothing.

### Verified

Configuration plus a real `compileDebugKotlin` of this module, bytecode target 65 (Java 21):

| AGP | `builtInKotlin` | Who compiles Kotlin | |
|---|---|---|---|
| 8.13.2 | unset / false | KGP | pass |
| 9.0.1, 9.1.0, 9.3.1, 9.4.0 | false | KGP | pass, was the failure |
| 9.0.1, 9.3.1 | true | AGP built-in | pass |
| 9.3.1 | unset (default true) | AGP built-in | pass |

Tested with KGP 2.3.20 and 2.4.10, Gradle 9.5.1 and 9.6.1, JDK 21. `flutter build apk` of the example app still passes on its current AGP 8.13.2.

In a stock `flutter create` 3.47 app the module now behaves exactly like a plugin generated from Flutter's own migrated template: Flutter's fallback applies KGP before the script is evaluated, we apply nothing, and the package is absent from the KGP warning list.

### Not in this PR

* **The full built-in Kotlin migration.** Dropping KGP outright, as the [plugin-author guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) asks, raises the floor from Flutter 3.29 to 3.44 and leans entirely on Flutter's fallback. That fallback works in a stock app but never fires in this repo's own example app, where the Kotlin sources then go silently uncompiled until javac fails on the missing classes. Worth understanding before we depend on it, so it stays a separate change.
* **CI coverage for this class of bug.** A config-only job over an AGP and flag matrix would have caught it and costs seconds per leg. Bumping the example app to AGP 9 would not: it currently fails in `file_picker`, which carries a verbatim copy of the same AGP-major heuristic and silently ships no `FilePickerPlugin`.

Docs: the minimum versions table now names JDK 21, which cost a reporter in #1018 a second, separate build failure on JDK 17.