### PR TITLE
fix(offline): accept int coordinates from the iOS JSON payload

### DIFF
--- a/maplibre_gl/lib/src/offline_region.dart
+++ b/maplibre_gl/lib/src/offline_region.dart
@@ -36,17 +36,23 @@ class OfflineRegionDefinition {
       bounds: _latLngBoundsFromList(map['bounds']),
       mapStyleUrl: map['mapStyleUrl'],
       // small integers may deserialize to Int
-      minZoom: map['minZoom'].toDouble(),
-      maxZoom: map['maxZoom'].toDouble(),
+      minZoom: (map['minZoom'] as num).toDouble(),
+      maxZoom: (map['maxZoom'] as num).toDouble(),
       includeIdeographs: map['includeIdeographs'] ?? false,
     );
   }
 
   static LatLngBounds _latLngBoundsFromList(List<dynamic> json) {
+    // The iOS side hands these back as a JSON string, and JSON has no way to
+    // tell 60.0 apart from 60: whole-degree coordinates arrive here as int.
     return LatLngBounds(
-      southwest: LatLng(json[0][0], json[0][1]),
-      northeast: LatLng(json[1][0], json[1][1]),
+      southwest: _latLngFromList(json[0]),
+      northeast: _latLngFromList(json[1]),
     );
+  }
+
+  static LatLng _latLngFromList(List<dynamic> json) {
+    return LatLng((json[0] as num).toDouble(), (json[1] as num).toDouble());
   }
 }
 
