### PR TITLE
chore(example): move the Android build to AGP 9.4 and Gradle 9.7

### DIFF
--- a/maplibre_gl_example/android/app/build.gradle
+++ b/maplibre_gl_example/android/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    // No Kotlin Gradle Plugin here, as of the Flutter 3.44 app template: AGP compiles Kotlin
+    // where built-in Kotlin is on, and Flutter applies KGP itself where it is off.
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -34,10 +35,6 @@ android {
         targetCompatibility JavaVersion.VERSION_21
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -60,4 +57,11 @@ android {
 
 flutter {
     source '../..'
+}
+
+// The Java and Kotlin targets have to agree, and android.kotlinOptions is gone in AGP 9.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+    }
 }

--- a/maplibre_gl_example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/maplibre_gl_example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/maplibre_gl_example/android/settings.gradle
+++ b/maplibre_gl_example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.13.2" apply false
+    id "com.android.application" version "9.4.0" apply false
     id "org.jetbrains.kotlin.android" version "2.4.10" apply false
 }
 

--- a/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
+++ b/maplibre_gl_example/lib/examples/advanced/offline_regions.dart
@@ -621,7 +621,7 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
         // which carries the sidecars too. The DB is tens of MB, so this loads it
         // into memory once, fine for an example.
         final bytes = await File(exported).readAsBytes();
-        final savedPath = await FilePicker.saveFile(
+        final savedTo = await FilePicker.saveFile(
           dialogTitle: 'Save offline database',
           fileName: 'offline_regions_export.db',
           bytes: bytes,
@@ -630,7 +630,7 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              savedPath == null ? 'Save cancelled' : 'Saved to $savedPath',
+              savedTo == null ? 'Save cancelled' : 'Saved to $savedTo',
             ),
           ),
         );
@@ -661,7 +661,7 @@ class _OfflineRegionsBodyState extends State<_OfflineRegionBody> {
       // back to `any` rather than risk hiding valid files behind a filter.
       type: FileType.any,
     );
-    final path = picked?.files.singleOrNull?.path;
+    final path = picked.singleOrNull?.path;
     if (path == null) return; // user cancelled
 
     try {

--- a/maplibre_gl_example/pubspec.yaml
+++ b/maplibre_gl_example/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  file_picker: ^11.0.2
+  file_picker: ^12.2.0
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1
@@ -26,7 +26,7 @@ dependencies:
   # flutter >=3.24.0. On anything older the Gradle build fails on an unresolved
   # `compilerOptions`. Lift this once the example itself targets that baseline.
   permission_handler: ^12.0.0
-  share_plus: ^12.0.1
+  share_plus: ^13.3.0
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.3


### PR DESCRIPTION
Supersedes #1016. Pairs with the wrapper bump in #1000's sibling for the example, which cannot land on its own, see below.

The example pinned AGP 8.13.2, the one configuration where "who compiles the plugin's Kotlin" has a single answer. That is why #1008 shipped: on AGP 9 with the flag the Flutter template writes, the answer is different, and nothing in this repository ever built that. #1023 covers it at configuration level; this covers it as a real app.

### What moves

* **AGP 8.13.2 to 9.4.0**, and the wrapper **Gradle 9.5.1 to 9.7.1**, because AGP 9.4 requires Gradle 9.6 or newer. The two are a package deal in the other direction as well: AGP 8 cannot run on Gradle 9.6+, which removed an internal API it relies on, so #1000-style wrapper bumps break the build unless AGP moves at the same time.
* **The app module drops the Kotlin Gradle Plugin**, matching the Flutter 3.44 template: Flutter applies KGP itself where built-in Kotlin is off, AGP compiles Kotlin where it is on. `jvmTarget` moves from `android.kotlinOptions`, which AGP 9 removed, to the Kotlin extension, staying at 21 to match `compileOptions`.
* **`android.builtInKotlin=false` and `android.newDsl=false` stay** as they are. They are what a real Flutter app carries today, so leaving them is the point of the exercise, not an oversight.

### Why file_picker had to move too

`file_picker` 11.x carries the same bug this repo just fixed:

```groovy
def isAgp9OrAbove = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger() >= 9
apply plugin: 'com.android.library'
if (!isAgp9OrAbove) {
    apply plugin: 'org.jetbrains.kotlin.android'
}
```

With `android.builtInKotlin=false` its Kotlin never compiles, and unlike our case it fails silently: no configuration error, just `GeneratedPluginRegistrant.java: cannot find symbol FilePickerPlugin` at javac. That was the actual blocker for #1016.

`file_picker` 12.2.0 is federated, and its Android implementation (`android_file_picker`) reads both the AGP version and `android.builtInKotlin`, so it works either way. It pulls two consequences: `share_plus` to 13.3.0, because file_picker 12 wants win32 6 while share_plus 12 pinned win32 5, and two API changes in the offline regions example, `pickFiles` returning a list instead of a result object and `saveFile` returning a `Uri` instead of a path.

### Verified

`flutter analyze` clean, `flutter build apk --debug` green on Flutter 3.47 with JDK 21, and the app installed and run on a Pixel 8 emulator (API 34): the map renders with tiles and labels, and logcat shows no `NoClassDefFoundError`, which is the failure mode when a plugin's Kotlin quietly does not compile.


### Unrelated, found while doing this

`path_provider_foundation` 2.6.0 replaced its plugin implementation with direct FFI calls and ships no `Package.swift`, so the Flutter tool falls back to CocoaPods for iOS and regenerates `maplibre_gl_example/ios/Podfile` on any `flutter pub get`. That happens on `main` as it stands, with or without this PR, and undoes the SPM-only setup from #891. Not touched here; worth its own issue.
