### PR TITLE
feat(ios): expose hapticFeedbackEnabled on MapLibreMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Added
+* **iOS**: `MapLibreMap.hapticFeedbackEnabled` turns off the light haptic tap the native SDK plays when a rotate gesture brings the bearing to due north. It defaults to `true`, the SDK's own default, so nothing changes unless you set it. Android and web play no haptic on rotation and ignore it (#1033).
+
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 
 ### Fixed

--- a/maplibre_gl/CHANGELOG.md
+++ b/maplibre_gl/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* **iOS**: `MapLibreMap.hapticFeedbackEnabled` turns off the light haptic tap the native SDK plays when a rotate gesture brings the bearing to due north. It defaults to `true`, the SDK's own default, so nothing changes unless you set it. Android and web play no haptic on rotation and ignore it (#1033).
+
 ## [0.27.1](https://github.com/maplibre/flutter-maplibre-gl/compare/v0.27.0...v0.27.1)
 
 ### Fixed

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/Convert.swift
@@ -43,6 +43,9 @@ class Convert {
         if let tiltGesturesEnabled = options["tiltGesturesEnabled"] as? Bool {
             delegate.setTiltGesturesEnabled(tiltGesturesEnabled: tiltGesturesEnabled)
         }
+        if let hapticFeedbackEnabled = options["hapticFeedbackEnabled"] as? Bool {
+            delegate.setHapticFeedbackEnabled(hapticFeedbackEnabled: hapticFeedbackEnabled)
+        }
         if let trackCameraPosition = options["trackCameraPosition"] as? Bool {
             delegate.setTrackCameraPosition(trackCameraPosition: trackCameraPosition)
         }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapController.swift
@@ -2766,6 +2766,11 @@ class MapLibreMapController: NSObject, FlutterPlatformView, MLNMapViewDelegate, 
         mapView.allowsTilting = tiltGesturesEnabled
     }
 
+    func setHapticFeedbackEnabled(hapticFeedbackEnabled: Bool) {
+        // The SDK plays a light impact when a rotate gesture crosses due north.
+        mapView.isHapticFeedbackEnabled = hapticFeedbackEnabled
+    }
+
     func setTrackCameraPosition(trackCameraPosition: Bool) {
         self.trackCameraPosition = trackCameraPosition
     }

