### PR TITLE
feat: add setFlingPhysics to tune pan inertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [Unreleased]
+
+### Added
+* `MapLibreMapController.setFlingPhysics` tunes the inertia that follows a pan gesture: a base time that sets how long the map coasts after the finger leaves the screen, a velocity threshold below which it does not coast at all, and a switch that turns coasting off. Both native SDKs expose this and neither was reachable from Dart, so an app could only disable the whole gesture. **Android** maps the values onto `UiSettings` one to one; **iOS** has a single `decelerationRate` and approximates them; **Web** is a no-op. Omitting a value leaves the SDK default in place, so existing apps are unaffected.
+
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [Unreleased]
 
 ### Added
-* `MapLibreMapController.setFlingPhysics` tunes the inertia that follows a pan gesture: a base time that sets how long the map coasts after the finger leaves the screen, a velocity threshold below which it does not coast at all, and a switch that turns coasting off. Both native SDKs expose this and neither was reachable from Dart, so an app could only disable the whole gesture. **Android** maps the values onto `UiSettings` one to one; **iOS** has a single `decelerationRate` and approximates them; **Web** is a no-op. Omitting a value leaves the SDK default in place, so existing apps are unaffected.
+* `MapLibreMapController.setFlingPhysics` tunes the inertia that follows a pan gesture: a base time that sets how long the map coasts after the finger leaves the screen, a velocity threshold below which it does not coast at all, and a switch that turns coasting off. Both native SDKs expose this and neither was reachable from Dart, so an app could only disable the whole gesture. **Android** maps the values onto `UiSettings` one to one; **iOS** has a single `decelerationRate` and approximates them; **Web** is a no-op. Omitting a value leaves the SDK default in place, so existing apps are unaffected (#1032).
 
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+* `MapLibreMapController.setFlingPhysics` tunes the inertia that follows a pan gesture (base time, velocity threshold, on/off). Android maps the values onto `UiSettings` one to one, iOS approximates them with its single `decelerationRate`, and web is a no-op. Omitting a value leaves the SDK default in place.
+
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 
 ### Fixed

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Added
-* `MapLibreMapController.setFlingPhysics` tunes the inertia that follows a pan gesture (base time, velocity threshold, on/off). Android maps the values onto `UiSettings` one to one, iOS approximates them with its single `decelerationRate`, and web is a no-op. Omitting a value leaves the SDK default in place.
+* `MapLibreMapController.setFlingPhysics` tunes the inertia that follows a pan gesture (base time, velocity threshold, on/off). Android maps the values onto `UiSettings` one to one, iOS approximates them with its single `decelerationRate`, and web is a no-op. Omitting a value leaves the SDK default in place (#1032).
 
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 

--- a/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
+++ b/maplibre_gl/android/src/main/java/org/maplibre/maplibregl/MapLibreMapController.java
@@ -63,6 +63,7 @@ import org.maplibre.android.maps.MapLibreMapOptions;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.OnMapReadyCallback;
 import org.maplibre.android.maps.Style;
+import org.maplibre.android.maps.UiSettings;
 import org.maplibre.android.offline.OfflineManager;
 import org.maplibre.android.style.expressions.Expression;
 import org.maplibre.android.style.layers.CircleLayer;
@@ -220,6 +221,10 @@ final class MapLibreMapController
   // Tint of the attribution (i) button, or null to leave the MapLibre SDK
   // default in place. Only set through the attributionButtonColor map option.
   private Integer attributionButtonColor = null;
+  // Fling inertia, or null for the SDK default. See map#setFlingPhysics.
+  private Integer flingBaseTimeMs = null;
+  private Long flingThreshold = null;
+  private Boolean flingEnabled = null;
   /**
    * Idempotency guards for {@link MapView} lifecycle dispatch, so each transition fires
    * once per {@link MapView} instance. See the lifecycle observer section below.
@@ -521,6 +526,10 @@ final class MapLibreMapController
     if (attributionButtonColor != null) {
       mapLibreMap.getUiSettings().setAttributionTintColor(attributionButtonColor);
     }
+
+    // Re-apply fling physics: UiSettings belongs to the MapView, so a recreated
+    // view would otherwise fall back to the SDK defaults.
+    applyFlingPhysics();
 
     // Apply camera target bounds if set during initialization
     if (bounds != null) {
@@ -1652,6 +1661,26 @@ final class MapLibreMapController
           if (mapView != null) {
             mapView.setMaximumFps(fps);
           }
+          result.success(null);
+          break;
+        }
+      case "map#setFlingPhysics":
+        {
+          // Held as fields: UiSettings lives on the MapView, so a recreated
+          // view has to be told again in onMapReady.
+          if (call.hasArgument("baseTimeMs")) {
+            flingBaseTimeMs = call.argument("baseTimeMs");
+          }
+          if (call.hasArgument("threshold")) {
+            // Dart sends a double while UiSettings takes a long: the value is a
+            // velocity in pixels per second, where a fraction carries no meaning.
+            final Number threshold = call.argument("threshold");
+            flingThreshold = threshold == null ? null : threshold.longValue();
+          }
+          if (call.hasArgument("enabled")) {
+            flingEnabled = call.argument("enabled");
+          }
+          applyFlingPhysics();
           result.success(null);
           break;
         }
@@ -3776,6 +3805,26 @@ final class MapLibreMapController
           CameraMode.NONE, CameraMode.TRACKING, CameraMode.TRACKING_COMPASS, CameraMode.TRACKING_GPS
         };
     locationComponent.setCameraMode(cameraModes[this.myLocationTrackingMode]);
+  }
+
+  /**
+   * Applies the fling inertia requested from Dart, if any. Values the caller never set are left
+   * alone, so the SDK defaults (150 ms base time, velocity threshold 1000) stay in place.
+   */
+  private void applyFlingPhysics() {
+    if (mapLibreMap == null) {
+      return;
+    }
+    final UiSettings uiSettings = mapLibreMap.getUiSettings();
+    if (flingBaseTimeMs != null) {
+      uiSettings.setFlingAnimationBaseTime(flingBaseTimeMs);
+    }
+    if (flingThreshold != null) {
+      uiSettings.setFlingThreshold(flingThreshold);
+    }
+    if (flingEnabled != null) {
+      uiSettings.setFlingVelocityAnimationEnabled(flingEnabled);
+    }
   }
 
   private void updateMyLocationRenderMode() {

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -547,6 +547,19 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
                 }
             }
             result(nil)
+        case "map#setFlingPhysics":
+            guard let arguments = methodCall.arguments as? [String: Any] else { return }
+            // iOS exposes a single deceleration rate instead of Android's base
+            // time and velocity threshold, so the request is mapped onto the
+            // three documented rates rather than reproduced exactly.
+            if let enabled = arguments["enabled"] as? Bool, !enabled {
+                mapView.decelerationRate = MLNMapViewDecelerationRateImmediate
+            } else if let baseTimeMs = arguments["baseTimeMs"] as? Int {
+                mapView.decelerationRate = baseTimeMs < 150
+                    ? MLNMapViewDecelerationRateFast
+                    : MLNMapViewDecelerationRateNormal
+            }
+            result(nil)
         case "map#forceOnlineMode":
             // Force online mode by ensuring network requests are enabled
             // In MapLibre GL iOS, this is typically handled by the style and data sources

--- a/maplibre_gl/lib/src/controller.dart
+++ b/maplibre_gl/lib/src/controller.dart
@@ -1166,6 +1166,38 @@ class MapLibreMapController extends ChangeNotifier {
     return _maplibrePlatform.setMaximumFps(fps);
   }
 
+  /// Tunes the inertia that follows a pan gesture.
+  ///
+  /// [baseTime] is added to the coast duration and the coast distance is
+  /// proportional to it, so a smaller value shortens both — the map stops
+  /// sooner after the finger leaves the screen. [threshold] is the gesture
+  /// velocity below which no coasting happens at all, which keeps the map from
+  /// drifting after a short drag. [enabled] turns coasting off entirely.
+  ///
+  /// Android maps these onto `UiSettings` one to one (defaults: 150 ms and
+  /// 1000). iOS exposes a single `decelerationRate`, so the values are
+  /// approximated there, and the web implementation is a no-op.
+  ///
+  /// The returned [Future] completes after the change has been made on the
+  /// platform side.
+  Future<void> setFlingPhysics({
+    Duration? baseTime,
+    double? threshold,
+    bool? enabled,
+  }) async {
+    if (baseTime != null && baseTime.isNegative) {
+      throw ArgumentError.value(baseTime, 'baseTime', 'must not be negative');
+    }
+    if (threshold != null && (threshold.isNaN || threshold < 0)) {
+      throw ArgumentError.value(threshold, 'threshold', 'must not be negative');
+    }
+    return _maplibrePlatform.setFlingPhysics(
+      baseTime: baseTime,
+      threshold: threshold,
+      enabled: enabled,
+    );
+  }
+
   /// Forces the map to use online mode, disabling any offline functionality.
   ///
   /// This is useful for testing or when you want to ensure the map always

--- a/maplibre_gl/test/controller_test.dart
+++ b/maplibre_gl/test/controller_test.dart
@@ -699,6 +699,49 @@ void main() {
     });
   });
 
