### PR TITLE
test(android): cover the AGP and built-in Kotlin combinations in CI, and correct the docs

### DIFF
--- a/.github/gradle-compat/.gitignore
+++ b/.github/gradle-compat/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/.github/gradle-compat/README.md
+++ b/.github/gradle-compat/README.md
@@ -1,0 +1,35 @@
+# Android Gradle compatibility check
+
+Who compiles the Kotlin in `maplibre_gl/android` depends on the host app, not on this repository:
+
+| App configuration | Kotlin compiled by |
+|---|---|
+| AGP 8 | the Kotlin Gradle Plugin, applied by the module |
+| AGP 9, built-in Kotlin enabled (its default) | AGP itself |
+| AGP 9, `android.builtInKotlin=false` (what the Flutter template writes from 3.44 on) | KGP again, applied by the module or by Flutter's fallback |
+
+0.27.0 shipped a version of that logic where the third row had nobody compiling its Kotlin, and no
+build in this repository noticed, because the example app pins one AGP version (#1008, #1018).
+
+This standalone Gradle build configures the module on its own and asserts which side owns the
+compilation, so every combination is covered without an app, a Flutter SDK, or a full build. It is
+run by the `android-gradle-compat` job in `.github/workflows/flutter_ci.yml`.
+
+## Running it locally
+
+Needs JDK 21, an Android SDK, and a Gradle matching the AGP under test: AGP 8 wants Gradle 9.5 at
+the latest, since Gradle 9.6 removed an internal API it relies on, and AGP 9.4 wants 9.6 or newer.
+
+```sh
+cd .github/gradle-compat
+
+# AGP 9 with built-in Kotlin off: the case that broke in 0.27.0
+gradle :maplibre_gl:help -PagpVersion=9.0.1 -PkgpVersion=2.3.20 \
+    -Pandroid.builtInKotlin=false -Pandroid.newDsl=false -PexpectKotlinOwner=kgp
+
+# AGP 9 as it comes out of the box, compiling Kotlin itself
+gradle :maplibre_gl:help -PagpVersion=9.3.1 -PexpectKotlinOwner=agp
+```
+
+Leave `-PexpectKotlinOwner` out to print what happens instead of asserting it. Every run reports a
+line like `gradle-compat: agp=9.3.1 builtInKotlin=false owner=kgp compileDebugKotlin=true`.

--- a/.github/gradle-compat/build.gradle
+++ b/.github/gradle-compat/build.gradle
@@ -1,0 +1,39 @@
+// AGP and KGP come from the root script classpath, the way an app's root build.gradle provides
+// them. Parent-first class loading then makes the versions under test win over the pins in the
+// module's own buildscript block, which is what happens in a real app too.
+buildscript {
+    def agpVersion = project.hasProperty('agpVersion') ? project.agpVersion : '8.13.2'
+    def kgpVersion = project.hasProperty('kgpVersion') ? project.kgpVersion : '2.4.10'
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "com.android.tools.build:gradle:$agpVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kgpVersion"
+    }
+}
+
+// Configuring is not the whole check: 0.27.0 configured fine wherever built-in Kotlin was on, and
+// left the module with nothing to compile its Kotlin where it was off (#1008, #1018). So assert
+// which side ended up owning Kotlin, and that a Kotlin compile task exists at all.
+gradle.projectsEvaluated {
+    def module = project(':maplibre_gl')
+    def kgpApplied = module.pluginManager.hasPlugin('org.jetbrains.kotlin.android')
+    def owner = kgpApplied ? 'kgp' : (module.extensions.findByName('kotlin') != null ? 'agp' : 'none')
+    def compileTask = module.tasks.findByName('compileDebugKotlin')
+
+    println "gradle-compat: agp=${com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION} " +
+        "builtInKotlin=${providers.gradleProperty('android.builtInKotlin').getOrElse('unset')} " +
+        "owner=${owner} compileDebugKotlin=${compileTask != null}"
+
+    def expected = project.findProperty('expectKotlinOwner')
+    if (expected != null && owner != expected) {
+        throw new GradleException("Kotlin compilation owner is '$owner', expected '$expected'")
+    }
+    if (compileTask == null) {
+        throw new GradleException("No compileDebugKotlin task: the module would ship no Kotlin classes")
+    }
+}

--- a/.github/gradle-compat/settings.gradle
+++ b/.github/gradle-compat/settings.gradle
@@ -1,0 +1,7 @@
+// Standalone Gradle build that configures only the plugin's android/ module, so CI can check who
+// compiles its Kotlin across AGP versions and built-in Kotlin settings without building an app.
+// See README.md in this directory.
+rootProject.name = 'gradle-compat'
+
+include ':maplibre_gl'
+project(':maplibre_gl').projectDir = file('../../maplibre_gl/android')

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -45,6 +45,7 @@ jobs:
               - 'scripts/**'
               - 'pubspec.yaml'
               - '.github/workflows/**'