@@ -64,8 +70,10 @@ class OfflineRegion {
 
   factory OfflineRegion.fromMap(Map<String, dynamic> json) {
     return OfflineRegion(
-      id: json['id'],
-      definition: OfflineRegionDefinition.fromMap(json['definition']),
+      id: (json['id'] as num).toInt(),
+      definition: OfflineRegionDefinition.fromMap(
+        Map<String, dynamic>.from(json['definition'] as Map),
+      ),
       // Offline databases created by external tools (e.g. maplibre-native's
       // offline.cpp) may have no metadata, in which case the native layer
       // returns null. Default to an empty map instead of throwing.

--- a/maplibre_gl/test/offline_region_test.dart
+++ b/maplibre_gl/test/offline_region_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -82,6 +84,24 @@ void main() {
       expect(def.maxZoom, 15.0);
     });
 
+    test('fromMap handles integer bounds', () {
+      // iOS returns regions as a JSON string, and JSON cannot tell 60.0 apart
+      // from 60, so whole-degree coordinates arrive as int. See issue #241.
+      final map = <String, dynamic>{
+        'bounds': [
+          [60, -4.5],
+          [61, 9],
+        ],
+        'mapStyleUrl': 'https://example.com/style.json',
+        'minZoom': 5.0,
+        'maxZoom': 15.0,
+        'includeIdeographs': false,
+      };
+      final def = OfflineRegionDefinition.fromMap(map);
+      expect(def.bounds.southwest, const LatLng(60.0, -4.5));
+      expect(def.bounds.northeast, const LatLng(61.0, 9.0));
+    });
+
     test('toString', () {
       final def = OfflineRegionDefinition(
         bounds: bounds,
@@ -113,6 +133,22 @@ void main() {
       final region = OfflineRegion.fromMap(map);
       expect(region.id, 42);
       expect(region.definition.mapStyleUrl, 'https://example.com/style.json');
+      expect(region.metadata['name'], 'Test Region');
+    });
+
+    test('fromMap parses an iOS JSON payload with whole-number values', () {
+      // Exactly what MLNOfflineStorage's packs serialize to on iOS when the
+      // region happens to sit on whole degrees and zoom levels. See #241.
+      const iosJson =
+          '{"id":42,"metadata":{"name":"Test Region"},"definition":{"bounds":[[60,-4.5],[61,9]],"mapStyleUrl":"https://example.com/style.json","minZoom":0,"maxZoom":10}}';
+      final region = OfflineRegion.fromMap(
+        json.decode(iosJson) as Map<String, dynamic>,
+      );
+      expect(region.id, 42);
+      expect(region.definition.bounds.southwest, const LatLng(60.0, -4.5));
+      expect(region.definition.bounds.northeast, const LatLng(61.0, 9.0));
+      expect(region.definition.minZoom, 0.0);
+      expect(region.definition.maxZoom, 10.0);
       expect(region.metadata['name'], 'Test Region');
     });
 

--- a/maplibre_gl_platform_interface/lib/src/location.dart
+++ b/maplibre_gl_platform_interface/lib/src/location.dart
@@ -41,7 +41,10 @@ class LatLng {
     return <double>[longitude, latitude];
   }
 
-  LatLng._fromJson(List<dynamic> json) : this(json[0], json[1]);
+  /// Values that cross a JSON boundary lose their `double` type when they
+  /// have no fractional part (60.0 is written as `60`), so accept any [num].
+  LatLng._fromJson(List<dynamic> json)
+    : this((json[0] as num).toDouble(), (json[1] as num).toDouble());
 
   @override
   String toString() => 'LatLng($latitude, $longitude)';

--- a/maplibre_gl_platform_interface/test/location_test.dart
+++ b/maplibre_gl_platform_interface/test/location_test.dart
@@ -148,6 +148,16 @@ void main() {
       expect(LatLngBounds.fromList(null), isNull);
     });
 
+    test('fromList accepts ints for whole-degree coordinates', () {
+      // JSON has no way to tell 60.0 apart from 60. See issue #241.
+      final bounds = LatLngBounds.fromList([
+        [60, -4.5],
+        [61, 9],
+      ]);
+      expect(bounds!.southwest, const LatLng(60.0, -4.5));
+      expect(bounds.northeast, const LatLng(61.0, 9.0));
+    });
+
     test('contains returns true for point inside', () {
       final bounds = LatLngBounds(
         southwest: const LatLng(10.0, 20.0),


### PR DESCRIPTION
Fixes #241.

## The bug

On iOS, `getListOfRegions`, `mergeOfflineRegions` and `downloadOfflineRegion` throw for any region whose bounds sit on whole degrees:

```
type 'int' is not a subtype of type 'double'
package:maplibre_gl/src/offline_region.dart 47:32  _latLngBoundsFromList
```

iOS returns regions as a JSON **string** (`OfflineManagerUtils.regionsList`), and `JSONSerialization` writes the Double `60.0` as `60`. `json.decode` then hands back an `int`, which `_latLngBoundsFromList` passed straight into `LatLng(double, double)`.

That is why the report only reproduces for some regions. As [noted in the issue](https://github.com/maplibre/flutter-maplibre-gl/issues/241#issuecomment-2984634928):

```dart
LatLngBounds(southwest: LatLng(60.0, -4.5), northeast: LatLng(61.0, 9.0))    // throws
LatLngBounds(southwest: LatLng(60.123, -4.5), northeast: LatLng(61.123, 9.1)) // fine
```

A region only had to be listable if *every* coordinate carried a fractional part.

## The fix

- `offline_region.dart` parses bounds through a small `_latLngFromList` helper that coerces via `as num`. `minZoom`/`maxZoom`/`id` are hardened the same way; the zoom fields used a `dynamic.toDouble()` call that happened to work but would blow up on anything non-numeric.
- `LatLng._fromJson` in the platform interface carried the identical defect. It backs `LatLngBounds.fromList`, `LatLngQuad.fromList` and `CameraPosition.fromMap`, so fixing it there closes the same hole on every JSON path rather than only this one.

I deliberately did not change the Swift side: `JSONSerialization` gives no way to force a trailing `.0`, and Android's Gson already emits `60.0`, so a tolerant parse in Dart is the fix that covers both platforms.

## Tests

Three regression tests, including one that parses a verbatim iOS payload end to end:

```dart
const iosJson = '{"id":42,...,"bounds":[[60,-4.5],[61,9]],"minZoom":0,"maxZoom":10}}';
final region = OfflineRegion.fromMap(json.decode(iosJson) as Map<String, dynamic>);
expect(region.definition.bounds.southwest, const LatLng(60.0, -4.5));
```

Each one fails on `main` with the reported error and passes here. Full suites green (`maplibre_gl` 226, `maplibre_gl_platform_interface` 302) and `flutter analyze` clean.