+  group('Fling physics delegation', () {
+    test('setFlingPhysics passes every knob to the platform', () async {
+      await controller.setFlingPhysics(
+        baseTime: const Duration(milliseconds: 110),
+        threshold: 1200,
+        enabled: true,
+      );
+
+      final call = platform.callsFor('setFlingPhysics').single;
+      expect(call.namedArgs['baseTime'], const Duration(milliseconds: 110));
+      expect(call.namedArgs['threshold'], 1200.0);
+      expect(call.namedArgs['enabled'], isTrue);
+    });
+
+    test('setFlingPhysics leaves an omitted knob null', () async {
+      // Null means "keep the SDK default", so a partial call must not
+      // invent values for the knobs the caller left out.
+      await controller.setFlingPhysics(threshold: 0);
+
+      final call = platform.callsFor('setFlingPhysics').single;
+      expect(call.namedArgs['baseTime'], isNull);
+      expect(call.namedArgs['threshold'], 0.0);
+      expect(call.namedArgs['enabled'], isNull);
+    });
+
+    test('setFlingPhysics rejects negative values', () async {
+      expect(
+        () => controller.setFlingPhysics(
+          baseTime: const Duration(milliseconds: -1),
+        ),
+        throwsArgumentError,
+      );
+      for (final threshold in <double>[-1, double.nan]) {
+        expect(
+          () => controller.setFlingPhysics(threshold: threshold),
+          throwsArgumentError,
+          reason: 'threshold $threshold should be rejected',
+        );
+      }
+      expect(platform.wasCalled('setFlingPhysics'), isFalse);
+    });
+  });
+
   group('Padding', () {
     test(
       'setPadding maps named edges to EdgeInsets via updateContentInsets',

--- a/maplibre_gl/test/helpers/fake_platform.dart
+++ b/maplibre_gl/test/helpers/fake_platform.dart
@@ -150,7 +150,15 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
     Duration? baseTime,
     double? threshold,
     bool? enabled,
-  }) async {}
+  }) async {
+    calls.add(
+      PlatformCall(
+        'setFlingPhysics',
+        [],
+        {'baseTime': baseTime, 'threshold': threshold, 'enabled': enabled},
+      ),
+    );
+  }
 
   @override
   Future<void> forceOnlineMode() async {}

