### PR TITLE
docs: follow up on the local sprites and glyphs guide

### DIFF
--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -2432,7 +2432,7 @@ class MapLibreMapController extends ChangeNotifier {
   /// 1. Passing the URL of the map style. This should be a custom map style served remotely using a URL that start with 'http(s)://'
   /// 2. Passing the style as a local asset. Create a JSON file in the `assets` and add a reference in `pubspec.yml`. Set the style string to the relative path for this asset in order to load it into the map.
   /// 3. Passing the style as a local file. create an JSON file in app directory (e.g. ApplicationDocumentsDirectory). Set the style string to the absolute path of this JSON file.
-  /// 4. Passing the raw JSON of the map style. This is only supported on Android.
+  /// 4. Passing the raw JSON of the map style.
   Future<void> setStyle(String styleString) async {
     return _maplibrePlatform.setStyle(styleString);
   }

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -514,7 +514,7 @@ abstract class MapLibrePlatform {
   /// 1. Passing the URL of the map style. This should be a custom map style served remotely using a URL that start with 'http(s)://'
   /// 2. Passing the style as a local asset. Create a JSON file in the `assets` and add a reference in `pubspec.yml`. Set the style string to the relative path for this asset in order to load it into the map.
   /// 3. Passing the style as a local file. create a JSON file in app directory (e.g. ApplicationDocumentsDirectory). Set the style string to the absolute path of this JSON file.
-  /// 4. Passing the raw JSON of the map style. This is only supported on Android.
+  /// 4. Passing the raw JSON of the map style.
   Future<void> setStyle(String styleString);
 
   @mustCallSuper

--- a/website/docs/concepts/styles.md
+++ b/website/docs/concepts/styles.md
@@ -205,8 +205,17 @@ MapLibreMap(
 
 Passing the JSON directly as `styleString` works too, see [Raw JSON string](#raw-json-string).
 
-!!! warning "`styleString` takes a path, not a `file://` URL"
-    `file://` belongs in the `sprite` and `glyphs` fields, which the native engines fetch themselves. The style document is resolved by the plugin instead: give it the absolute path. A `file://` prefix there is treated as a Flutter asset key on both platforms, and the map stays blank without throwing.
+!!! warning "What goes in `styleString`, and what does not"
+    `file://` belongs in `sprite` and `glyphs`, which the native engines fetch themselves. The style document is resolved by the plugin, and it takes exactly four forms:
+
+    | Where your style is | What to pass |
+    | ------------------- | ------------ |
+    | A file on disk | its absolute path: `'$cache/style.json'` |
+    | Your Flutter assets | its asset key: `'assets/my_style.json'` |
+    | Built in Dart | the JSON string itself |
+    | A server | its URL: `'https://example.com/style.json'` |
+
+    Anything else is read as an asset key, misses, and leaves the map blank without throwing. So `'file:///...'` and `'asset://...'` never work here: the plugin adds the `asset://` prefix itself, and writing it yourself only doubles it.
 
 ## Switching style at runtime
 

--- a/website/docs/concepts/styles.md
+++ b/website/docs/concepts/styles.md
@@ -114,7 +114,7 @@ flutter:
     # One entry per font stack directory: `assets/glyphs/` alone bundles nothing.
     - assets/glyphs/Noto Sans Regular/
     - assets/glyphs/Noto Sans Bold/
-    - assets/glyphs/Open Sans Regular,Arial Unicode MS Regular/
+    - assets/glyphs/Noto Sans Regular,Arial Unicode MS Regular/
 ```
 
 `sprite` in the style is a prefix, not a file: MapLibre appends the extension itself and picks one set based on the screen density, `sprite.json` and `sprite.png` at pixel ratio 1, `sprite@2x.json` and `sprite@2x.png` above it. Almost every device is above it, so ship both pairs:
@@ -136,29 +136,35 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 
+/// Bump this whenever you ship different sprites or glyphs.
+const mapAssetsVersion = 1;
+
 Future<String> copyAssetPrefixesToCache(List<String> prefixes) async {
   final cache = await getApplicationCacheDirectory();
+  final stamp = File('${cache.path}/maplibre_assets.version');
+  if (stamp.existsSync() && stamp.readAsStringSync() == '$mapAssetsVersion') {
+    return cache.path;
+  }
   final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
   final assets = manifest.listAssets().where(
     (asset) => prefixes.any(asset.startsWith),
   );
   for (final asset in assets) {
     final data = await rootBundle.load(asset);
-    final bytes = data.buffer.asUint8List(
-      data.offsetInBytes,
-      data.lengthInBytes,
-    );
     final out = File('${cache.path}/$asset');
-    // Rewrite when missing or stale, so an app update ships the new files.
-    if (out.existsSync() && out.lengthSync() == bytes.length) continue;
     await out.parent.create(recursive: true);
-    await out.writeAsBytes(bytes);
+    await out.writeAsBytes(
+      data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+    );
   }
+  await stamp.writeAsString('$mapAssetsVersion');
   return cache.path;
 }
 ```
 
 The copy keeps the asset paths, so `assets/sprites/sprite.png` lands in `<cache>/assets/sprites/sprite.png`.
+
+The stamp file keeps later launches cheap: when it matches, nothing is read out of the asset bundle at all. Bump `mapAssetsVersion` when you ship new sprites or glyphs, otherwise the app keeps serving the copies made by the previous version. The system may purge the cache directory at any time, which is harmless here because the copy runs again at the next launch; use `getApplicationSupportDirectory()` instead if you want the copies to survive regardless.
 
 ### Point the style at the copies
 
@@ -179,7 +185,7 @@ final style = '''
 ''';
 ```
 
-`{fontstack}` and `{range}` stay as placeholders; MapLibre fills them in per request. Font stack names containing spaces and commas, such as `Open Sans Regular,Arial Unicode MS Regular`, need no escaping: the engine percent-decodes `file://` paths before reading them.
+`{fontstack}` and `{range}` stay as placeholders; MapLibre fills them in per request. Font stack names containing spaces and commas, such as `Noto Sans Regular,Arial Unicode MS Regular`, need no escaping: the engine percent-decodes `file://` paths before reading them.
 
 Write that JSON next to the copied files and pass its absolute path to the map:
 
@@ -198,6 +204,9 @@ MapLibreMap(
 ```
 
 Passing the JSON directly as `styleString` works too, see [Raw JSON string](#raw-json-string).
+
+!!! warning "`styleString` takes a path, not a `file://` URL"
+    `file://` belongs in the `sprite` and `glyphs` fields, which the native engines fetch themselves. The style document is resolved by the plugin instead: give it the absolute path. A `file://` prefix there is treated as a Flutter asset key on both platforms, and the map stays blank without throwing.
 
 ## Switching style at runtime
 


### PR DESCRIPTION
Follow-up to #1011, which is already merged. Three things I only caught after the merge, plus a cosmetic one.

**The copy helper read the whole glyph set on every launch.** It called `rootBundle.load()` for each asset and only then compared sizes to decide whether to skip the write, so an app whose cache was already current still pulled every glyph across the platform channel at startup. Worse, the comparison was on length alone: a redesigned sprite sheet or a regenerated glyph range that happened to keep its byte count was never rewritten, which is exactly the case the "so an app update ships the new files" comment claimed to cover. The helper now stamps the cache with a version constant the app owns. A current cache costs one small file read; bumping `mapAssetsVersion` rewrites everything unconditionally.

**`file://` on `styleString` itself fails silently.** The page hands the reader `file://` URLs for `sprite` and `glyphs`, which is correct since the native engines fetch those, and it is a short step from there to trying the same prefix on the style document. That one is resolved by the plugin, not by the engine: a string that does not start with `/` and is not `http(s)://` or `mapbox://` goes down the Flutter-asset branch on both platforms (`MapLibreMapController.java`, `MapLibreMapController.swift`), so `file:///.../style.json` is looked up as an asset key, misses, and leaves a blank map with no Dart exception. Added a warning that says to pass the absolute path.

**Stale dartdoc.** `setStyle` in `maplibre_gl` and in `maplibre_gl_platform_interface` still said raw JSON is "only supported on Android". iOS sets `mapView.styleJSON` and web parses the string in `_sanitizeStyleObject`, and `MapLibreMap.styleString` already documents it without the caveat, so those two comments were the last ones out of step. The website page lost the same claim in #1011.

Finally, the font stack example used `Open Sans Regular,Arial Unicode MS Regular` among otherwise Noto Sans entries; it is now `Noto Sans Regular,Arial Unicode MS Regular`. And a sentence noting the cache directory is purgeable, with `getApplicationSupportDirectory()` as the alternative when the copies should survive.

**Verification.** The Dart snippet was extracted and run through `dart analyze` inside `maplibre_gl_example`: clean, including `avoid_slow_async_io`. No CHANGELOG entry: documentation and comments only, no behaviour change.