--- a/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
+++ b/maplibre_gl/ios/maplibre_gl/Sources/maplibre_gl/MapLibreMapOptionsSink.swift
@@ -8,6 +8,7 @@ protocol MapLibreMapOptionsSink {
     func setRotateGesturesEnabled(rotateGesturesEnabled: Bool)
     func setScrollGesturesEnabled(scrollGesturesEnabled: Bool)
     func setTiltGesturesEnabled(tiltGesturesEnabled: Bool)
+    func setHapticFeedbackEnabled(hapticFeedbackEnabled: Bool)
     func setTrackCameraPosition(trackCameraPosition: Bool)
     func setZoomGesturesEnabled(zoomGesturesEnabled: Bool)
     func setDoubleClickZoomEnabled(doubleClickZoomEnabled: Bool)

--- a/maplibre_gl/lib/src/maplibre_map.dart
+++ b/maplibre_gl/lib/src/maplibre_map.dart
@@ -27,6 +27,7 @@ class MapLibreMap extends StatefulWidget {
     this.scrollGesturesEnabled = true,
     this.zoomGesturesEnabled = true,
     this.tiltGesturesEnabled = true,
+    this.hapticFeedbackEnabled = true,
     this.doubleClickZoomEnabled,
     this.dragEnabled = true,
     this.featureTapsTriggersMapClick = false,
@@ -195,6 +196,15 @@ class MapLibreMap extends StatefulWidget {
 
   /// True if the map view should respond to tilt gestures.
   final bool tiltGesturesEnabled;
+
+  /// Whether the device plays a light haptic tap when a rotate gesture
+  /// brings the map's bearing to due north. Defaults to `true`, the native
+  /// SDK default. Set to `false` for apps where the user rotates the map
+  /// constantly, such as chart plotters, and the tap becomes noise.
+  ///
+  /// **Available only on iOS. Has no effect on Android or Web**, which play
+  /// no haptic on rotation.
+  final bool hapticFeedbackEnabled;
 
   /// Set to true to forcefully disable/enable if map should respond to double
   /// click to zoom.
@@ -599,6 +609,7 @@ class MapLibreMapOptions {
     required this.tiltGesturesEnabled,
     required this.zoomGesturesEnabled,
     required this.doubleClickZoomEnabled,
+    this.hapticFeedbackEnabled,
     this.trackCameraPosition,
     this.myLocationEnabled,
     this.myLocationTrackingMode,
@@ -636,6 +647,7 @@ class MapLibreMapOptions {
         zoomGesturesEnabled: map.zoomGesturesEnabled,
         doubleClickZoomEnabled:
             map.doubleClickZoomEnabled ?? map.zoomGesturesEnabled,
+        hapticFeedbackEnabled: map.hapticFeedbackEnabled,
         myLocationEnabled: map.myLocationEnabled,
         myLocationTrackingMode: map.myLocationTrackingMode,
         myLocationRenderMode: map.myLocationRenderMode,
@@ -672,6 +684,8 @@ class MapLibreMapOptions {
   final bool zoomGesturesEnabled;
 
   final bool doubleClickZoomEnabled;
+
+  final bool? hapticFeedbackEnabled;
 
   final bool? trackCameraPosition;
 
@@ -748,6 +762,7 @@ class MapLibreMapOptions {
     addIfNonNull('tiltGesturesEnabled', tiltGesturesEnabled);
     addIfNonNull('zoomGesturesEnabled', zoomGesturesEnabled);
     addIfNonNull('doubleClickZoomEnabled', doubleClickZoomEnabled);
+    addIfNonNull('hapticFeedbackEnabled', hapticFeedbackEnabled);
 
     addIfNonNull('trackCameraPosition', trackCameraPosition);
     addIfNonNull('myLocationEnabled', myLocationEnabled);

--- a/maplibre_gl/test/maplibre_map_options_test.dart
+++ b/maplibre_gl/test/maplibre_map_options_test.dart
@@ -79,4 +79,31 @@ void main() {
       expect(diff, isEmpty);
     });
   });
+
+  group('MapLibreMap.hapticFeedbackEnabled', () {
+    test('defaults to true and is sent to the platform', () {
+      final options = MapLibreMapOptions.fromWidget(MapLibreMap());
+
+      expect(options.toMap()['hapticFeedbackEnabled'], isTrue);
+    });
+
+    test('false is sent to the platform', () {
+      final options = MapLibreMapOptions.fromWidget(
+        MapLibreMap(hapticFeedbackEnabled: false),
+      );
+
+      expect(options.toMap()['hapticFeedbackEnabled'], isFalse);
+    });
+
+    test('updatesMap reports a change and nothing else', () {
+      final before = MapLibreMapOptions.fromWidget(MapLibreMap());
+      final after = MapLibreMapOptions.fromWidget(
+        MapLibreMap(hapticFeedbackEnabled: false),
+      );
+
+      final diff = before.updatesMap(after);
+
+      expect(diff, {'hapticFeedbackEnabled': false});
+    });
+  });
 }

--- a/maplibre_gl_example/lib/examples/interaction/map_gestures_example.dart
+++ b/maplibre_gl_example/lib/examples/interaction/map_gestures_example.dart
@@ -34,6 +34,7 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
   bool _tiltGesturesEnabled = true;
   bool _zoomGesturesEnabled = true;
   bool _doubleClickToZoomEnabled = true;
+  bool _hapticFeedbackEnabled = true;
 
   // Movement State
   bool _isMoving = false;
@@ -90,6 +91,10 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
     setState(() => _doubleClickToZoomEnabled = enabled);
   }
 
+  Future<void> _updateHapticFeedback(bool enabled) async {
+    setState(() => _hapticFeedbackEnabled = enabled);
+  }
+
   Future<void> _enableAllGestures() async {
     setState(() {
       _rotateGesturesEnabled = true;
@@ -97,6 +102,7 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
       _tiltGesturesEnabled = true;
       _zoomGesturesEnabled = true;
       _doubleClickToZoomEnabled = true;
+      _hapticFeedbackEnabled = true;
     });
   }
 
@@ -107,6 +113,7 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
       _tiltGesturesEnabled = false;
       _zoomGesturesEnabled = false;
       _doubleClickToZoomEnabled = false;
+      _hapticFeedbackEnabled = false;
     });
   }
 