--- a/maplibre_gl/test/helpers/fake_platform.dart
+++ b/maplibre_gl/test/helpers/fake_platform.dart
@@ -146,6 +146,13 @@ class FakeMapLibrePlatform extends MapLibrePlatform {
   Future<void> setMaximumFps(int fps) async {}
 
   @override
+  Future<void> setFlingPhysics({
+    Duration? baseTime,
+    double? threshold,
+    bool? enabled,
+  }) async {}
+
+  @override
   Future<void> forceOnlineMode() async {}
 
   @override

--- a/maplibre_gl_example/lib/examples/interaction/map_gestures_example.dart
+++ b/maplibre_gl_example/lib/examples/interaction/map_gestures_example.dart
@@ -39,6 +39,9 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
   bool _isMoving = false;
   String _lastGesture = 'None';
 
+  // Pan inertia preset in effect; set through the controller, not a map option.
+  String _inertia = 'default';
+
   void _onMapCreated(MapLibreMapController controller) {
     _controller = controller;
     controller.addListener(_onMapChanged);
@@ -88,6 +91,24 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
 
   Future<void> _updateDoubleClickZoom(bool enabled) async {
     setState(() => _doubleClickToZoomEnabled = enabled);
+  }
+
+  /// Applies a pan inertia preset. A smaller base time shortens the coast that
+  /// follows a swipe; a higher threshold keeps a short drag from drifting.
+  Future<void> _setInertia(
+    String label, {
+    Duration? baseTime,
+    double? threshold,
+    bool? enabled,
+  }) async {
+    await _controller?.setFlingPhysics(
+      baseTime: baseTime,
+      threshold: threshold,
+      enabled: enabled,
+    );
+    if (mounted) {
+      setState(() => _inertia = label);
+    }
   }
 
   Future<void> _enableAllGestures() async {
@@ -189,6 +210,39 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
               value: _doubleClickToZoomEnabled,
               onChanged: _updateDoubleClickZoom,
               contentPadding: EdgeInsets.zero,
+            ),
+          ],
+        ),
+        ControlGroup(
+          title: 'Pan Inertia: $_inertia',
+          children: [
+            ExampleButton(
+              label: 'Default',
+              icon: Icons.restart_alt,
+              onPressed:
+                  () => _setInertia(
+                    'default',
+                    baseTime: const Duration(milliseconds: 150),
+                    threshold: 1000,
+                    enabled: true,
+                  ),
+            ),
+            ExampleButton(
+              label: 'Short',
+              icon: Icons.compress,
+              onPressed:
+                  () => _setInertia(
+                    'short',
+                    baseTime: const Duration(milliseconds: 110),
+                    threshold: 1200,
+                    enabled: true,
+                  ),
+            ),
+            ExampleButton(
+              label: 'Off',
+              icon: Icons.block,
+              onPressed: () => _setInertia('off', enabled: false),
+              style: ExampleButtonStyle.destructive,
             ),
           ],
         ),