+              - '.github/gradle-compat/**'
             docs:
               - 'website/**'
               - 'maplibre_gl_example/lib/examples/docs/**'
@@ -152,6 +153,67 @@ jobs:
     uses: ./.github/workflows/_build.yml
     with:
       platform: android
+
+  # Who compiles the Android module's Kotlin depends on the app: AGP itself, the Kotlin Gradle
+  # Plugin the module applies, or Flutter's fallback. The example app pins one AGP version, so it
+  # exercises exactly one of those, and 0.27.0 shipped a combination where none of them did
+  # (#1008, #1018). This configures the module standalone across the combinations and asserts
+  # which side ends up owning the compilation. Configuration only: seconds per leg, no Flutter SDK.
+  # See .github/gradle-compat/README.md.
+  android-gradle-compat:
+    name: "Android Gradle compat (AGP ${{ matrix.agp }}, built-in Kotlin ${{ matrix.built-in-kotlin }})"
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Gradle 9.6 removed an internal API AGP 8 relies on, so AGP 8 pairs with 9.5 at the latest.
+          - agp: '8.13.2'
+            gradle: '9.5.1'
+            kgp: '2.4.10'
+            built-in-kotlin: 'none'
+            props: ''
+            owner: 'kgp'
+          # What the Flutter template and its migrator write from 3.44 on, and the versions from #1018.
+          - agp: '9.0.1'
+            gradle: '9.5.1'
+            kgp: '2.3.20'
+            built-in-kotlin: 'off'
+            props: '-Pandroid.builtInKotlin=false -Pandroid.newDsl=false'
+            owner: 'kgp'
+          # AGP 9 out of the box, compiling Kotlin itself.
+          - agp: '9.3.1'
+            gradle: '9.5.1'
+            kgp: '2.4.10'
+            built-in-kotlin: 'default'
+            props: ''
+            owner: 'agp'
+          # The AGP and Gradle pair dependabot is proposing for the example app.
+          - agp: '9.4.0'
+            gradle: '9.7.1'
+            kgp: '2.4.10'
+            built-in-kotlin: 'off'
+            props: '-Pandroid.builtInKotlin=false -Pandroid.newDsl=false'
+            owner: 'kgp'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ matrix.gradle }}
+      - name: Configure the Android module
+        working-directory: .github/gradle-compat
+        run: >
+          gradle :maplibre_gl:help
+          -PagpVersion=${{ matrix.agp }}
+          -PkgpVersion=${{ matrix.kgp }}
+          -PexpectKotlinOwner=${{ matrix.owner }}
+          ${{ matrix.props }}
 
   build-ios:
     name: "Build iOS package"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## Unreleased
 
 ### Fixed