@@ -126,6 +133,7 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
         tiltGesturesEnabled: _tiltGesturesEnabled,
         zoomGesturesEnabled: _zoomGesturesEnabled,
         doubleClickZoomEnabled: _doubleClickToZoomEnabled,
+        hapticFeedbackEnabled: _hapticFeedbackEnabled,
       ),
       controls: [
         InfoCard(
@@ -188,6 +196,13 @@ class _MapGesturesBodyState extends State<_MapGesturesBody> {
               subtitle: const Text('Double tap to zoom in'),
               value: _doubleClickToZoomEnabled,
               onChanged: _updateDoubleClickZoom,
+              contentPadding: EdgeInsets.zero,
+            ),
+            SwitchListTile(
+              title: const Text('Haptic Feedback'),
+              subtitle: const Text('Tap when rotating to north (iOS only)'),
+              value: _hapticFeedbackEnabled,
+              onChanged: _updateHapticFeedback,
               contentPadding: EdgeInsets.zero,
             ),
           ],


### PR DESCRIPTION
Fixes #1033

## Problem

On iOS the MapLibre SDK plays a light haptic tap every time a rotate gesture brings the bearing to due north. Rocking the map back and forth across north taps the device on every crossing. The SDK property that controls this, `MLNMapView.hapticFeedbackEnabled`, defaults to `YES` and the plugin never set or exposed it, so an app had no way to turn it off.

## Change

Adds `hapticFeedbackEnabled` to `MapLibreMap`, defaulting to `true` so existing apps see no change. It flows through `MapLibreMapOptions` and the iOS options sink like the other gesture flags, and can be changed at runtime through the normal `map#update` path.

Android and web play no haptic on rotation. Both read options by key, so they ignore the new one.

- `maplibre_gl/lib/src/maplibre_map.dart`: new widget field, plumbed through `MapLibreMapOptions.toMap`.
- `MapLibreMapOptionsSink.swift`, `Convert.swift`, `MapLibreMapController.swift`: sink method, key parsing, and the setter.
- `maplibre_gl/test/maplibre_map_options_test.dart`: default serializes as `true`, `false` serializes, and `updatesMap` reports exactly that key on change.
- `maplibre_gl_example`: a Haptic Feedback switch on the Map Gestures page, included in Enable All / Disable All.
- Root and package `CHANGELOG.md`: entry under Unreleased.

## Testing

- `dart analyze --fatal-warnings --fatal-infos` clean on `maplibre_gl` and `maplibre_gl_example`.
- `flutter test` in `maplibre_gl`: 229 tests pass, including the 3 new ones.
- Example app builds for the iOS simulator.
- Verified on a physical iPhone in an app consuming this branch: with the option set to `false`, rotating through north no longer taps.

## Checklist

- [x] Example app updated
- [x] Tests added
- [x] Analyzer passes
- [ ] Code generation re-run (no templates touched)
- [x] Changelog updated
- [x] No unrelated formatting noise
- [x] iOS tested on device; Android and web unaffected (option is ignored)