--- a/maplibre_gl_platform_interface/CHANGELOG.md
+++ b/maplibre_gl_platform_interface/CHANGELOG.md
@@ -3,7 +3,7 @@
 See the [top-level CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for full details.
 
 ### Added
-* `MapLibrePlatform.setFlingPhysics` carries the pan inertia settings to the platform implementations. Out-of-tree implementations of `MapLibrePlatform` have to add the method.
+* `MapLibrePlatform.setFlingPhysics` carries the pan inertia settings to the platform implementations. Out-of-tree implementations of `MapLibrePlatform` have to add the method (#1032).
 
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 

--- a/maplibre_gl_platform_interface/CHANGELOG.md
+++ b/maplibre_gl_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+See the [top-level CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for full details.
+
+### Added
+* `MapLibrePlatform.setFlingPhysics` carries the pan inertia settings to the platform implementations. Out-of-tree implementations of `MapLibrePlatform` have to add the method.
+
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 
 See the [top-level CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for full details.

--- a/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
+++ b/maplibre_gl_platform_interface/lib/src/maplibre_gl_platform_interface.dart
@@ -141,6 +141,22 @@ abstract class MapLibrePlatform {
   /// Sets the maximum frames per second for the map rendering.
   Future<void> setMaximumFps(int fps);
 
+  /// Tunes the inertia that follows a pan gesture.
+  ///
+  /// [baseTime] is added to the coast duration, and the coast distance is
+  /// proportional to it, so a smaller value shortens both. [threshold] is the
+  /// gesture velocity below which no coasting happens at all. [enabled] turns
+  /// coasting off entirely.
+  ///
+  /// Android maps these onto `UiSettings` one to one. iOS exposes a single
+  /// `decelerationRate`, so the values are approximated there, and the web
+  /// implementation is a no-op.
+  Future<void> setFlingPhysics({
+    Duration? baseTime,
+    double? threshold,
+    bool? enabled,
+  });
+
   /// Forces the map to use online mode (disables offline mode).
   Future<void> forceOnlineMode();
 

--- a/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
+++ b/maplibre_gl_platform_interface/lib/src/method_channel_maplibre_gl.dart
@@ -299,6 +299,19 @@ class MapLibreMethodChannel extends MapLibrePlatform {
   }
 
   @override
+  Future<void> setFlingPhysics({
+    Duration? baseTime,
+    double? threshold,
+    bool? enabled,
+  }) async {
+    await _channel.invokeMethod('map#setFlingPhysics', <String, dynamic>{
+      if (baseTime != null) 'baseTimeMs': baseTime.inMilliseconds,
+      if (threshold != null) 'threshold': threshold,
+      if (enabled != null) 'enabled': enabled,
+    });
+  }
+
+  @override
   Future<void> forceOnlineMode() async {
     await _channel.invokeMethod('map#forceOnlineMode');
   }

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -1,5 +1,10 @@
 See the [top-level CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/blob/main/CHANGELOG.md) for full details.
 
+## [Unreleased]
+
+### Added
+* `setFlingPhysics` is implemented as a no-op: maplibre-gl-js keeps the equivalent knobs on the drag-pan handler, which this wrapper does not expose yet.
+
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 
 ### Fixed

--- a/maplibre_gl_web/CHANGELOG.md
+++ b/maplibre_gl_web/CHANGELOG.md
@@ -3,7 +3,7 @@ See the [top-level CHANGELOG](https://github.com/maplibre/flutter-maplibre-gl/bl
 ## [Unreleased]
 
 ### Added
-* `setFlingPhysics` is implemented as a no-op: maplibre-gl-js keeps the equivalent knobs on the drag-pan handler, which this wrapper does not expose yet.
+* `setFlingPhysics` is implemented as a no-op: maplibre-gl-js keeps the equivalent knobs on the drag-pan handler, which this wrapper does not expose yet (#1032).
 
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 

--- a/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
+++ b/maplibre_gl_web/lib/src/maplibre_web_gl_platform.dart
@@ -551,6 +551,17 @@ class MapLibreMapController extends MapLibrePlatform
   }
 
   @override
+  Future<void> setFlingPhysics({
+    Duration? baseTime,
+    double? threshold,
+    bool? enabled,
+  }) async {
+    // No-op on web. maplibre-gl-js keeps the equivalent knobs on the drag-pan
+    // handler (`deceleration`, `maxSpeed`), which this wrapper does not expose;
+    // wiring them is a separate change rather than a partial mapping here.
+  }
+
+  @override
   Future<void> forceOnlineMode() async {
     // Web implementation: Force online mode
     // In web, we can ensure network requests are enabled


### PR DESCRIPTION
## What

Adds `MapLibreMapController.setFlingPhysics` to tune the inertia that follows a pan gesture.

```dart
await controller.setFlingPhysics(
  baseTime: const Duration(milliseconds: 110), // shorter coast after a swipe
  threshold: 1200,                             // no drift after a short drag
  enabled: true,
);
```

## Why

Both native SDKs expose this and neither is reachable from Dart, so today an app can only turn the whole gesture off with `scrollGesturesEnabled: false`. Android has `UiSettings.setFlingAnimationBaseTime`, `setFlingThreshold` and `setFlingVelocityAnimationEnabled`; iOS has `MLNMapView.decelerationRate`. In an app where the map sits under a bottom sheet, the default coast overshoots badly, and there was no way to shorten it short of patching the plugin — which is what I ended up doing before writing this.

Not passing a value leaves the SDK default alone, so nothing changes for existing apps.

## Platform mapping

| | Behaviour |
|---|---|
| **Android** | One to one onto `UiSettings` (defaults: 150 ms, 1000). The values are kept as fields and re-applied in `onMapReady`, because `UiSettings` belongs to the `MapView` and a recreated view would otherwise fall back to the defaults. |
| **iOS** | Approximated. There is only `decelerationRate`, so `enabled: false` maps to `Immediate`, a base time under 150 ms to `Fast`, otherwise `Normal`. `threshold` has no counterpart and is ignored. The approximation is documented on the method. |
| **Web** | No-op. maplibre-gl-js keeps the equivalent knobs on the drag-pan handler, which this wrapper does not expose yet. |

Negative `baseTime`, negative `threshold` and `NaN` throw `ArgumentError` before reaching the channel.

## Testing

- `melos run analyze-all`, `melos run format-all`, `melos run test:io` — all pass locally.
- Three controller tests: the pass-through, the knobs left out of a partial call staying `null`, and the rejected values.
- **Android: verified on a physical device.** The shorter preset is clearly perceptible in normal use. The re-apply in `onMapReady` is reasoned from the SDK, not from a measured view recreation.
- **iOS: not verified — I have no device or Mac.** The Swift side is small and mirrors the Android case, but it needs someone with hardware to confirm before merge.
- Web: unchanged behaviour, no-op override only.

## Checklist

- [x] Example app updated — `Map Gestures` gains a *Pan Inertia* group with a default / short / off preset
- [x] Tests added
- [x] Analyzer passes
- [ ] Code generation re-run — not applicable, no templates touched
- [x] Changelog updated — root and all three packages, under `## [Unreleased]`
- [x] No unrelated formatting noise
- [ ] All affected platforms tested — Android yes, iOS not (see above)
- [ ] Screenshots — the change is motion, not layout; a still would not show it

Happy to move this to a discussion first if you would rather align on the API shape (naming, or whether `threshold` belongs in a cross-platform signature when iOS cannot honour it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnVCArxLp8QX9P1Ky192wC