-* **Android**: 0.27.0 failed to configure with `Could not find method kotlin()` on AGP 9 whenever the app has `android.builtInKotlin=false`, which the Flutter template writes into every app created with 3.44 or later. The plugin took AGP 9 to mean AGP compiles Kotlin itself, but with that flag off nothing did, so the build only got through with `android.builtInKotlin=true` added by hand. The plugin now applies the Kotlin Gradle Plugin whenever AGP has not taken Kotlin over, so the workaround can be dropped (#1008).
+* **Android**: 0.27.0 failed to configure with `Could not find method kotlin()` on AGP 9 whenever the app has `android.builtInKotlin=false`, which Flutter 3.44 and later write into new apps through the template and into existing ones through a migrator. The plugin took AGP 9 to mean AGP compiles Kotlin itself, but with that flag off nothing did, so the build only got through with `android.builtInKotlin=true` added by hand. The plugin now applies the Kotlin Gradle Plugin whenever AGP has not taken Kotlin over, so the workaround can be dropped (#1008).
+* **iOS**: `getListOfRegions`, `mergeOfflineRegions` and `downloadOfflineRegion` threw `type 'int' is not a subtype of type 'double'` for any region whose bounds sat on whole degrees, such as `LatLng(60.0, -4.5)` to `LatLng(61.0, 9.0)`. iOS returns regions as JSON, where `60.0` is written `60` and reads back as an `int`, so only regions with a fractional part in every coordinate could be listed. Coordinates and zoom levels now accept either form (#241).
 
 ### Docs
 * The [minimum versions](https://maplibre.org/flutter-maplibre-gl/getting-started/#minimum-versions) table names the JDK requirement: the Android build targets Java 21, so JDK 17 fails with `invalid source release: 21` (#1018).

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 ### Fixed
-* **Android**: 0.27.0 failed to configure with `Could not find method kotlin()` on AGP 9 whenever the app has `android.builtInKotlin=false`, which the Flutter template writes into every app created with 3.44 or later. The plugin took AGP 9 to mean AGP compiles Kotlin itself, but with that flag off nothing did, so the build only got through with `android.builtInKotlin=true` added by hand. The plugin now applies the Kotlin Gradle Plugin whenever AGP has not taken Kotlin over, so the workaround can be dropped (#1008).
+* **Android**: 0.27.0 failed to configure with `Could not find method kotlin()` on AGP 9 whenever the app has `android.builtInKotlin=false`, which Flutter 3.44 and later write into new apps through the template and into existing ones through a migrator. The plugin took AGP 9 to mean AGP compiles Kotlin itself, but with that flag off nothing did, so the build only got through with `android.builtInKotlin=true` added by hand. The plugin now applies the Kotlin Gradle Plugin whenever AGP has not taken Kotlin over, so the workaround can be dropped (#1008).
+* **iOS**: `getListOfRegions`, `mergeOfflineRegions` and `downloadOfflineRegion` threw `type 'int' is not a subtype of type 'double'` for any region whose bounds sat on whole degrees, such as `LatLng(60.0, -4.5)` to `LatLng(61.0, 9.0)`. iOS returns regions as JSON, where `60.0` is written `60` and reads back as an `int`, so only regions with a fractional part in every coordinate could be listed. Coordinates and zoom levels now accept either form (#241).
 
 ### Docs
 * The [minimum versions](https://maplibre.org/flutter-maplibre-gl/getting-started/#minimum-versions) table names the JDK requirement: the Android build targets Java 21, so JDK 17 fails with `invalid source release: 21` (#1018).

--- a/maplibre_gl/README.md
+++ b/maplibre_gl/README.md
@@ -55,7 +55,7 @@ MapLibreMap(
 );
 ```
 
-**Requires** Flutter 3.29+ · Dart 3.7+ · Android 5.0 (API 21)+ · iOS 13+ · a browser with WebGL2 (Safari 15+).
+**Requires** Flutter 3.29+ · Dart 3.7+ · JDK 21 for Android builds · Android 5.0 (API 21)+ · iOS 13+ · a browser with WebGL2 (Safari 15+).
 
 Then head to the [getting started guide](https://maplibre.org/flutter-maplibre-gl/getting-started/) for platform setup (location permissions on iOS/Android; web needs no `index.html` changes) and to learn how to add markers, layers, offline tiles and more.
 

--- a/maplibre_gl/android/build.gradle
+++ b/maplibre_gl/android/build.gradle
@@ -26,8 +26,11 @@ apply plugin: 'com.android.library'
 // Who compiles our Kotlin depends on the app: from AGP 9 the Android Gradle plugin does, but
 // only where built-in Kotlin is on, and the Flutter template turns it off (#905, #1008, #1018).
 // Flutter 3.44 and later then apply KGP for us, though not always before this script runs. So
-// apply it only when no Kotlin extension exists yet, through pluginManager, which keeps Flutter's
-// scan for KGP-applying plugins from naming the package.
+// apply it only when no Kotlin extension exists yet. pluginManager is the same call as
+// `apply plugin:` at runtime, but Flutter's warning about KGP-applying plugins is a regex over
+// this file that matches only the `apply plugin:` form, so writing it this way keeps the package
+// out of a warning that is wrong wherever this branch does not run, and leaves Flutter's own
+// fallback free to apply KGP first.
 if (project.extensions.findByName('kotlin') == null) {
     project.pluginManager.apply('kotlin-android')
 }
@@ -69,9 +72,9 @@ android {
     }
 }
 
-// Set through the Kotlin extension rather than android.kotlinOptions, which AGP 9
-// removes. The extension is there either way: AGP registered it, or the block above
-// applied KGP because AGP had not.
+// Set through the Kotlin extension rather than android.kotlinOptions, which AGP 9 removes. The
+// extension is there whichever way Kotlin arrived: AGP registered it, Flutter applied KGP before
+// this script ran, or the block above applied KGP because neither had.
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -209,6 +209,8 @@ Future<void> main() async {
 | Flutter  | 3.29.0 |
 | Dart     | 3.7.0 |
 | Android  | API 21 (Android 5.0) |
-| JDK      | 21, to build the Android side |
 | iOS      | iOS 13 |
 | Web      | WebGL2, see [Requirements](#requirements) |
+| JDK      | 21 |
+
+The JDK version is for building: the Android side targets Java 21, so JDK 17 fails with `invalid source release: 21`.

--- a/website/docs/migration.md
+++ b/website/docs/migration.md
@@ -75,7 +75,9 @@ None of these need a code change, but they are the places where code that worked
 
 ### Android apps on AGP 9
 
-The plugin no longer applies the Kotlin Gradle Plugin when your app builds with Android Gradle Plugin 9 or later, which is what broke that build before. Apps on AGP 8 are unaffected and need no change.
+Nothing to do, on AGP 8 or AGP 9. The plugin applies the Kotlin Gradle Plugin only where nothing else compiles its Kotlin: on AGP 9 with built-in Kotlin enabled, AGP's own default, it applies nothing and AGP compiles it; where built-in Kotlin is disabled, which is what Flutter 3.44 and later write into `android/gradle.properties` as `android.builtInKotlin=false`, it applies KGP itself.
+
+0.27.0 got that wrong and failed to configure with `Could not find method kotlin()` on AGP 9 whenever built-in Kotlin was disabled. It is fixed in 0.27.1. If you worked around it by setting `android.builtInKotlin=true`, or by applying `kotlin-android` to the module from your root `android/build.gradle`, remove the workaround: on a multi-plugin app the flag puts every other KGP-applying plugin into a conflicting configuration.
 
 ## Upgrading from earlier 0.26 releases
 


### PR DESCRIPTION
Follow-ups to #1020, from reviewing it after the merge. No behaviour change: one CI job, one fixture, and corrections to text that #1020 left saying the wrong thing.

### CI coverage

Who compiles the Android module's Kotlin is decided by the app, not by this repository:

| App configuration | Kotlin compiled by |
|---|---|
| AGP 8 | KGP, applied by the module |
| AGP 9, built-in Kotlin on (AGP's default) | AGP itself |
| AGP 9, `android.builtInKotlin=false` (what Flutter 3.44+ writes) | KGP again, applied by the module or by Flutter's fallback |

The example app pins one AGP version, so CI only ever exercised the first row. That is exactly how #1008 shipped: the third row had nobody compiling the Kotlin, and every job stayed green.

`.github/gradle-compat` is a standalone Gradle build that includes only `maplibre_gl/android`, takes the AGP and KGP versions as properties, and asserts which side ended up owning the compilation:

```
gradle-compat: agp=9.0.1 builtInKotlin=false owner=kgp compileDebugKotlin=true
```

Asserting the owner rather than just "it configured" is the point: 0.27.0 configured perfectly wherever built-in Kotlin was on. The new job runs four legs, seconds each, no Flutter SDK and no Android build:

| AGP | Gradle | KGP | `builtInKotlin` | Expected owner |
|---|---|---|---|---|
| 8.13.2 | 9.5.1 | 2.4.10 | none | KGP |
| 9.0.1 | 9.5.1 | 2.3.20 | off | KGP |
| 9.3.1 | 9.5.1 | 2.4.10 | default | AGP |
| 9.4.0 | 9.7.1 | 2.4.10 | off | KGP |

All four verified locally, along with the negative case (a wrong `expectKotlinOwner` fails the build).

### One thing this turned up for the pending dependabot PRs

The AGP and Gradle pairings above are forced. **AGP 8 cannot run on Gradle 9.6 or newer**:

```
Plugin 'com.android.internal.library' relies on 'org.gradle.api.problems.internal.InternalProblems',
a Gradle internal API that was removed in Gradle 9.6.0. [...] or use Gradle 9.5.
```

So #1000 (wrapper to 9.7.1) and #1016 (example to AGP 9.4.0) are mergeable only together: the wrapper alone breaks AGP 8.13.2, and AGP 9.4.0 alone will not start on Gradle 9.5.1. Worth noting that #1016 also needs `file_picker` first, which carries a verbatim copy of the AGP-major heuristic this fixed and therefore ships no `FilePickerPlugin` on AGP 9.

### Docs and comments #1020 left wrong

* **`website/docs/migration.md`** still said the plugin "no longer applies the Kotlin Gradle Plugin when your app builds with AGP 9 or later", the opposite of the shipped behaviour, and contradicted the new changelog entry. Rewritten around the three cases, with the removal of the `android.builtInKotlin=true` workaround spelled out: on a multi-plugin app that flag puts every other KGP-applying plugin into a conflicting configuration, as reported in #1018.
* **`maplibre_gl/README.md`** carries the other statement of the minimums, and it is what pub.dev shows first. It was missing the JDK 21 requirement that `getting-started.md` gained.
* **Changelogs** said the flag arrives in apps "created with 3.44 or later", which misses the migrator that writes it into existing apps on upgrade, the more common way to meet this bug.
* **Minimum versions table** had a row reading `21, to build the Android side` in a column of bare versions, wedged between the platform rows. JDK moves below them, rationale in prose.
* **Two comments in `android/build.gradle`.** One implied `pluginManager.apply` differs from `apply plugin:` at runtime; it does not, the difference is only that Flutter's warning is a regex over this file, and the comment now says so. The other offered two possible owners of the Kotlin extension where the same diff had just introduced a third.